### PR TITLE
Non-Selectable Delete message in the Modal

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/table/TableDeleteConfirmationBody.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/TableDeleteConfirmationBody.svelte
@@ -12,10 +12,12 @@
 </script>
 
 <div class="table-delete-confirmation-body">
-  <p>
+  <div class="non-selectable">
+    <p>
     To confirm the deletion of the <strong>{tableName}</strong> table, please enter
     the table name into the input field below.
-  </p>
+    </p>
+  </div>
   <TextInput autofocus bind:value />
   <WarningBox>
     Warning: This action is permanent and once deleted, the table cannot be
@@ -34,5 +36,14 @@
     > :global(* + *) {
       margin-top: 1rem;
     }
+  }
+
+  .non-selectable {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently supported by most browsers */
   }
 </style>

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/TableDeleteConfirmationBody.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/TableDeleteConfirmationBody.svelte
@@ -12,12 +12,10 @@
 </script>
 
 <div class="table-delete-confirmation-body">
-  <div class="non-selectable">
-    <p>
+  <p class="non-selectable">
     To confirm the deletion of the <strong>{tableName}</strong> table, please enter
     the table name into the input field below.
-    </p>
-  </div>
+  </p>
   <TextInput autofocus bind:value />
   <WarningBox>
     Warning: This action is permanent and once deleted, the table cannot be


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3307

<!-- Concisely describe what the pull request does. -->
The PR makes the modal text for delete confirmation non-selectable so that the user cannot copy it to the text-box
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
