### PR TITLE
Implement decorator for drf-spectacular to generate documentation for `display_options`

### DIFF
--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -1,5 +1,4 @@
 import warnings
-from mathesar.api.serializers.shared_serializers import DisplayOptionsMappingSerializer
 from psycopg.errors import DuplicateColumn, InvalidTextRepresentation, NotNullViolation
 from psycopg2.errors import StringDataRightTruncation
 from rest_access_policy import AccessViewSetMixin
@@ -10,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from drf_spectacular.utils import PolymorphicProxySerializer
 from drf_spectacular.utils import extend_schema
+from mathesar.api.serializers.shared_serializers import DisplayOptionsMappingSerializer
 
 from mathesar.api.db.permissions.columns import ColumnAccessPolicy
 from mathesar.api.exceptions.database_exceptions import exceptions as database_api_exceptions

--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -40,13 +40,13 @@ class ColumnViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
         return prefetched_queryset
 
     @extend_schema(
-    request=PolymorphicProxySerializer(
-        component_name='ColumnDisplayOptions',
-        serializers=[
-            DisplayOptionsMappingSerializer,
-        ],
-        resource_type_field_name='type',
-    )
+        request=PolymorphicProxySerializer(
+            component_name='ColumnDisplayOptions',
+            serializers=[
+                DisplayOptionsMappingSerializer,
+            ],
+            resource_type_field_name='type',
+        )
     )
     def create(self, request, table_pk=None):
         table = get_table_or_404(table_pk)
@@ -113,13 +113,13 @@ class ColumnViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
         return Response(out_serializer.data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
-    request=PolymorphicProxySerializer(
-        component_name='ColumnDisplayOptions',
-        serializers=[
-            DisplayOptionsMappingSerializer,
-        ],
-        resource_type_field_name='type',
-    )
+        request=PolymorphicProxySerializer(
+            component_name='ColumnDisplayOptions',
+            serializers=[
+                DisplayOptionsMappingSerializer,
+                ],
+            resource_type_field_name='type',
+        )
     )
     def partial_update(self, request, pk=None, table_pk=None):
         column_instance = self.get_object()

--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -117,7 +117,7 @@ class ColumnViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
             component_name='ColumnDisplayOptions',
             serializers=[
                 DisplayOptionsMappingSerializer,
-                ],
+            ],
             resource_type_field_name='type',
         )
     )


### PR DESCRIPTION

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3256 

Implemented the `extend_schema` decorator and the `PolymorphicProxySerializer` class to document the `display_options` field in the OpenAPI schema. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
