### PR TITLE
Fixed formatting strings for timestampsWithTZ

### DIFF
--- a/mathesar_ui/src/utils/date-time/DateTimeSpecification.ts
+++ b/mathesar_ui/src/utils/date-time/DateTimeSpecification.ts
@@ -168,10 +168,10 @@ export default class DateTimeSpecification {
       ...timestamp,
       ...combine(timestamp, ['[AD]', '[BC]'], (a, b) => `${a} ${b}`),
     ];
-    const timestampWithTZ = combine(date, timeWithTZ, (a, b) => `${a} ${b}`);
+    const timestampWithTZ = combine(date, timeWithTZ, (a, b) => `${a}T${b}`);
     const timestampWithTZFull = [
       ...timestampWithTZ,
-      ...combine(timestampWithTZ, ['[AD]', '[BC]'], (a, b) => `${a} ${b}`),
+      ...combine(timestampWithTZ, ['[AD]', '[BC]'], (a, b) => `${a}T${b}`),
     ];
 
     switch (this.type) {


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2966 

<!-- Concisely describe what the pull request does. -->

**Technical details**
In `parse` of [DateTimeFormatter](https://github.com/mathesar-foundation/mathesar/blob/develop/mathesar_ui/src/utils/date-time/DateTimeFormatter.ts#L15-L38) the value is calculated by providing `userInputOrServerResponse` and `formattingOptions`.
We are getting formatting options like so
```
const formattingOptions = [
      this.specification.getFormattingString(),
      ...this.specification.getCommonFormattingStrings(),
      ...this.specification.getCanonicalFormattingStrings(),
    ];
 ```
 
Now in the `getCanonicalFormattingStrings()` which can be found [here](https://github.com/mathesar-foundation/mathesar/blob/704c1257788255acf2b9b6bbfd7a275724000fd6/mathesar_ui/src/utils/date-time/DateTimeSpecification.ts#L156-L191), the formatting strings for TZ timestamps are made using this

https://github.com/mathesar-foundation/mathesar/blob/704c1257788255acf2b9b6bbfd7a275724000fd6/mathesar_ui/src/utils/date-time/DateTimeSpecification.ts#L171-L175

This code returns these values for `timestampWithTZ` and `timestampWithTZFull`
   
<img width="465" alt="image" src="https://github.com/mathesar-foundation/mathesar/assets/31622972/85ab9913-43a8-4f95-ac6f-7f11aecae5f3">

Hence `dayjs` was not able to parse datetimestring containing TZ timestamp.

Adding a simple `T` fixes the issue.

@seancolsen can you please review this.

<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="1295" alt="image" src="https://github.com/mathesar-foundation/mathesar/assets/31622972/34459b94-d1af-4e7d-bd49-c8c4fa48d555">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
