### PR TITLE
Implement `schemas.add` RPC method

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ from db.engine import add_custom_types_to_ischema_names, create_engine as sa_cre
 from db.types import install
 from db.sql import install as sql_install
 from db.schemas.operations.drop import drop_schema_via_name as drop_sa_schema
-from db.schemas.operations.create import create_schema as create_sa_schema
+from db.schemas.operations.create import create_schema_if_not_exists_via_sql_alchemy
 from db.schemas.utils import get_schema_oid_from_name, get_schema_name_from_oid
 
 from fixtures.utils import create_scoped_fixtures
@@ -210,7 +210,7 @@ def create_db_schema(SES_engine_cache):
         if schema_mustnt_exist:
             assert schema_name not in created_schemas
         logger.debug(f'creating {schema_name}')
-        create_sa_schema(schema_name, engine, if_not_exists=True)
+        create_schema_if_not_exists_via_sql_alchemy(schema_name, engine)
         schema_oid = get_schema_oid_from_name(schema_name, engine)
         db_name = engine.url.database
         created_schemas_in_this_engine = created_schemas.setdefault(db_name, {})

--- a/db/schemas/operations/alter.py
+++ b/db/schemas/operations/alter.py
@@ -27,10 +27,8 @@ def comment_on_schema(schema_name, engine, comment):
     Change description of a schema.
 
     Args:
-        schema_name: The name of the schema whose comment we will
-                     change.
-        comment: The new comment. Any quotes or special characters must
-                 be escaped.
+        schema_name: The name of the schema whose comment we will change.
+        comment: The new comment.
         engine: SQLAlchemy engine object for connecting.
 
     Returns:

--- a/db/schemas/operations/create.py
+++ b/db/schemas/operations/create.py
@@ -1,26 +1,53 @@
-from db.schemas.operations.alter import comment_on_schema
-from db.connection import execute_msar_func_with_engine
+from db.connection import execute_msar_func_with_engine, exec_msar_func
 
 
-def create_schema(schema_name, engine, comment=None, if_not_exists=False):
+def create_schema_via_sql_alchemy(schema_name, engine, description=None):
     """
-    Creates a schema.
+    Creates a schema using a SQLAlchemy engine.
 
     Args:
         schema_name: Name of the schema to create.
         engine: SQLAlchemy engine object for connecting.
-        comment: The new comment. Any quotes or special characters must
-                 be escaped.
-        if_not_exists: Whether to ignore an error if the schema does
-                       exist.
+        description: A new description to set on the schema.
+
+    If a schema already exists with the given name, this function will raise an error.
 
     Returns:
-        Returns a string giving the command that was run.
+        The integer oid of the newly created schema.
     """
