### PR TITLE
Paste API

### DIFF
--- a/db/records/operations/paste.py
+++ b/db/records/operations/paste.py
@@ -1,0 +1,7 @@
+from db import connection as db_conn
+
+
+def bulk_paste_records(table_oid, updates, inserts, engine):
+    db_conn.execute_msar_func_with_engine(
+        engine, 'bulk_paste_records', table_oid, updates, inserts
+    )

--- a/db/sql/0_msar.sql
+++ b/db/sql/0_msar.sql
@@ -2668,9 +2668,11 @@ BEGIN
   LOOP
     DECLARE
       col_name text := quote_ident(uq_col_name);
-      value text := quote_literal(changes->>col_name);
+      value text := quote_literal(changes->>uq_col_name);
     BEGIN
-      set_clause := set_clause || col_name || ' = ' || value || ', ';
+      -- NOTE the use of CONCAT instead of ||, this is because CONCAT doesn't reduce its whole
+      -- output to NULL if any of its arguments are NULL; was useful for debugging.
+      set_clause := CONCAT(set_clause, col_name, ' = ', value, ', ');
     END;
   END LOOP;
 
@@ -2683,9 +2685,9 @@ BEGIN
   LOOP
     DECLARE
       col_name text := quote_ident(uq_col_name);
-      value text := quote_literal(conditionals->>col_name);
+      value text := quote_literal(conditionals->>uq_col_name);
     BEGIN
-      where_clause := where_clause || col_name || ' = ' || value || ', ';
+      where_clause := CONCAT(where_clause, col_name, ' = ', value, ', ');
     END;
   END LOOP;
 
@@ -2693,7 +2695,7 @@ BEGIN
   where_clause := rtrim(where_clause, ', ');
 
   -- Construct the final UPDATE statement
-  update_statement := update_statement || set_clause || ' WHERE ' || where_clause;
+  update_statement := CONCAT(update_statement, set_clause, ' WHERE ', where_clause);
 
   RETURN update_statement;
 END;

--- a/db/sql/test_0_msar.sql
+++ b/db/sql/test_0_msar.sql
@@ -2112,3 +2112,19 @@ BEGIN
   );
 END;
 $$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION test_generate_update_statement() RETURNS SETOF TEXT AS $$
+DECLARE
+  update_statement_string text := __msar.generate_update_statement(
+    q_table_name := '"Patents"."NASA Record Put"',
+    changes      := '{"Status": "0"}',
+    conditionals := '{"id": 1}'
+  );
+BEGIN
+  RETURN NEXT is(
+    update_statement_string,
+    'UPDATE "Patents"."NASA Record Put" SET "Status" = ''0'' WHERE id = ''1'''
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/db/sql/test_0_msar.sql
+++ b/db/sql/test_0_msar.sql
@@ -2095,9 +2095,9 @@ BEGIN
       "col1": 4
     }
   ]';
-  msar.bulk_paste_records(
+  PERFORM msar.bulk_paste_records(
     tab_id := tab_id,
-    updates := updates;
+    updates := updates,
     inserts := inserts
   );
   RETURN NEXT is(

--- a/mathesar/api/db/permissions/records.py
+++ b/mathesar/api/db/permissions/records.py
@@ -18,7 +18,7 @@ class RecordAccessPolicy(AccessPolicy):
             'condition_expression': 'is_atleast_viewer_nested_table_resource'
         },
         {
-            'action': ['destroy', 'update', 'partial_update', 'create', 'delete'],
+            'action': ['destroy', 'update', 'partial_update', 'create', 'delete', 'paste'],
             'principal': 'authenticated',
             'effect': 'allow',
             'condition_expression': 'is_atleast_editor_nested_table_resource'

--- a/mathesar/api/ui/viewsets/records.py
+++ b/mathesar/api/ui/viewsets/records.py
@@ -31,7 +31,6 @@ class RecordViewSet(AccessViewSetMixin, viewsets.GenericViewSet):
                     status_code=status.HTTP_400_BAD_REQUEST,
                     referent_table=table,
                 )
-
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=['post'], detail=False)
@@ -39,4 +38,9 @@ class RecordViewSet(AccessViewSetMixin, viewsets.GenericViewSet):
         table = get_table_or_404(table_pk)
         updates = request.data.get("updates")
         inserts = request.data.get("inserts")
-        table.bulk_paste_records(updates, inserts)
+        table.bulk_paste_records(updates=updates, inserts=inserts)
+        #import logging
+        #logger = logging.getLogger('paste viewset')
+        #logger.debug(f'updates: {updates}')
+        #logger.debug(f'inserts: {inserts}')
+        return Response(status=status.HTTP_200_OK)

--- a/mathesar/api/ui/viewsets/records.py
+++ b/mathesar/api/ui/viewsets/records.py
@@ -33,3 +33,10 @@ class RecordViewSet(AccessViewSetMixin, viewsets.GenericViewSet):
                 )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=['post'], detail=False)
+    def paste(self, request, table_pk=None):
+        table = get_table_or_404(table_pk)
+        updates = request.data.get("updates")
+        inserts = request.data.get("inserts")
+        table.bulk_paste_records(updates, inserts)

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -527,6 +527,13 @@ class Table(DatabaseObject, Relation):
     def bulk_delete_records(self, id_values):
         return bulk_delete_records(self._sa_table, self.schema._sa_engine, id_values)
 
