### PR TITLE
Allow unsetting schema comment using NULL

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -865,8 +865,7 @@ CREATE OR REPLACE FUNCTION msar.set_schema_description(
 ) RETURNS void AS $$/*
 Set the PostgreSQL description (aka COMMENT) of a schema.
 
-Descriptions are removed by passing an empty string. Passing a NULL description will cause
-this function to return NULL without doing anything.
+Descriptions are removed by passing an empty string or NULL.
 
 Args:
   sch_id: The OID of the schema.
@@ -875,7 +874,7 @@ Args:
 BEGIN
   EXECUTE format('COMMENT ON SCHEMA %I IS %L', msar.get_schema_name(sch_id), description);
 END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION msar.patch_schema(sch_id oid, patch jsonb) RETURNS void AS $$/*

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -885,11 +885,12 @@ Args:
   patch: A JSONB object with the following keys:
     - name: (optional) The new name of the schema
     - description: (optional) The new description of the schema. To remove a description, pass an
-      empty string. Passing a NULL description will have no effect on the description.
+      empty string or NULL.
 */
 BEGIN
   PERFORM msar.rename_schema(sch_id, patch->>'name');
-  PERFORM msar.set_schema_description(sch_id, patch->>'description');
+  PERFORM CASE WHEN patch ? 'description'
+  THEN msar.set_schema_description(sch_id, patch->>'description') END;
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
@@ -1136,14 +1137,13 @@ Args:
 */
 DECLARE
   new_tab_name text;
-  comment text;
   col_alters jsonb;
 BEGIN
   new_tab_name := tab_alters->>'name';
-  comment := tab_alters->>'description';
   col_alters := tab_alters->'columns';
   PERFORM msar.rename_table(tab_id, new_tab_name);
-  PERFORM msar.comment_on_table(tab_id, comment);
+  PERFORM CASE WHEN tab_alters ? 'description'
+  THEN msar.comment_on_table(tab_id, tab_alters->>'description') END;
   PERFORM msar.alter_columns(tab_id, col_alters);
   RETURN __msar.get_qualified_relation_name_or_null(tab_id);
 END;

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -1325,10 +1325,9 @@ BEGIN
   PERFORM msar.patch_schema(sch_oid, '{"description": "yay"}');
   RETURN NEXT is(obj_description(sch_oid), 'yay');
 
-  -- Edge case: setting the description to null doesn't actually remove it. This behavior is
-  -- debatable. I did it this way because it was easier to implement.
+  -- Description is removed when NULL is passed.
   PERFORM msar.patch_schema(sch_oid, '{"description": null}');
-  RETURN NEXT is(obj_description(sch_oid), 'yay');
+  RETURN NEXT is(obj_description(sch_oid), NULL);
 
   -- Description is removed when an empty string is passed.
   PERFORM msar.patch_schema(sch_oid, '{"description": ""}');


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3638

<!-- Concisely describe what the pull request does. -->
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
