### PR TITLE
GH workflow to create draft release with built static files

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -22,12 +22,12 @@ jobs:
         run: npm ci && npm run build
 
       - name: Move static files
-        run: mv ./mathesar/static/mathesar ./static-files
+        run: mv ./mathesar/static/mathesar ./static_files
 
       - name: Zip static files
         uses: montudor/action-zip@v1
         with:
-          args: zip -qq -r static_files.zip static-files
+          args: zip -qq -r static_files.zip static_files
 
       - name: Create a draft release
         id: create_release

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
+
 
 jobs:
   build:
@@ -14,20 +16,26 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-        run: cd mathesar_ui && npm ci && npm run build
-        run: cd ..
 
-      - uses: montudor/action-zip@v1
+      - name: Build frontend static files
+        working-directory: ./mathesar_ui
+        run: npm ci && npm run build
+
+      - name: Move static files
+        run: mv ./mathesar/static/mathesar ./static-files
+
+      - name: Zip static files
+        uses: montudor/action-zip@v1
         with:
-          args: zip -r static_files.zip ./mathesar/static/mathesar/
+          args: zip -qq -r static_files.zip static-files
 
-      - name: Create a Release
+      - name: Create a draft release
         id: create_release
         uses: shogo82148/actions-create-release@v1
+        with:
+          draft: true
 
-      # A release created by shogo82148/actions-create-release is always a draft release.
-
-      - name: Upload Assets
+      - name: Upload assets
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,34 @@
+name: Build static files and create draft release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+        run: cd mathesar_ui && npm ci && npm run build
+        run: cd ..
+
+      - uses: montudor/action-zip@v1
+        with:
+          args: zip -r static_files.zip ./mathesar/static/mathesar/
+
+      - name: Create a Release
+        id: create_release
+        uses: shogo82148/actions-create-release@v1
+
+      # A release created by shogo82148/actions-create-release is always a draft release.
+
+      - name: Upload Assets
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: static_files.zip

--- a/docs/docs/installation/build-from-source/index.md
+++ b/docs/docs/installation/build-from-source/index.md
@@ -32,14 +32,6 @@ You'll need to install the following system packages before you install Mathesar
 
 - [PostgreSQL](https://www.postgresql.org/download/linux/) 13 or newer (Verify by logging in, and running the query: `SELECT version();`)
 
-- [NodeJS](https://nodejs.org/en/download) 18 or newer (Verify with `node --version`)
-
-    _(This is required for installation only and will eventually be [relaxed](https://github.com/centerofci/mathesar/issues/2871))_
-
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) 9 or newer (Verify with `npm --version`)
-
-    _(This is required for installation only and will eventually be [relaxed](https://github.com/centerofci/mathesar/issues/2871))_
-
 - [Caddy](https://caddyserver.com/docs/install) (Verify with `caddy version`)
 
 - [git](https://git-scm.com/downloads) (Verify with `git --version`)
@@ -220,16 +212,20 @@ Then press <kbd>Enter</kbd> to customize this guide with your domain name.
             You need to export the environment variables each time you restart the shell as they don't persist across sessions.
 
 
-1. Install the frontend dependencies
+1. Download release static files and extract into the correct directory
 
     ```
-    npm ci --prefix mathesar_ui
+    wget https://github.com/mathesar-foundation/mathesar/releases/download/{{mathesar_version}}/static_files.zip
+    unzip static_files.zip && mv static_files /mathesar/static/mathesar
     ```
-      
-1. Compile the Mathesar Frontend App
-   ```
-   npm run --prefix mathesar_ui build --max_old_space_size=4096
-   ```
+
+
+1. Compile Mathesar translation files
+
+    ```
+    python manage.py compilemessages
+    ```
+
 
 1. Install Mathesar functions on the database:
 


### PR DESCRIPTION
Fixes #2871 

**Details**
* Adds a workflow that creates a draft release whenever a tag is pushed. This draft release includes the built frontend static files.
  * Tested this on [my fork](https://github.com/pavish/mathesar/releases), since this needs to be on the develop branch inorder for us to test it.
* Updates docs:
  * Removes NodeJS & npm dependencies and downloads & extracts static_files to correct location
  * Adds step to compile the Django translation files (This seems to have been missed previously, I only caught it when adding ja translations).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
