### PR TITLE
Exception handler tests

### DIFF
--- a/mathesar/tests/rpc/exceptions/test_error_codes.py
+++ b/mathesar/tests/rpc/exceptions/test_error_codes.py
@@ -1,12 +1,12 @@
+import pytest
+
+from psycopg.errors import BadCopyFileFormat
+from django.core.exceptions import FieldDoesNotExist
+from mathesar.utils.connections import BadInstallationTarget
+from db.functions.exceptions import UnknownDBFunctionID
+from sqlalchemy.exc import IntegrityError
 from http.client import CannotSendRequest
 
-from django.core.exceptions import FieldDoesNotExist
-from psycopg.errors import BadCopyFileFormat
-import pytest
-from sqlalchemy.exc import IntegrityError
-
-from db.functions.exceptions import UnknownDBFunctionID
-from mathesar.utils.connections import BadInstallationTarget
 import mathesar.rpc.exceptions.error_codes as err_codes
 
 

--- a/mathesar/tests/rpc/exceptions/test_error_handler.py
+++ b/mathesar/tests/rpc/exceptions/test_error_handler.py
@@ -1,0 +1,37 @@
+import pytest
+
+from modernrpc.exceptions import RPCException
+from psycopg.errors import BadCopyFileFormat
+from django.core.exceptions import FieldDoesNotExist
+from mathesar.utils.connections import BadInstallationTarget
+from db.functions.exceptions import UnknownDBFunctionID
+from http.client import CannotSendRequest
+
+from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+
+
+@handle_rpc_exceptions
+def fake_func(exception):
+    raise exception
+
+
+@pytest.mark.parametrize(
+    "example_err,expect_code", [
+        (AssertionError, -31002),
+        (BadCopyFileFormat, -30009),
+        (FieldDoesNotExist, -29030),
+        (BadInstallationTarget, -28002),
+        (UnknownDBFunctionID, -27024),
+        (CannotSendRequest, -25031),
+    ]
+)
+def test_handle_rpc_exceptions(example_err, expect_code):
+    """
+    Tests whether a function wrapped by `handle_rpc_exceptions` always raises a `RPCException`
+    for any given exception raised inside the function.
+    """
+    with pytest.raises(RPCException) as rpc_exception:
+        fake_func(example_err)
+    assert hasattr(fake_func, '__wrapped__')
+    assert example_err.__name__ in rpc_exception.value.args[0]
+    assert str(expect_code) in rpc_exception.value.args[0]


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #3524

<!-- Concisely describe what the pull request does. -->

This adds tests for the error handling decorator `handle_rpc_exceptions`, and verifies a function wrapped always raises a `RPCException`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
