### PR TITLE
remove remaining SQLAlchemy filters dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ EXPOSE 5432
 WORKDIR /code/
 
 COPY requirements* ./
-RUN pip install --no-cache-dir -r ${PYTHON_REQUIREMENTS} --force-reinstall sqlalchemy-filters
+RUN pip install --no-cache-dir -r ${PYTHON_REQUIREMENTS}
 COPY . .
 
 RUN cd mathesar_ui && npm ci && npm run build

--- a/Dockerfile.integ-tests
+++ b/Dockerfile.integ-tests
@@ -131,7 +131,7 @@ COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY requirements-demo.txt .
 
-RUN pip install -r requirements.txt --force-reinstall sqlalchemy-filters
+RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt
 RUN pip install -r requirements-demo.txt
 COPY . .

--- a/db/records/exceptions.py
+++ b/db/records/exceptions.py
@@ -1,12 +1,8 @@
-from sqlalchemy_filters.exceptions import FieldNotFound
-
-
-# Grouping exceptions follow the sqlalchemy_filters exceptions patterns
 class BadGroupFormat(Exception):
     pass
 
 
-class GroupFieldNotFound(FieldNotFound):
+class GroupFieldNotFound(Exception):
     pass
 
 

--- a/db/records/operations/select.py
+++ b/db/records/operations/select.py
@@ -42,10 +42,8 @@ def get_records(
                          'direction' field.
         search:          list of dictionaries, where each dictionary has a 'column' and
                          'literal' field.
-                         See: https://github.com/centerofci/sqlalchemy-filters#sort-format
         filter:          a dictionary with one key-value pair, where the key is the filter id and
                          the value is a list of parameters; supports composition/nesting.
-                         See: https://github.com/centerofci/sqlalchemy-filters#filters-format
         group_by:        group.GroupBy object
         duplicate_only:  list of column names; only rows that have duplicates across those rows
                          will be returned

--- a/mathesar/api/db/viewsets/records.py
+++ b/mathesar/api/db/viewsets/records.py
@@ -40,8 +40,6 @@ class RecordViewSet(AccessViewSetMixin, viewsets.ViewSet):
 
     # For filter parameter formatting, see:
     # db/functions/operations/deserialize.py::get_db_function_from_ma_function_spec function doc>
-    # For sorting parameter formatting, see:
-    # https://github.com/centerofci/sqlalchemy-filters#sort-format
     def list(self, request, table_pk=None):
         paginator = TableLimitOffsetPagination()
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3424 

<!-- Concisely describe what the pull request does. -->

This removes an errant import of `sqlalchemy_filters`, and also the steps in our `Dockerfile`s where it was installed regardless of `requirements.txt`.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The only place it was used was as a dependency of a custom exception. I removed that dependency.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
