### PR TITLE
Migration to copy `MATHESAR_DATABASES` credentials

### DIFF
--- a/mathesar/migrations/0006_mathesar_databases_to_model.py
+++ b/mathesar/migrations/0006_mathesar_databases_to_model.py
@@ -1,0 +1,34 @@
+from decouple import config as decouple_config
+from django.conf import settings
+from django.db import migrations
+
+
+def update_conn_info(apps, _):
+    """Add info from MATHESAR_DATABASES to new model fields."""
+    Database = apps.get_model('mathesar', 'Database')
+    django_db_key = decouple_config('DJANGO_DATABASE_KEY', default="default")
+    user_databases = [key for key in settings.DATABASES if key != django_db_key]
+    for database_key in user_databases:
+        try:
+            db = Database.current_objects.get(name=database_key)
+        except Database.DoesNotExist:
+            continue
+        db_info = settings.DATABASES[database_key]
+        if 'postgres' in db_info['ENGINE']:
+            db.name = database_key
+            db.db_name = db_info['NAME']
+            db.username = db_info['USER']
+            db.password = db_info['PASSWORD']
+            db.host = db_info['HOST']
+            db.port = db_info['PORT']
+            db.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mathesar', '0005_release_0_1_4'),
+    ]
+    operations = [
+        migrations.RunPython(update_conn_info),
+    ]


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3426 

<!-- Concisely describe what the pull request does. -->

See #3430 for a discussion and context.

This PR adds a custom migration step that copies credentials from the `MATHESAR_DATABASES` variable (via the `django.conf.settings.DATABASES` dict) into the new `Database` model.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