+    def bulk_paste_records(self, inserts, updates):
+        return bulk_paste_records(
+            table_oid=self.oid,
+            updates=updates,
+            inserts=inserts
+        )
+
     def add_constraint(self, constraint_obj):
         # The max here has the effect of filtering for the largest OID, which is
         # the most newly-created constraint. Other methods (e.g., trying to get

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -29,6 +29,7 @@ from db.records.operations.insert import insert_record_or_records
 from db.records.operations.select import get_column_cast_records, get_count, get_record
 from db.records.operations.select import get_records
 from db.records.operations.update import update_record
+from db.records.operations.paste import bulk_paste_records
 from db.schemas.operations.drop import drop_schema
 from db.schemas.operations.select import get_schema_description
 from db.schemas import utils as schema_utils
@@ -527,11 +528,12 @@ class Table(DatabaseObject, Relation):
     def bulk_delete_records(self, id_values):
         return bulk_delete_records(self._sa_table, self.schema._sa_engine, id_values)
 
-    def bulk_paste_records(self, inserts, updates):
+    def bulk_paste_records(self, updates, inserts):
         return bulk_paste_records(
             table_oid=self.oid,
             updates=updates,
-            inserts=inserts
+            inserts=inserts,
+            engine=self._sa_engine
         )
 
     def add_constraint(self, constraint_obj):

--- a/mathesar/tests/api/test_record_api.py
+++ b/mathesar/tests/api/test_record_api.py
@@ -1432,3 +1432,53 @@ def test_record_patch_unique_violation(create_patents_table, client):
         f'/api/db/v0/tables/{table.id}/constraints/{constraint_id}/'
     ).json()
     assert actual_constraint_details['name'] == 'NASA unique record PATCH_pkey'
+
+
+def test_record_paste(create_patents_table, client):
+    table_name = 'NASA Record Put'
+    table = create_patents_table(table_name)
+    records = table.get_records()
+    record_0_id = records[0]['id']
+    record_1_id = records[1]['id']
+
+    updates = [
+        dict(
+            changes=dict(
+                Status='0',
+            ),
+            conditionals=dict(
+                id=record_0_id,
+            ),
+        ),
+        dict(
+            changes=dict(
+                Status='1',
+            ),
+            conditionals=dict(
+                id=record_1_id,
+            ),
+        ),
+    ]
+    inserts = [
+    ]
+    data = dict(
+        updates=updates,
+        inserts=inserts,
+    )
+    breakpoint()
+    response = client.post(f'/api/ui/v0/tables/{table.id}/records/paste/', data=data)
+    #response_json = response.json()
+    assert response.status_code == 200
+    records_new = table.get_records()
+    found_record_0 = False
+    found_record_1 = False
+    for record_new in records_new:
+        if record_new['id'] == record_0_id:
+            assert record_new['Status'] == '0'
+            found_record_0 = True
+        elif record_new['id'] == record_1_id:
+            assert record_new['Status'] == '1'
+            found_record_1 = True
+        else:
+            assert record_new in records
+    assert found_record_0 and found_record_1


### PR DESCRIPTION
Fixes #2844

Implements paste API.

Initially we envisioned a generic bulk upsert API that could be used by the frontend paste functionality, hence the title of #2844. I explored that idea extensively, but opted for a non-generic API specifically for pasting.

In my estimate, the bulk upsert as expected by a user using paste in a spreadsheet is wildly different than the bulk upsert expected by database administrator doing `INSERT ON CONFLICT DO UPDATE`. Trying to accomodate both seemed like a good way to waste a lot of time and end up with bad UX for both.

Instead of summarizing my concerns, I'll summarize the features of the proposed paste API:

```python
updates = [
	dict(
		changes=dict(
			Status='0',
		),
		conditionals=dict(
			id=record_0_id,
		),
	),
	dict(
		changes=dict(
			Status='1',
			Center='2'
		),
		conditionals=dict(
			id=record_1_id,
		),
	),
]
inserts = [
	dict(
		Status='3',
		Center='4',
	),
	dict(
		Status='5',
		Center='6',
	),
]
data = dict(
	updates=updates,
	inserts=inserts,
)
client.post(f'/api/ui/v0/tables/{table.id}/records/paste/', data=data)
```

Above is the basic outline of the API. The endpoint accepts (via `POST`) a dict, that has two fields: updates and inserts.

It's assumed that frontend will always know whether a given row being pasted should result in an update or an insert. Making that explicit prevents surprises in case of relevant changes having been made that were not synced with the calling frontend.

Updates are a sequence of dicts: each dict has a `changes` key and a `conditionals` key: `changes` define the field-value pairs to change in the row that is satisfied by the equality comparisons defined by field-value pairs in `conditionals`. Think how `UPDATE` works in SQL. An update with `changes` being `{'field1':'val1'}` and `conditionals` being `{'id':'val2'}` requests that for the single row whose `id` field equals `val2`, its `field1` field's value is set to `val1`.

If more than one row would be updated by a given update, that's a fatal exception, because when pasting a row it should never result in more than one updated row. The paste API attempts to minimize surprises to the end user.

Inserts are a sequence of dicts: each dict defines the field-value pairs that should be set on the new resulting row.

An insert will always result in a new row or will panic if that's impossible for whatever reason.

Any panic encountered will rollback all changes made. Paste is meant to be an all-or-nothing operation.

Also, this API panics if any user-defined changes to `SERIAL` or `IDENTITY` columns are requested. These column types need special handling when mutating their values, because there are sequences involved, and that seems hard to safely generalize (i.e. prevent surprises).

All updates are performed before any inserts. All updates are performed in order requested; same for inserts.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
