### PR TITLE
Remove dead front end API client code to GET one schema

### DIFF
--- a/mathesar_ui/src/api/rest/schemas.ts
+++ b/mathesar_ui/src/api/rest/schemas.ts
@@ -15,10 +15,6 @@ function list(connectionId: Connection['id']) {
   );
 }
 
-function get(schemaId: SchemaEntry['id']) {
-  return getAPI<SchemaResponse>(`/api/db/v0/schemas/${schemaId}/`);
-}
-
 function add(props: {
   name: SchemaEntry['name'];
   description: SchemaEntry['description'];
@@ -48,7 +44,6 @@ function deleteSchema(schemaId: SchemaEntry['id']) {
 
 export default {
   list,
-  get,
   add,
   update,
   delete: deleteSchema,

--- a/mathesar_ui/src/stores/schemas.ts
+++ b/mathesar_ui/src/stores/schemas.ts
@@ -175,29 +175,6 @@ async function refetchSchemasForDB(
   }
 }
 
-export async function refetchSchema(
-  connectionId: Connection['id'],
-  schemaId: SchemaEntry['id'],
-): Promise<SchemaResponse | undefined> {
-  const store = dbSchemaStoreMap.get(connectionId);
-  if (!store) {
-    console.error(`DB Schemas store for db: ${connectionId} not found.`);
-    return undefined;
-  }
-
-  try {
-    const schemaRequest = schemasApi.get(schemaId);
-    const response = await schemaRequest;
-    if (!response) {
-      return undefined;
-    }
-    updateSchemaInDBSchemaStore(connectionId, response);
-    return response;
-  } catch (err) {
-    return undefined;
-  }
-}
-
 let preload = true;
 
 function getSchemasStoreForDB(


### PR DESCRIPTION
I found this dead code, so I'm removing it myself without review. This helps us better organize our RPC API transition because it's clearer what code usage we have for our REST endpoints. We're not implementing any RPC functions for unused REST endpoints / HTTP methods. Removing this dead frontend code makes it clearer that we don't need to implement a `schemas.get` RPC function.

@pavish heads up about this. You might wish to take a quick glance.

[Wiki edit](https://github.com/mathesar-foundation/mathesar-wiki/commit/6440455c47f1e2e1c0dd9290dd642a1ebd1be387) which removes this entry from our to-do list.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


