### PR TITLE
Wire RPC functions to new models

### DIFF
--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -44,6 +44,7 @@ To use an RPC function:
       members:
       - add_from_known_connection
       - add_from_scratch
+      - grant_access_to_user
       - DBModelReturn
 
 ---

--- a/mathesar/migrations/0007_users_permissions_remodel.py
+++ b/mathesar/migrations/0007_users_permissions_remodel.py
@@ -79,6 +79,10 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='role',
+            constraint=models.UniqueConstraint(fields=('name', 'server'), name='unique_role'),
+        ),
+        migrations.AddConstraint(
+            model_name='role',
             constraint=models.UniqueConstraint(fields=('id', 'server'), name='role_id_server_index'),
         ),
         migrations.CreateModel(

--- a/mathesar/migrations/0007_users_permissions_remodel.py
+++ b/mathesar/migrations/0007_users_permissions_remodel.py
@@ -45,6 +45,10 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
         ),
+        migrations.AddConstraint(
+            model_name='server',
+            constraint=models.UniqueConstraint(fields=('host', 'port'), name='unique_server'),
+        ),
         migrations.CreateModel(
             name='Database',
             fields=[

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -15,6 +15,13 @@ class Server(BaseModel):
     host = models.CharField(max_length=255)
     port = models.IntegerField()
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["host", "port"], name="unique_server"
+            ),
+        ]
+
 
 class Database(BaseModel):
     name = models.CharField(max_length=128)

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -1,5 +1,6 @@
 from django.db import models
 from encrypted_fields.fields import EncryptedCharField
+import psycopg
 
 
 class BaseModel(models.Model):
@@ -42,6 +43,9 @@ class Role(BaseModel):
     class Meta:
         constraints = [
             models.UniqueConstraint(
+                fields=["name", "server"], name="unique_role"
+            ),
+            models.UniqueConstraint(
                 fields=["id", "server"], name="role_id_server_index"
             )
         ]
@@ -59,3 +63,14 @@ class UserDatabaseRoleMap(BaseModel):
                 fields=["user", "database"], name="user_one_role_per_database"
             )
         ]
+
+
+    @property
+    def connection(self):
+        return psycopg.connect(
+            host=self.server.host,
+            port=self.server.port,
+            dbname=self.database.name,
+            user=self.role.name,
+            password=self.role.password,
+        )

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -64,7 +64,6 @@ class UserDatabaseRoleMap(BaseModel):
             )
         ]
 
-
     @property
     def connection(self):
         return psycopg.connect(

--- a/mathesar/rpc/connections.py
+++ b/mathesar/rpc/connections.py
@@ -132,7 +132,7 @@ def add_from_scratch(
 @handle_rpc_exceptions
 def grant_access_to_user(*, connection_id: int, user_id: int):
     """
-    Migrate a connection to new models, grant access for a user.
+    Migrate a connection to new models and grant access to a user.
 
     This function is designed to be temporary, and should probably be
     removed once we have completed the new users and permissions setup

--- a/mathesar/rpc/connections.py
+++ b/mathesar/rpc/connections.py
@@ -6,7 +6,7 @@ from typing import TypedDict
 from modernrpc.core import rpc_method
 from modernrpc.auth.basic import http_basic_auth_superuser_required
 
-from mathesar.utils import connections
+from mathesar.utils import connections, permissions
 from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 
 
@@ -125,3 +125,22 @@ def add_from_scratch(
         user, password, host, port, nickname, database, sample_data
     )
     return DBModelReturn.from_db_model(db_model)
+
+
+@rpc_method(name='connections.grant_access_to_user')
+@http_basic_auth_superuser_required
+@handle_rpc_exceptions
+def grant_access_to_user(*, connection_id: int, user_id: int):
+    """
+    Migrate a connection to new models, grant access for a user.
+
+    This function is designed to be temporary, and should probably be
+    removed once we have completed the new users and permissions setup
+    for beta. You pass any conneciton id and user id. The function will
+    fill the required models as needed.
+
+    Args:
+        connection_id: The Django id of an old-style connection.
+        user_id: The Django id of a user.
+    """
+    permissions.create_user_database_role_map(connection_id, user_id)

--- a/mathesar/rpc/utils.py
+++ b/mathesar/rpc/utils.py
@@ -1,14 +1,14 @@
-from mathesar.database.base import get_psycopg_connection
-from mathesar.models.deprecated import Connection
+from mathesar.models.base import UserDatabaseRoleMap
 
 
-def connect(conn_id, user):
+def connect(database_id, user):
     """
     Return a psycopg connection, given a Connection model id.
 
     Args:
         conn_id: The Django id corresponding to the Connection.
     """
-    print("User is: ", user)
-    conn_model = Connection.current_objects.get(id=conn_id)
-    return get_psycopg_connection(conn_model)
+    user_database_role = UserDatabaseRoleMap.objects.get(
+        user=user, database__id=database_id
+    )
+    return user_database_role.connection

--- a/mathesar/rpc/utils.py
+++ b/mathesar/rpc/utils.py
@@ -3,10 +3,11 @@ from mathesar.models.base import UserDatabaseRoleMap
 
 def connect(database_id, user):
     """
-    Return a psycopg connection, given a Connection model id.
+    Get a psycopg database connection.
 
     Args:
-        conn_id: The Django id corresponding to the Connection.
+        database_id: The Django id of the Database used for connecting.
+        user: A user model instance who'll connect to the database.
     """
     user_database_role = UserDatabaseRoleMap.objects.get(
         user=user, database__id=database_id

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -45,6 +45,11 @@ METHODS = [
         [user_is_superuser]
     ),
     (
+        connections.grant_access_to_user,
+        "connections.grant_access_to_user",
+        [user_is_superuser]
+    ),
+    (
         schemas.add,
         "schemas.add",
         [user_is_authenticated]

--- a/mathesar/utils/permissions.py
+++ b/mathesar/utils/permissions.py
@@ -1,0 +1,20 @@
+from mathesar.models.base import Server, Database, Role, UserDatabaseRoleMap
+from mathesar.models.deprecated import Connection
+from mathesar.models.users import User
+
+
+def create_user_database_role_map(connection_id, user_id):
+    """Move data from old-style connection model to new models."""
+    conn = Connection.current_objects.get(id=connection_id)
+
+    server = Server.objects.get_or_create(host=conn.host, port=conn.port)[0]
+    database = Database.objects.get_or_create(name=conn.db_name, server=server)[0]
+    role = Role.objects.get_or_create(
+        name=conn.username, server=server, password=conn.password
+    )[0]
+    return UserDatabaseRoleMap.objects.create(
+        user=User.objects.get(id=user_id),
+        database=database,
+        role=role,
+        server=server
+    )


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3631 

<!-- Concisely describe what the pull request does. -->

This is a small PR that changes the connection logic for RPC functions to use the new models. It also adds a (maybe temporary) RPC function to easily migrate a deprecated `Connection` to the new setup, and give an identified user access to the associated map entry.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Merging this PR will require developers to run the migration function in order to test the other RPC functions, since it replaces the connection "always allowed" logic with something more robust.

I think we should merge it in case someone somewhere is using our develop branch for something with sensitive data.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [X] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
