### PR TITLE
In SQL, return an empty array when a schema has no tables

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -838,13 +838,16 @@ Each returned JSON object in the array will have the form:
 Args:
   sch_id: The OID or name of the schema.
 */
-SELECT jsonb_agg(
-  jsonb_build_object(
-    'oid', pgc.oid::bigint,
-    'name', pgc.relname,
-    'schema', pgc.relnamespace::bigint,
-    'description', msar.obj_description(pgc.oid, 'pg_class')
-  )
+SELECT coalesce(
+  jsonb_agg(
+    jsonb_build_object(
+      'oid', pgc.oid::bigint,
+      'name', pgc.relname,
+      'schema', pgc.relnamespace::bigint,
+      'description', msar.obj_description(pgc.oid, 'pg_class')
+    )
+  ),
+  '[]'::jsonb
 )
 FROM pg_catalog.pg_class AS pgc 
   LEFT JOIN pg_catalog.pg_namespace AS pgn ON pgc.relnamespace = pgn.oid

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -2696,7 +2696,7 @@ BEGIN
 
   -- Test table info for schema 'alice' that contains no tables
   RETURN NEXT is(
-    alice_table_info, null
+    alice_table_info, '[]'::jsonb
   );
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Before

- `msar.get_table_info` would return `NULL` for a schema with no tables.
- This bubbled up to the API layer, meaning that `tables.list` would sometimes return `null`.
- This bubbled up to the front end creating this [bug](https://github.com/mathesar-foundation/mathesar/pull/3651#pullrequestreview-2193724572).

## After

- `msar.get_table_info` returns an empty array for a schema with no tables.
- The return type for `tables.list` can remain as-documented `list[TableInfo]` (instead of `Optional[list[TableInfo]]`), and the return type in the front end can also remain as currently typed. The typing is simpler.
- Bug fixed.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

