### PR TITLE
Fix issues with `tables.patch` RPC method

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1181,6 +1181,10 @@ Args:
   new_tab_name: unquoted, unqualified new table name
 */
 BEGIN
+  IF old_tab_name = new_tab_name THEN
+    -- Return early if the names are the same. This avoids an error from Postgres.
+    RETURN;
+  END IF;
   EXECUTE format('ALTER TABLE %I.%I RENAME TO %I', sch_name, old_tab_name, new_tab_name);
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1170,41 +1170,9 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- Rename table ------------------------------------------------------------------------------------
 
+DROP FUNCTION IF EXISTS msar.rename_table(text, text, text);
 CREATE OR REPLACE FUNCTION
-__msar.rename_table(old_tab_name text, new_tab_name text) RETURNS text AS $$/*
-Change a table's name, returning the command executed.
-
-Args:
-  old_tab_name: properly quoted, qualified table name
-  new_tab_name: properly quoted, unqualified table name
-*/
-BEGIN
-  RETURN __msar.exec_ddl(
-    'ALTER TABLE %s RENAME TO %s', old_tab_name, new_tab_name
-  );
-END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-
-CREATE OR REPLACE FUNCTION
-msar.rename_table(tab_id oid, new_tab_name text) RETURNS text AS $$/*
-Change a table's name, returning the command executed.
-
-Args:
-  tab_id: the OID of the table whose name we want to change
-  new_tab_name: unquoted, unqualified table name
-*/
-BEGIN
-  RETURN __msar.rename_table(
-    __msar.get_qualified_relation_name_or_null(tab_id),
-    quote_ident(new_tab_name)
-  );
-END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-
-CREATE OR REPLACE FUNCTION
-msar.rename_table(sch_name text, old_tab_name text, new_tab_name text) RETURNS text AS $$/*
+msar.rename_table(sch_name text, old_tab_name text, new_tab_name text) RETURNS void AS $$/*
 Change a table's name, returning the command executed.
 
 Args:
@@ -1212,12 +1180,30 @@ Args:
   old_tab_name: unquoted, unqualified original table name
   new_tab_name: unquoted, unqualified new table name
 */
-DECLARE fullname text;
 BEGIN
-  fullname := __msar.build_qualified_name_sql(sch_name, old_tab_name);
-  RETURN __msar.rename_table(fullname, quote_ident(new_tab_name));
+  EXECUTE format('ALTER TABLE %I.%I RENAME TO %I', sch_name, old_tab_name, new_tab_name);
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
+
+DROP FUNCTION IF EXISTS msar.rename_table(oid, text);
+CREATE OR REPLACE FUNCTION
+msar.rename_table(tab_id oid, new_tab_name text) RETURNS void AS $$/*
+Change a table's name, returning the command executed.
+
+Args:
+  tab_id: the OID of the table whose name we want to change
+  new_tab_name: unquoted, unqualified table name
+*/
+BEGIN
+  PERFORM msar.rename_table(
+    msar.get_relation_schema_name(tab_id),
+    msar.get_relation_name(tab_id),
+    new_tab_name
+  );
+END;
+$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
 
 
 -- Comment on table --------------------------------------------------------------------------------

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -1370,6 +1370,19 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION test_rename_table_with_same_name() RETURNS SETOF TEXT AS $$
+BEGIN
+  PERFORM __setup_alter_table();
+  PERFORM msar.rename_table(
+    sch_name =>'public',
+    old_tab_name => 'alter_this_table',
+    new_tab_name => 'alter_this_table'
+  );
+  RETURN NEXT has_table('alter_this_table');
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION test_rename_table_using_oid() RETURNS SETOF TEXT AS $$
 BEGIN
   PERFORM __setup_alter_table();

--- a/db/tables/operations/alter.py
+++ b/db/tables/operations/alter.py
@@ -1,4 +1,6 @@
 """The functions in this module wrap SQL functions that use `ALTER TABLE`."""
+import json
+
 from db import constants
 from db import connection as db_conn
 from db.columns.operations.alter import batch_update_columns
@@ -66,7 +68,7 @@ def alter_table_on_database(table_oid, table_data_dict, conn):
     }
     """
     return db_conn.exec_msar_func(
-        conn, 'alter_table', table_oid, table_data_dict
+        conn, 'alter_table', table_oid, json.dumps(table_data_dict)
     ).fetchone()[0]
 
 

--- a/db/tests/tables/operations/test_alter.py
+++ b/db/tests/tables/operations/test_alter.py
@@ -1,3 +1,5 @@
+import json
+
 from unittest.mock import patch
 import db.tables.operations.alter as tab_alter
 
@@ -42,4 +44,8 @@ def test_alter_table():
     assert call_args[0] == "conn"
     assert call_args[1] == "alter_table"
     assert call_args[2] == 12345
-    assert call_args[3] == {"name": "newname", "description": "this is a comment", "columns": {}}
+    assert call_args[3] == json.dumps({
+        "name": "newname",
+        "description": "this is a comment",
+        "columns": {},
+    })


### PR DESCRIPTION
When implementing the front end for patching tables, I encountered the following issues with `tables.patch`:

- All requests were failing with:

    > ProgrammingError: cannot adapt type 'dict' us ing placeholder '%s' (format: AUTO)

    ecc9cdedcc3c6115a3d7552cc1f02d5131617502 fixes this.

- I was unable to submit a request to rename a table to its current name.

    da89d221c04404b5c96f2d0d7460a838a8a40198 fixes this.



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


