### PR TITLE
Refactor list of RPC methods to test

### DIFF
--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -12,10 +12,22 @@ from mathesar.rpc import columns
 from mathesar.rpc import connections
 
 
-exposed_functions = [
-    "columns.list",
-    "connections.add_from_known_connection",
-    "connections.add_from_scratch",
+METHODS = [
+    (
+        columns.list_,
+        "columns.list",
+        [user_is_authenticated]
+    ),
+    (
+        connections.add_from_known_connection,
+        "connections.add_from_known_connection",
+        [user_is_superuser]
+    ),
+    (
+        connections.add_from_scratch,
+        "connections.add_from_scratch",
+        [user_is_superuser]
+    )
 ]
 
 
@@ -31,34 +43,10 @@ def test_rpc_endpoint_expected_methods(live_server, admin_client):
         content_type="application/json"
     ).json()["result"]
     mathesar_methods = [m for m in all_methods if not m.startswith("system.")]
-    expect_methods = [
-        "columns.list",
-        "connections.add_from_known_connection",
-        "connections.add_from_scratch",
-    ]
-    assert sorted(mathesar_methods) == expect_methods
+    assert sorted(mathesar_methods) == sorted(m[1] for m in METHODS)
 
 
-@pytest.mark.parametrize(
-    "func,exposed_name,auth_pred_params",
-    [
-        (
-            columns.list_,
-            "columns.list",
-            [user_is_authenticated]
-        ),
-        (
-            connections.add_from_known_connection,
-            "connections.add_from_known_connection",
-            [user_is_superuser]
-        ),
-        (
-            connections.add_from_scratch,
-            "connections.add_from_scratch",
-            [user_is_superuser]
-        )
-    ]
-)
+@pytest.mark.parametrize("func,exposed_name,auth_pred_params", METHODS)
 def test_correctly_exposed(func, exposed_name, auth_pred_params):
     """Tests to make sure every RPC function is correctly wired up."""
     # Make sure we didn't typo the function names for the endpoint.


### PR DESCRIPTION
This PR cleans up the code in test_endpoints.py so that it's easier to add new RPC methods to that file.

This is its own PR because:

1. It would be nice to get this merged soon so that we can all work on top of it.
1. I ran into some weird test failures that I want help troubleshooting in isolation.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

