### PR TITLE
Fix return type error when re-defining `get_constraints_for_table` SQL function

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -517,6 +517,7 @@ END;
 $$ LANGUAGE SQL;
 
 
+DROP FUNCTION IF EXISTS msar.get_constraints_for_table(oid);
 CREATE OR REPLACE FUNCTION msar.get_constraints_for_table(tab_id oid) RETURNS TABLE
 (
   oid oid,


### PR DESCRIPTION
The `msar.get_constraints_for_table` SQL function had previously been defined with a different return type. That meant that restarting the service layer would give:

```
------------Setting up User Databases------------
Installing Mathesar on preexisting PostgreSQL database mathesar at host mathesar_dev_db...
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/code/mathesar/install.py", line 61, in <module>
    main()
  File "/code/mathesar/install.py", line 37, in main
    install_on_db_with_key(database_key, skip_confirm)
  File "/code/mathesar/install.py", line 46, in install_on_db_with_key
    install.install_mathesar(
  File "/code/db/install.py", line 31, in install_mathesar
    sql_install.install(user_db_engine)
  File "/code/db/sql/install.py", line 13, in install
    load_file_with_engine(engine, file_handle)
  File "/code/db/connection.py", line 79, in load_file_with_engine
    conn.execute(file_handle.read())
  File "/usr/local/lib/python3.9/site-packages/psycopg/connection.py", line 891, in execute
    raise ex.with_traceback(None)
psycopg.errors.InvalidFunctionDefinition: cannot change return type of existing function
DETAIL:  Row type defined by OUT parameters is different.
HINT:  Use DROP FUNCTION msar.get_constraints_for_table(oid) first.
```


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

