### PR TITLE
Add release notes helper script

### DIFF
--- a/docs/docs/releases/.gitignore
+++ b/docs/docs/releases/.gitignore
@@ -1,0 +1,2 @@
+cache/***
+missing_prs.csv

--- a/docs/docs/releases/README.md
+++ b/docs/docs/releases/README.md
@@ -1,0 +1,26 @@
+# Release notes
+
+This is developer documentation to help with release notes. It is not published in our docs guide.
+
+## How to generate release notes
+
+1. Create an empty release notes file.
+
+    For example:
+
+    ```
+    touch 1.2.3.md
+    ```
+
+1. Run this script to find PRs which have been merged but not yet included in the latest release notes file.
+
+    ```
+    ./find_missing_prs.sh
+    ```
+
+    (See comments within the script to better understand how it works.)
+
+1. Open `missing_prs.csv` to see the PRs you need to add. Incorporate them into the release notes as you see fit. Save the release notes and commit them.
+
+1. Re-run the script as needed. When more PRs are merged, they will appear in `missing_prs.csv`.
+

--- a/docs/docs/releases/find_missing_prs.sh
+++ b/docs/docs/releases/find_missing_prs.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+## DEPENDENCIES
+##
+## This script requires the following things to be installed:
+##
+## - The GitHub CLI: https://cli.github.com/
+## - DuckDB: https://duckdb.org/
+
+COMMITS_FILE=cache/commits.txt
+ALL_PRS_FILE=cache/all_prs.json
+INCLUDED_PRS_FILE=cache/included_prs.txt
+MISSING_PRS_FILE=missing_prs.csv
+
+# Use the latest release notes file
+NOTES_FILE=$(ls -1 | grep -e '^[0-9]\.[0-9]\.[0-9]' | sort | tail -n 1)
+
+# Assume the release version number to match the file name
+RELEASE=$(echo $NOTES_FILE | sed s/.md$//)
+
+# See all our local branches
+BRANCHES=$(git branch --format="%(refname:short)")
+
+# Find the release branch. If we've already cut a branch for the release (and we
+# have it locally), then use that. Otherwise, use "develop".
+RELEASE_BRANCH=$(
+  if echo $BRANCHES | grep -q $RELEASE; then
+    echo $RELEASE
+  else
+    echo "develop"
+  fi
+)
+
+# Find and cache the hashes for all the PR-merge commits included in the release
+# branch but not included in the master branch.
+git log --format=%H --first-parent master..$RELEASE_BRANCH > $COMMITS_FILE
+
+# Find and cache details about all the PRs merged within the past year. This
+# gets more PRs than we need, but we'll filter it shortly.
+gh pr list \
+  --base $RELEASE_BRANCH \
+  --limit 1000 \
+  --json additions,author,deletions,mergeCommit,title,url \
+  --search "is:closed merged:>$(date -d '1 year ago' '+%Y-%m-%d')" \
+  --jq 'map({
+      additions: .additions,
+      author: .author.login,
+      deletions: .deletions,
+      mergeCommit: .mergeCommit.oid,
+      title: .title,
+      url: .url
+    })' > $ALL_PRS_FILE
+
+# Find and cache the URLs to any PRs that we've already referenced in the
+# release notes.
+grep -Po 'https://github\.com/mathesar-foundation/mathesar/pull/\d*' \
+  $NOTES_FILE > $INCLUDED_PRS_FILE
+
+# Generate a CSV containing details for PRs that match commits in the release
+# but not in the release notes.
+echo "
+  SELECT
+    pr.title,
+    pr.url,
+    pr.author,
+    pr.additions,
+    pr.deletions,
+    '[#' || regexp_extract(pr.url, '(\d+)$', 1) || '](' || pr.url || ')' AS link
+  FROM read_json('$ALL_PRS_FILE', auto_detect=true) AS pr
+  JOIN read_csv('$COMMITS_FILE', columns={'hash': 'text'}) AS commit
+    ON commit.hash = pr.mergeCommit
+  LEFT JOIN read_csv('$INCLUDED_PRS_FILE', columns={'url': 'text'}) AS included
+    ON included.url = pr.url
+  WHERE included.url IS NULL
+  ORDER BY pr.additions DESC;" | \
+  duckdb -csv > $MISSING_PRS_FILE
+


### PR DESCRIPTION
This is a non-functional changes which adds tooling to help generate release notes.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>