-    result = execute_msar_func_with_engine(
-        engine, 'create_schema', schema_name, if_not_exists
+    return execute_msar_func_with_engine(
+        engine, 'create_schema', schema_name, description
     ).fetchone()[0]
 
-    if comment:
-        comment_on_schema(schema_name, engine, comment)
-    return result
+
+def create_schema_if_not_exists_via_sql_alchemy(schema_name, engine):
+    """
+    Ensure that a schema exists using a SQLAlchemy engine.
+
+    Args:
+        schema_name: Name of the schema to create.
+        engine: SQLAlchemy engine object for connecting.
+
+    Returns:
+        The integer oid of the newly created schema.
+    """
+    return execute_msar_func_with_engine(
+        engine, 'create_schema_if_not_exists', schema_name
+    ).fetchone()[0]
+
+
+def create_schema(schema_name, conn, description=None):
+    """
+    Create a schema using a psycopg connection.
+
+    Args:
+        schema_name: Name of the schema to create.
+        conn: a psycopg connection
+        description: A new description to set on the schema.
+
+    If a schema already exists with the given name, this function will raise an error.
+
+    Returns:
+        The integer oid of the newly created schema.
+    """
+    return exec_msar_func(conn, 'create_schema', schema_name, description).fetchone()[0]

--- a/db/tables/operations/infer_types.py
+++ b/db/tables/operations/infer_types.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from db import constants
 from db.columns.base import MathesarColumn
 from db.columns.operations.infer_types import infer_column_type
-from db.schemas.operations.create import create_schema
+from db.schemas.operations.create import create_schema_if_not_exists_via_sql_alchemy
 from db.tables.operations.create import CreateTableAs
 from db.tables.operations.select import reflect_table
 from db.types.operations.convert import get_db_type_enum_from_class
@@ -43,7 +43,7 @@ def infer_table_column_types(schema, table_name, engine, metadata=None, columns_
     table = reflect_table(table_name, schema, engine, metadata=metadata)
 
     temp_name = TEMP_TABLE % (int(time()))
-    create_schema(TEMP_SCHEMA, engine, if_not_exists=True)
+    create_schema_if_not_exists_via_sql_alchemy(TEMP_SCHEMA, engine)
     with engine.begin() as conn:
         while engine.dialect.has_table(conn, temp_name, schema=TEMP_SCHEMA):
             temp_name = TEMP_TABLE.format(int(time()))

--- a/db/tests/schemas/operations/test_create.py
+++ b/db/tests/schemas/operations/test_create.py
@@ -1,16 +1,16 @@
 from unittest.mock import patch
-from db.schemas.operations.create import create_schema_via_sql_alchemy
+import db.schemas.operations.create as sch_create
 
 
 def test_create_schema_via_sql_alchemy(engine_with_schema):
     engine = engine_with_schema
-    with patch.object(create_schema_via_sql_alchemy, 'execute_msar_func_with_engine') as mock_exec:
-        create_schema_via_sql_alchemy(
+    with patch.object(sch_create, 'execute_msar_func_with_engine') as mock_exec:
+        sch_create.create_schema_via_sql_alchemy(
             schema_name='new_schema',
             engine=engine,
-            comment=None,
+            description=None,
         )
     call_args = mock_exec.call_args_list[0][0]
     assert call_args[0] == engine
-    assert call_args[1] == "create_schema_via_sql_alchemy"
+    assert call_args[1] == "create_schema"
     assert call_args[2] == "new_schema"

--- a/db/tests/schemas/operations/test_create.py
+++ b/db/tests/schemas/operations/test_create.py
@@ -1,22 +1,16 @@
-import pytest
 from unittest.mock import patch
-import db.schemas.operations.create as sch_create
+from db.schemas.operations.create import create_schema_via_sql_alchemy
 
 
-@pytest.mark.parametrize(
-    "if_not_exists", [(True), (False), (None)]
-)
-def test_create_schema(engine_with_schema, if_not_exists):
+def test_create_schema_via_sql_alchemy(engine_with_schema):
     engine = engine_with_schema
-    with patch.object(sch_create, 'execute_msar_func_with_engine') as mock_exec:
-        sch_create.create_schema(
+    with patch.object(create_schema_via_sql_alchemy, 'execute_msar_func_with_engine') as mock_exec:
+        create_schema_via_sql_alchemy(
             schema_name='new_schema',
             engine=engine,
             comment=None,
-            if_not_exists=if_not_exists
         )
     call_args = mock_exec.call_args_list[0][0]
     assert call_args[0] == engine
-    assert call_args[1] == "create_schema"
+    assert call_args[1] == "create_schema_via_sql_alchemy"
     assert call_args[2] == "new_schema"
-    assert call_args[3] == if_not_exists or False

--- a/db/types/install.py
+++ b/db/types/install.py
@@ -1,12 +1,12 @@
 from db.types.custom import email, money, multicurrency, uri, json_array, json_object
 from db.constants import TYPES_SCHEMA
-from db.schemas.operations.create import create_schema
+from db.schemas.operations.create import create_schema_if_not_exists_via_sql_alchemy
 from db.types.operations.cast import install_all_casts
 import psycopg
 
 
-def create_type_schema(engine):
-    create_schema(TYPES_SCHEMA, engine, if_not_exists=True)
+def create_type_schema(engine) -> None:
+    create_schema_if_not_exists_via_sql_alchemy(TYPES_SCHEMA, engine)
 
 
 def install_mathesar_on_database(engine):
@@ -24,4 +24,6 @@ def install_mathesar_on_database(engine):
 def uninstall_mathesar_from_database(engine):
     conn_str = str(engine.url)
     with psycopg.connect(conn_str) as conn:
+        # TODO: Clean up this code so that it references all the schemas in our
+        # `INTERNAL_SCHEMAS` constant.
         conn.execute(f"DROP SCHEMA IF EXISTS __msar, msar, {TYPES_SCHEMA} CASCADE")

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -52,6 +52,7 @@ To use an RPC function:
     options:
       members:
       - list_
+      - add
       - delete
       - SchemaInfo
 

--- a/mathesar/tests/imports/test_csv.py
+++ b/mathesar/tests/imports/test_csv.py
@@ -7,7 +7,7 @@ from mathesar.models.base import DataFile, Schema
 from mathesar.errors import InvalidTableError
 from mathesar.imports.base import create_table_from_data_file
 from mathesar.imports.csv import get_sv_dialect, get_sv_reader
-from db.schemas.operations.create import create_schema
+from db.schemas.operations.create import create_schema_via_sql_alchemy
 from db.schemas.utils import get_schema_oid_from_name
 from db.constants import COLUMN_NAME_TEMPLATE
 from psycopg.errors import DuplicateTable
@@ -45,7 +45,7 @@ def col_headers_empty_data_file(col_headers_empty_csv_filepath):
 
 @pytest.fixture()
 def schema(engine, test_db_model):
-    create_schema(TEST_SCHEMA, engine)
+    create_schema_via_sql_alchemy(TEST_SCHEMA, engine)
     schema_oid = get_schema_oid_from_name(TEST_SCHEMA, engine)
     yield Schema.current_objects.create(oid=schema_oid, database=test_db_model)
     with engine.begin() as conn:

--- a/mathesar/tests/imports/test_json.py
+++ b/mathesar/tests/imports/test_json.py
@@ -5,7 +5,7 @@ from sqlalchemy import text
 
 from mathesar.models.base import DataFile, Schema
 from mathesar.imports.base import create_table_from_data_file
-from db.schemas.operations.create import create_schema
+from db.schemas.operations.create import create_schema_via_sql_alchemy
 from db.schemas.utils import get_schema_oid_from_name
 from psycopg.errors import DuplicateTable
 
@@ -21,7 +21,7 @@ def data_file(patents_json_filepath):
 
 @pytest.fixture()
 def schema(engine, test_db_model):
-    create_schema(TEST_SCHEMA, engine)
+    create_schema_via_sql_alchemy(TEST_SCHEMA, engine)
     schema_oid = get_schema_oid_from_name(TEST_SCHEMA, engine)
     yield Schema.current_objects.create(oid=schema_oid, database=test_db_model)
     with engine.begin() as conn:

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -40,6 +40,11 @@ METHODS = [
         [user_is_superuser]
     ),
     (
+        schemas.add,
+        "schemas.add",
+        [user_is_authenticated]
+    ),
+    (
         schemas.list_,
         "schemas.list",
         [user_is_authenticated]

--- a/mathesar/utils/schemas.py
+++ b/mathesar/utils/schemas.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
 
-from db.schemas.operations.create import create_schema
+from db.schemas.operations.create import create_schema_via_sql_alchemy
 from db.schemas.utils import get_schema_oid_from_name, get_mathesar_schemas
 from mathesar.database.base import create_mathesar_engine
 from mathesar.models.base import Schema, Database
@@ -19,7 +19,7 @@ def create_schema_and_object(name, connection_id, comment=None):
     all_schemas = get_mathesar_schemas(engine)
     if name in all_schemas:
         raise ValidationError({"name": f"Schema name {name} is not unique"})
-    create_schema(name, engine, comment=comment)
+    create_schema_via_sql_alchemy(name, engine, comment)
     schema_oid = get_schema_oid_from_name(name, engine)
 
     schema = Schema.objects.create(oid=schema_oid, database=database_model)


### PR DESCRIPTION
Fixes  #3619

## Notes

I went around in circles a bit with this PR, which is why it took a while. I'll describe my thought process chronologically in hopes that it might be useful as these same problems could potentially apply to other DB objects as well...

1. First I proceeded to remove the `if_not_exists` parameter from `msar.create_schema` because I didn't want the additional complexity in there. I wanted to default to _not_ using `IF NOT EXISTS` for the sake of simplicity. This is in line with comments in [this meeting](https://tldv.io/app/meetings/665897c0678bae00133db210?transcript=true&video=true) (starting at 21:10) on which @mathemancer and @Anish9901 were supportive. I wanted to raise an exception if the supplied schema name already existed.

1. But then I noticed that our codebase actually made use of that `if_not_exists` parameter in a few places for internal schemas and creating ephemeral schemas on the fly for type inference. Ugh!

1. My initial instinct was to modify the IF NOT EXISTS code locations by resorting to calling raw SQL from within the service layer (instead of calling functions). I had a tricky time figuring out how to do that cleanly with SQLAlchemy. I imagine it's possible, but it didn't seem to fit our patterns, and I didn't want to fiddle with it too much.

1. After some hemming and hawing, I decided to retain support for `if_not_exists`, in `msar.create_schema` while also adding support for setting descriptions on schemas within the same function. This choice sent me down a rabbit hole, making me wish I had trusted my early intuition on `if_not_exists` more strongly.

1. The `msar.create_schema` function got more and more complex as I discovered more edge cases and inconsistencies. If it can return an existing schema, then we need to make sure that `NULL` description values don't overwrite existing description. Ok fine. Then for the front end's sake, we should actually be fetching and returning the description. Ok. But that means the return value gets much more complex. It should be an object instead of a simple oid. And if it's an object, it ought to match the structure of the objects returned from `msar.get_schemas`, meaning it should supply a `table_count` property too. Ugh. So I started modifying `msar.get_schemas` to accept a `sch_oid` filter parameter which would allow me to compose that function to reliably get the full schema details in a consistent manner. But then I just threw up my hands and said, "this is ridiculous!"

1. So I decided to split the function into two:

    - `msar.create_schema_if_not_exists(sch_name text)`

      and

    - `msar.create_schema(sch_name text, description text DEFAULT '')`

    This means you can use `IF NOT EXISTS` _OR_ you can supply a description — but you can't do both at the same time. And at the API layer there's no way to use `IF NOT EXISTS`.

    This approach has some limitations. But compared to cramming all that logic in one function, it's much simpler and less prone to weird edge cases and bugs.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


