### PR TITLE
Enable i18n

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ ENV NODE_MAJOR 18
 # Install dev requirements
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
+# Compile translation files
+RUN python manage.py compilemessages
+
 # Add NodeJS source
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list;
@@ -90,6 +93,9 @@ FROM base AS production
 
 # Install prod requirements
 RUN pip install --no-cache-dir -r requirements-prod.txt
+
+# Compile translation files
+RUN python manage.py compilemessages
 
 # Copy built frontend static files
 COPY --from=development /code/mathesar/static/mathesar ./mathesar/static/mathesar/

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -54,8 +54,8 @@ def get_i18n_settings_dev(display_language):
 
 
 def get_prod_translation_file_urls(language, manifest_data):
-    prod_module_url = static(manifest_data[language]["file"])
-    prod_legacy_url = static(manifest_data[f"{language}-legacy"]["file"])
+    prod_module_url = static(manifest_data[f"language_{language}"]["file"])
+    prod_legacy_url = static(manifest_data[f"language_{language}_legacy"]["file"])
 
     return {
         'module': prod_module_url,

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -8,19 +8,26 @@ from mathesar.utils.frontend import get_manifest_data
 def frontend_settings(request):
     manifest_data = get_manifest_data()
     development_mode = settings.MATHESAR_MODE == 'DEVELOPMENT'
+    display_language = get_display_language_from_request(request)
+    fallback_language = settings.FALLBACK_LANGUAGE
 
-    i18n_settings = get_i18n_settings(request, manifest_data, development_mode)
     frontend_settings = {
         'development_mode': development_mode,
         'manifest_data': manifest_data,
         'live_demo_mode': getattr(settings, 'MATHESAR_LIVE_DEMO', False),
         'live_demo_username': getattr(settings, 'MATHESAR_LIVE_DEMO_USERNAME', None),
         'live_demo_password': getattr(settings, 'MATHESAR_LIVE_DEMO_PASSWORD', None),
-        **i18n_settings
+        'display_language': display_language,
+        'include_i18n_fallback': display_language != fallback_language,
     }
     # Only include development URL if we're in development mode.
     if frontend_settings['development_mode'] is True:
         frontend_settings['client_dev_url'] = settings.MATHESAR_CLIENT_DEV_URL
+        i18n_settings = get_i18n_settings_dev(display_language)
+    else:
+        i18n_settings = get_i18n_settings_prod(display_language, manifest_data)
+
+    frontend_settings = { **frontend_settings, **i18n_settings }
 
     return frontend_settings
 
@@ -36,30 +43,33 @@ def get_display_language_from_request(request):
         return lang_from_locale_middleware
 
 
-def get_i18n_settings(request, manifest_data, development_mode):
-    """
-    Hard coding this for now
-    but will be taken from users model
-    and cookies later on
-    """
-    display_language = get_display_language_from_request(request)
-    fallback_language = 'en'
-
+def get_i18n_settings_dev(display_language):
     client_dev_url = settings.MATHESAR_CLIENT_DEV_URL
-
-    if development_mode is True:
-        module_translations_file_path = f'{client_dev_url}/src/i18n/languages/{display_language}/index.ts'
-        legacy_translations_file_path = f'{client_dev_url}/src/i18n/languages/{display_language}/index.ts'
-    else:
-        try:
-            module_translations_file_path = static(manifest_data[display_language]["file"])
-            legacy_translations_file_path = static(manifest_data[f"{display_language}-legacy"]["file"])
-        except KeyError:
-            module_translations_file_path = static(manifest_data[fallback_language]["file"])
-            legacy_translations_file_path = static(manifest_data[f"{fallback_language}-legacy"]["file"])
+    fallback_language = settings.FALLBACK_LANGUAGE
 
     return {
-        'module_translations_file_path': module_translations_file_path,
-        'legacy_translations_file_path': legacy_translations_file_path,
-        'display_language': display_language
+        'dev_display_language_url': f'{client_dev_url}/src/i18n/languages/{display_language}/index.ts',
+        'dev_fallback_language_url': f'{client_dev_url}/src/i18n/languages/{fallback_language}/index.ts',
+    }
+
+
+def get_prod_translation_file_urls(language, manifest_data):
+    prod_module_url = static(manifest_data[language]["file"])
+    prod_legacy_url = static(manifest_data[f"{language}-legacy"]["file"])
+
+    return {
+        'module': prod_module_url,
+        'legacy': prod_legacy_url,
+    }
+
+
+def get_i18n_settings_prod(display_language, manifest_data):
+    fallback_language = settings.FALLBACK_LANGUAGE
+
+    display_language_urls = get_prod_translation_file_urls(display_language, manifest_data)
+    fallback_language_urls = get_prod_translation_file_urls(fallback_language, manifest_data)
+
+    return {
+        'prod_display_language_urls': display_language_urls,
+        'prod_fallback_language_urls': fallback_language_urls,
     }

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -27,7 +27,7 @@ def frontend_settings(request):
     else:
         i18n_settings = get_i18n_settings_prod(display_language, manifest_data)
 
-    frontend_settings = { **frontend_settings, **i18n_settings }
+    frontend_settings = {**frontend_settings, **i18n_settings}
 
     return frontend_settings
 

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -9,7 +9,7 @@ def frontend_settings(request):
     manifest_data = get_manifest_data()
     development_mode = settings.MATHESAR_MODE == 'DEVELOPMENT'
 
-    i18n_settings = get_i18n_settings(manifest_data, development_mode)
+    i18n_settings = get_i18n_settings(request, manifest_data, development_mode)
     frontend_settings = {
         'development_mode': development_mode,
         'manifest_data': manifest_data,
@@ -36,13 +36,13 @@ def get_display_language_from_request(request):
         return lang_from_locale_middleware
 
 
-def get_i18n_settings(manifest_data, development_mode):
+def get_i18n_settings(request, manifest_data, development_mode):
     """
     Hard coding this for now
     but will be taken from users model
     and cookies later on
     """
-    display_language = 'en'
+    display_language = get_display_language_from_request(request)
     fallback_language = 'en'
 
     client_dev_url = settings.MATHESAR_CLIENT_DEV_URL

--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -279,4 +279,6 @@ LOCALE_PATHS = [
     'translations'
 ]
 LANGUAGE_COOKIE_NAME = 'display_language'
+FALLBACK_LANGUAGE = 'en'
+
 SALT_KEY = SECRET_KEY

--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from decouple import Csv, config as decouple_config
 from dj_database_url import parse as db_url
-from django.utils.translation import gettext_lazy
 
 
 # We use a 'tuple' with pipes as delimiters as decople naively splits the global

--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -272,8 +272,8 @@ BASE_TEMPLATE_ADDITIONAL_SCRIPT_TEMPLATES = []
 
 # i18n
 LANGUAGES = [
-    ('en', gettext_lazy('English')),
-    ('ja', gettext_lazy('Japanese')),
+    ('en', 'English'),
+    ('ja', 'Japanese'),
 ]
 LOCALE_PATHS = [
     'translations'

--- a/mathesar/templates/mathesar/index.html
+++ b/mathesar/templates/mathesar/index.html
@@ -19,12 +19,20 @@
     {% endfor %}
   {% endif %}
 
-  <script type="module" src="{{ module_translations_file_path }}"></script>
-
   {% if development_mode %}
+    <script type="module" src="{{ dev_display_language_url }}"></script>
+    {% if include_i18n_fallback %}
+      <script type="module" src="{{ dev_fallback_language_url }}"></script>
+    {% endif %}
+
     <script type="module" src="{{ client_dev_url }}/@vite/client"></script>
     <script type="module" src="{{ client_dev_url }}/src/main.ts"></script>
   {% else %}
+    <script type="module" src="{{ prod_display_language_urls.module }}"></script>
+    {% if include_i18n_fallback %}
+      <script type="module" src="{{ prod_fallback_language_urls.module }}"></script>
+    {% endif %}
+
     <!-- For legacy browsers that do not support modules -->
     <script nomodule>
       !(function () {
@@ -54,15 +62,29 @@
       nomodule
       src="{% static manifest_data.legacy_polyfill_js %}"
     ></script>
+
     <script
       nomodule
-      id="vite-legacy-translations-slot"
-      data-src="{{ legacy_translations_file_path }}"
+      id="vite-legacy-display-lang-slot"
+      data-src="{{ prod_display_language_urls.legacy }}"
     >
       System.import(
-        document.getElementById("vite-legacy-translations-slot").getAttribute("data-src")
+        document.getElementById("vite-legacy-display-lang-slot").getAttribute("data-src")
       );
     </script>
+
+    {% if include_i18n_fallback %}
+      <script
+        nomodule
+        id="vite-legacy-fallback-lang-slot"
+        data-src="{{ prod_fallback_language_urls.legacy }}"
+      >
+        System.import(
+          document.getElementById("vite-legacy-fallback-lang-slot").getAttribute("data-src")
+        );
+      </script>
+    {% endif %}
+
     <script
       nomodule
       id="vite-legacy-js-slot"

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -150,7 +150,6 @@
   <div class="login-card align-center">
     <h1>{% block h1 %} {% endblock %}</h1>
     {% block box_content %} {% endblock %}
-    <!-- Commenting it out to avoid releasing any half baked changes
     {% comment %} set_language https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#the-set-language-redirect-view  {% endcomment %}
     <form action="{% url 'set_language' %}" method="post">{% csrf_token %}
       <input name="next" type="hidden" value="{{ redirect_to }}">
@@ -165,6 +164,6 @@
           {% endfor %}
       </select>
     </form>
-    -->
+   
   </div>
 {% endblock %}

--- a/mathesar/utils/frontend.py
+++ b/mathesar/utils/frontend.py
@@ -26,8 +26,8 @@ def get_manifest_data():
     manifest_data['legacy_js'] = legacy_data['file']
 
     for locale, _ in settings.LANGUAGES or []:
-        manifest_data[locale] = raw_data[f'src/i18n/languages/{locale}/index.ts']
-        manifest_data[f"{locale}-legacy"] = raw_data[f'src/i18n/languages/{locale}/index-legacy.ts']
+        manifest_data[f"language_{locale}"] = raw_data[f'src/i18n/languages/{locale}/index.ts']
+        manifest_data[f"language_{locale}_legacy"] = raw_data[f'src/i18n/languages/{locale}/index-legacy.ts']
 
     # Cache data for 1 hour
     cache.set('manifest_data', manifest_data, 60 * 60)

--- a/mathesar_ui/src/App.svelte
+++ b/mathesar_ui/src/App.svelte
@@ -1,28 +1,26 @@
 <script lang="ts">
   import { Spinner } from '@mathesar-component-library';
   import { preloadCommonData } from '@mathesar/utils/preloadData';
+  import { isLoading as isTranslationLoading, locale } from 'svelte-i18n';
   import AppContext from './AppContext.svelte';
   import RootRoute from './routes/RootRoute.svelte';
   import { initI18n } from './i18n';
 
   const commonData = preloadCommonData();
-
-  let isTranslationsLoaded = false;
-  void (async () => {
-    await initI18n(commonData.user.display_language ?? 'en');
-    isTranslationsLoaded = true;
-  })();
+  void initI18n(commonData.user.display_language ?? 'en');
 </script>
 
-{#if isTranslationsLoaded}
-  <AppContext {commonData}>
-    <RootRoute {commonData} />
-  </AppContext>
-{:else if !isTranslationsLoaded}
-  <div class="app-loader">
-    <Spinner size="2rem" />
-  </div>
-{/if}
+<AppContext {commonData}>
+  {#if $isTranslationLoading}
+    <div class="app-loader">
+      <Spinner size="2rem" />
+    </div>
+  {:else}
+    {#key $locale}
+      <RootRoute {commonData} />
+    {/key}
+  {/if}
+</AppContext>
 
 <!--
   Supporting aliases in scss within the preprocessor is a bit of work.

--- a/mathesar_ui/src/i18n/index.ts
+++ b/mathesar_ui/src/i18n/index.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import { addMessages, init, register, locale } from 'svelte-i18n';
 import type { LangObject } from './languages/utils';
 
@@ -10,10 +11,14 @@ async function loadDictionaryAsync(
   language: LangObject['language'],
 ): Promise<LangObject['dictionary']> {
   const translationsModule = await loaders[language]();
-  return translationsModule.default.dictionary;
+  return { default: translationsModule.default.dictionary };
 }
 
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
+function setLanguageCookie(language: LangObject['language']) {
+  Cookies.set('display_language', language);
+}
 
 export async function initI18n(language: LangObject['language']) {
   register('en', () => loadDictionaryAsync('en'));
@@ -30,13 +35,15 @@ export async function initI18n(language: LangObject['language']) {
   }
 
   await init({
-    fallbackLocale: language,
+    fallbackLocale: 'en',
     initialLocale: language,
   });
+  setLanguageCookie(language);
 }
 
 export async function setLanguage(language: LangObject['language']) {
   await locale.set(language);
+  setLanguageCookie(language);
 }
 
 /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */

--- a/mathesar_ui/src/systems/users-and-permissions/UserDetailsForm.svelte
+++ b/mathesar_ui/src/systems/users-and-permissions/UserDetailsForm.svelte
@@ -24,7 +24,7 @@
   import GridFormInput from '@mathesar/components/form/GridFormInput.svelte';
   import { setLanguage } from '@mathesar/i18n';
   import SelectUserType from './SelectUserType.svelte';
-  // import SelectDisplayLanguage from './SelectDisplayLanguage.svelte';
+  import SelectDisplayLanguage from './SelectDisplayLanguage.svelte';
 
   const dispatch = createEventDispatcher<{ create: User; update: undefined }>();
   const userProfileStore = getUserProfileStoreFromContext();
@@ -84,10 +84,10 @@
       await userApi.update(user.id, request);
       if (isUserUpdatingThemselves && userProfileStore) {
         userProfileStore.update((details) => details.with(request));
+        const updatedLocale = request.display_language;
+        await setLanguage(updatedLocale);
       }
 
-      const updatedLocale = request.display_language;
-      await setLanguage(updatedLocale);
       dispatch('update');
       return;
     }
@@ -155,14 +155,13 @@
     />
   {/if}
 
-  <!-- Commenting this for now to avoid releasing any half baked changes to develop branch -->
-  <!-- <GridFormInput
+  <GridFormInput
     label={`${$_('display_language')} *`}
     field={displayLanguage}
     input={{
       component: SelectDisplayLanguage,
     }}
-  /> -->
+  />
 
   <GridFormInput
     label={`${$_('role')} *`}


### PR DESCRIPTION
**This PR Enables switching languages**

Tasks:
- [x] Use system default for login page
- [x] After logging in, use value stored for user
- [x] Ensure both en and js get loaded in parallel
- [x] ~~Add docs for building po files in Wiki~~ (added in https://github.com/mathesar-foundation/mathesar/pull/3489)
- [x] Build .po files in Dockerfile
- [ ] ~~Show language switcher dropdown in password change page and superuser creation page?~~ (Out of scope for this PR)
- [x] Test a production setup

**UX considerations**
* Within the app, the language switcher is present in the profile page and users page.
   * <img width="1322" alt="Screenshot 2024-03-15 at 5 49 21 PM" src="https://github.com/mathesar-foundation/mathesar/assets/11850603/2a7e56fb-dae9-4164-b888-b592f9b2d0f2">
* When the user installs and runs Mathesar for the first time, the language is automatically chosen based on the locale of the browser.
* In the super admin creation page, there's no option to switch languages.
    * <img width="969" alt="Screenshot 2024-03-15 at 5 45 59 PM" src="https://github.com/mathesar-foundation/mathesar/assets/11850603/4d4efa99-d4ff-4614-b5a8-ced6fee5f4e4">
* In the login page, there's an option to switch languages.
    * <img width="827" alt="Screenshot 2024-03-15 at 5 38 36 PM" src="https://github.com/mathesar-foundation/mathesar/assets/11850603/a0d3fe1b-a375-4cd3-b107-73d20e630c8a">
* Once the user logs in and sets their preference, it is retained in a cookie and the login page will choose the language based on that cookie, but the option is still present.
* Do we need the option to switch languages in the login page?
* Do we need this option in the super user creation page?
* If yes to the above, should we hide that select menu until we visually style it? (It's currently the default select menu and the appearance varies based on the browser)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
