### PR TITLE
Cast OIDs to bigint before putting in json

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -716,9 +716,9 @@ Args:
   tab_id: The OID or name of the table.
 */
 SELECT jsonb_build_object(
-  'oid', oid,
+  'oid', oid::bigint,
   'name', relname,
-  'schema', relnamespace,
+  'schema', relnamespace::bigint,
   'description', msar.obj_description(oid, 'pg_class')
 ) FROM pg_catalog.pg_class WHERE oid = tab_id;
 $$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
@@ -740,9 +740,9 @@ Args:
 */
 SELECT jsonb_agg(
   jsonb_build_object(
-    'oid', pgc.oid,
+    'oid', pgc.oid::bigint,
     'name', pgc.relname,
-    'schema', pgc.relnamespace,
+    'schema', pgc.relnamespace::bigint,
     'description', msar.obj_description(pgc.oid, 'pg_class')
   )
 )
@@ -772,7 +772,7 @@ Each returned JSON object in the array will have the form:
 SELECT jsonb_agg(schema_data)
 FROM (
   SELECT 
-    s.oid AS oid,
+    s.oid::bigint AS oid,
     s.nspname AS name,
     pg_catalog.obj_description(s.oid) AS description,
     COALESCE(count(c.oid), 0) AS table_count
@@ -2120,7 +2120,7 @@ SELECT jsonb_agg(
     'type', contype,
     'columns', ARRAY[attname],
     'deferrable', condeferrable,
-    'fkey_relation_id', confrelid::integer,
+    'fkey_relation_id', confrelid::bigint,
     'fkey_columns', confkey,
     'fkey_update_action', confupdtype,
     'fkey_delete_action', confdeltype,


### PR DESCRIPTION
## This PR:

- adjusts some SQL code to cast OID values to `bigint` before putting them in JSON
- clarifies the code standard related to casting OIDs, making it clear that OIDs must _always_ be cast

## Why

Say you run...

```sql
SELECT msar.get_schemas();
```

- Before this PR, you'd get:

    ```json5
    [
      {
        "oid": "2200",
        //     ^^^^^^ ⚠️ STRINGIFIED OID ⚠️
        "name": "public",
        "description": "standard public schema",
        "table_count": 2
      },
      // ...
    ]
    ```

    This can cause bugs, as I describe in the code standard.

    For example in #3648 @pavish [described](https://github.com/mathesar-foundation/mathesar/pull/3648#pullrequestreview-2163203218) a bug where API requests to modify a schema were not successfully modifying the schema because the DB layer was looking up the schema by _name_ instead of by OID (since the OID the client sent was the OID the client had — a _stringified_ OID).

- After this PR, you'll get:

    ```json5
    [
      {
        "oid": 2200,
        //     ^^^^ 👍 numeric OID
        "name": "public",
        "description": "standard public schema",
        "table_count": 2
      },
      // ...
    ]
    ```

I also made the change for `msar.get_table` and `msar.get_table_info`.

As best I can tell, no other code currently in develop needs this treatment. 



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

