### PR TITLE
Removed sqlalchemy-filters

### DIFF
--- a/db/records/operations/relevance.py
+++ b/db/records/operations/relevance.py
@@ -1,5 +1,4 @@
-from sqlalchemy import case, select
-from sqlalchemy_filters import apply_sort
+from sqlalchemy import case, select, desc
 from db.types import categories
 from db.types.operations.convert import get_db_type_enum_from_class
 
@@ -18,10 +17,7 @@ def get_rank_and_filter_rows_query(relation, parameters_dict, limit=10):
     parameters given in parameters_dict.
     """
     rank_cte = _get_scored_selectable(relation, parameters_dict)
-    filtered_ordered_cte = apply_sort(
-        select(rank_cte).where(rank_cte.columns[SCORE_COL] > 0),
-        {'field': SCORE_COL, 'direction': 'desc'}
-    ).cte()
+    filtered_ordered_cte = select(rank_cte).where(rank_cte.columns[SCORE_COL] > 0).order_by(desc(SCORE_COL)).cte()
     return select(
         *[filtered_ordered_cte.columns[c] for c in [col.name for col in relation.columns]]
     ).limit(limit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ responses==0.22.0
 SQLAlchemy-Utils==0.38.2
 thefuzz==0.19.0
 whitenoise==6.4.0
-git+https://github.com/mathesar-foundation/sqlalchemy-filters@models_to_tables#egg=sqlalchemy_filters
 gunicorn==20.1.0
 drf-spectacular==0.26.2
 pandas==2.0.2


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3314

<!-- Concisely describe what the pull request does. -->
Replaces the `apply_sort` function of sqlalchemy-filters with `order_by`

@kgodey @Anish9901 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Ran all the backend tests, they passed
<img width="981" alt="image" src="https://github.com/mathesar-foundation/mathesar/assets/31622972/12f2ee85-c478-43ce-8db5-f59a19a9f97f">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
