### PR TITLE
Add GH workflow to reset demo

### DIFF
--- a/.github/workflows/reset-demo.yml
+++ b/.github/workflows/reset-demo.yml
@@ -1,0 +1,51 @@
+name: Reset demo
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: '1,10,30,55 6 * * *'
+
+
+env:
+  PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
+  GKE_CLUSTER: mathesar-demo
+  GKE_ZONE: us-central1
+
+
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: GCP login
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GKE_DEMO_RESET_SA_KEY }}'
+
+      - name: Set up GKE credentials
+        uses: 'google-github-actions/get-gke-credentials@v0'
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_ZONE }}
+
+      - name: Delete existing demo deployment
+        run: kubectl delete deployments.apps demo-serve
+
+      - name: Wait until all pods are removed
+        run: >-
+          attempts=10
+          until [ $attempts -le 0 ] || [ -z "$(kubectl get pods)" ]; do
+            sleep 5
+            attempts=$((attempts - 1))
+          done
+          if [ $attempts -le 0 ]; then
+            return 1
+          fi
+
+      - name: Deploy demo
+        run: kubectl apply -f ./kubernetes_manifests/mathesar-demo.yml

--- a/.github/workflows/reset-demo.yml
+++ b/.github/workflows/reset-demo.yml
@@ -6,7 +6,7 @@ on:
       - master
   workflow_dispatch:
   schedule:
-    - cron: '1,10,30,55 6 * * *'
+    - cron: '1,9,17,30,45 6,7,8 * * *'
 
 
 env:


### PR DESCRIPTION
This PR adds a workflow that runs a cron job to reset the demo k8s deployment.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
