### PR TITLE
GH action to raise an issue when npm audit fails in workflow instead of failing the workflow

### DIFF
--- a/.github/workflows/run-lint-audit-tests-ui.yml
+++ b/.github/workflows/run-lint-audit-tests-ui.yml
@@ -54,7 +54,7 @@ jobs:
           create_pr_comments: false
           dedupe_issues: true
           working_directory: './mathesar_ui'
-          issue_labels: 'restricted: maintainers,type: bug,work: frontend,status: review'
+          issue_labels: 'restricted: maintainers,type: bug,work: frontend,status: triage'
         continue-on-error: true
 
   tests:


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes actions/toolkit#124

This PR uses a github action: [npm-audit-action](https://github.com/marketplace/actions/npm-audit-action), which creates a new issue (or if an issue is already open, it's configured to add a comment on the issue) when npm audit fails.

**Changes**
* Audit failure does not show the GH workflow to have failed. Instead, now it shows as succeeded.
  - I checked for a status like 'Passed with warnings', but unfortunately GH does not support that. https://github.com/actions/runner/issues/2347 keeps track of a similar feature request.
* An issue that is opened looks like this: https://github.com/centerofci/mathesar/issues/720
  - The action runs on push, so a new comment would be added to this issue, on each push of all branches. It might be better to only do this on master and on PRs. @kgodey Let me know what you think.
* Labels that are assigned for the issue do not contain spaces, due to a bug in the action itself. I've raised a bug report upstream. https://github.com/oke-py/npm-audit-action/issues/94

**Regarding current npm audit failure**:

npm audit is currently failing due to some of the packages in our dependency tree.
Most of the failing packages are are dependencies of jest and storybook.
In particular, there are some dependencies like ansi-html, which do not have any immediate patches available.

Forcing these packages to a later version might break our dependencies. In our case, these dependencies are not run in production so they do not pose much of a threat.

It would be better to wait for all our dependencies to be updated first, which at the time of creating this PR has not been done.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
