### PR TITLE
Add script to help resolve git merge conflicts in dict.json i18n file

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -187,6 +187,11 @@ Django uses gettext, which require the `.po` files to be compiled into a more ef
 - To handle pluralization and other complexities, the source translation strings may utilize a special syntax called [JSON with ICU Plurals](https://help.transifex.com/en/articles/6220806-json-with-icu-plurals) (a subset of the [ICU format](https://unicode-org.github.io/icu/userguide/icu/i18n.html)).
 - After making changes to your code, ensure that the source `/en/dict.json` file contains new translation strings, if any.
 - Do not update other translation files. They will be pulled from our translation service provider when the translation process is complete.
+- If you encounter merge conflicts in `en/dict.json`, run this script to automatically resolve them:
+
+    ```
+    python3 mathesar_ui/src/i18n/scripts/resolve_dict_merge_conflicts.py
+    ```
 
 ## Translation process
 

--- a/mathesar_ui/src/i18n/scripts/resolve_dict_merge_conflicts.py
+++ b/mathesar_ui/src/i18n/scripts/resolve_dict_merge_conflicts.py
@@ -30,12 +30,12 @@ incoming_rev = None
 with open(DICT_PATH, "r") as f:
     for line in f:
         if not current_rev:
-            match = re.search("^<<<<<<< (\w+)", line)
+            match = re.search(r"^<<<<<<< (\w+)", line)
             if match:
                 current_rev = match.group(1)
                 continue
         if not incoming_rev:
-            match = re.search("^>>>>>>> (\w+)", line)
+            match = re.search(r"^>>>>>>> (\w+)", line)
             if match:
                 incoming_rev = match.group(1)
                 continue

--- a/mathesar_ui/src/i18n/scripts/resolve_dict_merge_conflicts.py
+++ b/mathesar_ui/src/i18n/scripts/resolve_dict_merge_conflicts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import re
+import subprocess
+import json
+
+DICT_PATH = "mathesar_ui/src/i18n/languages/en/dict.json"
+CONFLICTS_PATH = "mathesar_ui/src/i18n/languages/en/dict.conflicts.json"
+
+
+def cmd(parts):
+    return subprocess.run(parts, capture_output=True).stdout.decode().strip()
+
+
+def get_commit_id(rev):
+    return cmd(["git", "rev-parse", rev])
+
+
+def get_merge_base(rev1, rev2):
+    return cmd(["git", "merge-base", rev1, rev2])
+
+
+def get_dict_at_commit(commit):
+    return json.loads(cmd(["git", "show", f"{commit}:{DICT_PATH}"]))
+
+
+current_rev = None
+incoming_rev = None
+
+with open(DICT_PATH, "r") as f:
+    for line in f:
+        if not current_rev:
+            match = re.search("^<<<<<<< (\w+)", line)
+            if match:
+                current_rev = match.group(1)
+                continue
+        if not incoming_rev:
+            match = re.search("^>>>>>>> (\w+)", line)
+            if match:
+                incoming_rev = match.group(1)
+                continue
+        if current_rev and incoming_rev:
+            break
+
+if not current_rev and not incoming_rev:
+    print("No merge conflict detected.")
+    exit(0)
+
+current_commit = get_commit_id(current_rev)
+incoming_commit = get_commit_id(incoming_rev)
+base_commit = get_merge_base(current_commit, incoming_commit)
+
+base_dict = get_dict_at_commit(base_commit)
+current_dict = get_dict_at_commit(current_commit)
+incoming_dict = get_dict_at_commit(incoming_commit)
+
+merged_dict = {}
+conflicts = {}
+keys = base_dict.keys() | current_dict.keys() | incoming_dict.keys()
+
+# This does a three way merge on a per-item basis
+for key in keys:
+    base_value = base_dict.get(key)
+    current_value = current_dict.get(key)
+    incoming_value = incoming_dict.get(key)
+
+    # New values are equal
+    if current_value == incoming_value:
+        if current_value:
+            merged_dict[key] = current_value
+        continue
+
+    # Only one new value exists
+    if current_value and not incoming_value:
+        merged_dict[key] = current_value
+        continue
+    if incoming_value and not current_value:
+        merged_dict[key] = incoming_value
+        continue
+
+    # Only one value changed
+    if current_value == base_value:
+        merged_dict[key] = incoming_value
+        continue
+    if incoming_value == base_value:
+        merged_dict[key] = current_value
+        continue
+
+    # Both values changed
+    merged_dict[key] = current_value
+    conflicts[key] = {
+        "base": base_value,
+        "current": current_value,
+        "incoming": incoming_value,
+    }
+
+with open(DICT_PATH, "w") as f:
+    f.write(json.dumps(merged_dict, indent=2, sort_keys=True) + "\n")
+
+cmd(["git", "add", DICT_PATH])
+
+if conflicts:
+    with open(CONFLICTS_PATH, "w") as f:
+        f.write(json.dumps(conflicts, indent=2, sort_keys=True))


### PR DESCRIPTION
@pavish heads up about this little tool I spun up today.

Even though we're sorting the keys in dict.json, I've still noticed that resolving merge conflicts in that file is a bit annoying. I threw together this script which helps out by doing a three-way merge on a per-key basis. It worked for me when I had to resolve merge conflicts today. It still needs some polish before I'd want to merge it in. I'd want to change the hard-coded paths to use a positional command line argument instead. This way we could run it on other dict.json files too.

If you think this would be useful, I can finish it.

Or if you have another idea for how to easy resolve these sort of merge conflicts, I'd be keen to hear it.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


