### PR TITLE
fix(clipboard): Handle negative numbers in TSV serialization for copy

### DIFF
--- a/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
+++ b/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
@@ -62,7 +62,7 @@ function getFormattedCellValue<
 function serializeTsv(data: string[][]): string {
   return Papa.unparse(data, {
     delimiter: '\t',
-    escapeFormulae: /^=|^\+|^@|^\t|^\r/,
+    escapeFormulae: /^=|^\+|^@|^\t|^\r|^-(?!\d+(\.\d+)?$)/,
   });
 }
 

--- a/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
+++ b/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
@@ -62,6 +62,18 @@ function getFormattedCellValue<
 function serializeTsv(data: string[][]): string {
   return Papa.unparse(data, {
     delimiter: '\t',
+    // From the [Papa Parse][1] library, `escapeFormulae` helps defend against
+    // formula [injection attacks][2]. We modify the default value though
+    // because it [didn't work][3] for negative numbers. We're supplying our own
+    // regex that uses the default behavior plus special handling for negative
+    // numbers. It doesn't escape negative numbers because they are valid. But
+    // it does escape anything else that begins with a hyphen.
+    //
+    // [1]: https://www.papaparse.com/docs
+    //
+    // [2]: https://owasp.org/www-community/attacks/CSV_Injection
+    //
+    // [3]: https://github.com/mathesar-foundation/mathesar/issues/3576
     escapeFormulae: /^=|^\+|^@|^\t|^\r|^-(?!\d+(\.\d+)?$)/,
   });
 }

--- a/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
+++ b/mathesar_ui/src/components/sheet/SheetClipboardHandler.ts
@@ -62,7 +62,7 @@ function getFormattedCellValue<
 function serializeTsv(data: string[][]): string {
   return Papa.unparse(data, {
     delimiter: '\t',
-    escapeFormulae: true,
+    escapeFormulae: /^=|^\+|^@|^\t|^\r/,
   });
 }
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3576 

<!-- Concisely describe what the pull request does. -->

The escapeFormulae option in papaparse was causing negative numbers to be incorrectly serialized with a leading single quote (e.g., "'-5" instead of -5) when copying data from the table. This commit modifies the escapeFormulae option to use a regular expression that excludes negative numbers from being escaped.

See `escapeFormula` here. https://www.papaparse.com/docs

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
