### PR TITLE
Add `table_privileges.list_direct` RPC function

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -81,6 +81,7 @@ MODERNRPC_METHODS_MODULES = [
     'mathesar.rpc.schema_privileges',
     'mathesar.rpc.servers',
     'mathesar.rpc.tables',
+    'mathesar.rpc.table_privileges',
     'mathesar.rpc.tables.metadata',
     'mathesar.rpc.types',
     'mathesar.rpc.explorations'

--- a/db/roles/operations/select.py
+++ b/db/roles/operations/select.py
@@ -13,5 +13,9 @@ def list_schema_privileges(schema_oid, conn):
     return exec_msar_func(conn, 'list_schema_privileges', schema_oid).fetchone()[0]
 
 
+def list_table_privileges(table_oid, conn):
+    return exec_msar_func(conn, 'list_table_privileges', table_oid).fetchone()[0]
+
+
 def get_curr_role_db_priv(db_name, conn):
     return exec_msar_func(conn, 'get_owner_oid_and_curr_role_db_priv', db_name).fetchone()[0]

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -2830,6 +2830,41 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION test_list_table_privileges_basic() RETURNS SETOF TEXT AS $$
+BEGIN
+CREATE TABLE restricted_table();
+RETURN NEXT is(
+  msar.list_table_privileges('restricted_table'::regclass),
+  format(
+    '[{"direct": ["INSERT", "SELECT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"], "role_oid": %s}]',
+    'mathesar'::regrole::oid
+  )::jsonb,
+  'Initially, only privileges for creator'
+);
+CREATE USER "Alice";
+RETURN NEXT is(
+  msar.list_table_privileges('restricted_table'::regclass),
+  format(
+    '[{"direct": ["INSERT", "SELECT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"], "role_oid": %s}]',
+    'mathesar'::regrole::oid
+  )::jsonb,
+  'Alice should not have any privileges on restricted_table'
+);
+GRANT SELECT, DELETE ON TABLE restricted_table TO "Alice";
+RETURN NEXT is(
+  msar.list_table_privileges('restricted_table'::regclass),
+  format(
+    '[{"direct": ["INSERT", "SELECT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"], "role_oid": %1$s},
+    {"direct": ["SELECT", "DELETE"], "role_oid": %2$s}]',
+    'mathesar'::regrole::oid,
+    '"Alice"'::regrole::oid
+  )::jsonb,
+  'Alice should have SELECT & DELETE privileges on restricted_table'
+);
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION test_list_roles() RETURNS SETOF TEXT AS $$
 DECLARE
   initial_role_count int;

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -134,6 +134,14 @@ To use an RPC function:
       - JoinableTableRecord
       - JoinableTableInfo
 
+## Table Privileges
+
+::: table_privileges
+    options:
+      members:
+      - list_direct
+      - TablePrivileges
+
 ## Table Metadata
 
 ::: tables.metadata

--- a/mathesar/rpc/table_privileges.py
+++ b/mathesar/rpc/table_privileges.py
@@ -1,0 +1,46 @@
+from typing import Literal, TypedDict
+
+from modernrpc.core import rpc_method, REQUEST_KEY
+from modernrpc.auth.basic import http_basic_auth_login_required
+
+from db.roles.operations.select import list_table_privileges
+from mathesar.rpc.utils import connect
+from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+
+
+class TablePrivileges(TypedDict):
+    """
+    Information about table privileges for a role.
+    Attributes:
+        role_oid: The `oid` of the role.
+        direct: A list of table privileges for the afforementioned role_oid.
+    """
+    role_oid: int
+    direct: list[Literal['INSERT', 'SELECT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']]
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            role_oid=d["role_oid"],
+            direct=d["direct"]
+        )
+
+
+@rpc_method(name="table_privileges.list_direct")
+@http_basic_auth_login_required
+@handle_rpc_exceptions
+def list_direct(
+        *, table_oid: int, database_id: int, **kwargs
+) -> list[TablePrivileges]:
+    """
+    List direct table privileges for roles.
+    Args:
+        table_oid: The OID of the table whose privileges we'll list.
+        database_id: The Django id of the database containing the table.
+    Returns:
+        A list of table privileges.
+    """
+    user = kwargs.get(REQUEST_KEY).user
+    with connect(database_id, user) as conn:
+        raw_priv = list_table_privileges(table_oid, conn)
+    return [TablePrivileges.from_dict(i) for i in raw_priv]

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -24,6 +24,7 @@ from mathesar.rpc import schemas
 from mathesar.rpc import schema_privileges
 from mathesar.rpc import servers
 from mathesar.rpc import tables
+from mathesar.rpc import table_privileges
 from mathesar.rpc import types
 
 METHODS = [
@@ -326,6 +327,11 @@ METHODS = [
     (
         tables.list_joinable,
         "tables.list_joinable",
+        [user_is_authenticated]
+    ),
+    (
+        table_privileges.list_direct,
+        "table_privileges.list_direct",
         [user_is_authenticated]
     ),
     (

--- a/mathesar/tests/rpc/test_table_privileges.py
+++ b/mathesar/tests/rpc/test_table_privileges.py
@@ -1,0 +1,63 @@
+"""
+This file tests the table_privileges RPC functions.
+
+Fixtures:
+    rf(pytest-django): Provides mocked `Request` objects.
+    monkeypatch(pytest): Lets you monkeypatch an object for testing.
+"""
+from contextlib import contextmanager
+
+from mathesar.rpc import table_privileges
+from mathesar.models.users import User
+
+
+def test_table_privileges_list_direct(rf, monkeypatch):
+    _username = 'alice'
+    _password = 'pass1234'
+    _database_id = 2
+    _table_oid = 123456
+    _privileges = [
+        {
+            "role_oid": 12345,
+            "direct": [
+                "INSERT",
+                "SELECT",
+                "UPDATE",
+                "DELETE",
+                "TRUNCATE",
+                "REFERENCES",
+                "TRIGGER"]
+        }
+    ]
+    request = rf.post('/api/rpc/v0/', data={})
+    request.user = User(username=_username, password=_password)
+
+    @contextmanager
+    def mock_connect(database_id, user):
+        if database_id == _database_id and user.username == _username:
+            try:
+                yield True
+            finally:
+                pass
+        else:
+            raise AssertionError('incorrect parameters passed')
+
+    def mock_list_privileges(
+            table_oid,
+            conn,
+    ):
+        if table_oid != _table_oid:
+            raise AssertionError('incorrect parameters passed')
+        return _privileges
+
+    monkeypatch.setattr(table_privileges, 'connect', mock_connect)
+    monkeypatch.setattr(
+        table_privileges,
+        'list_table_privileges',
+        mock_list_privileges
+    )
+    expect_response = _privileges
+    actual_response = table_privileges.list_direct(
+        table_oid=_table_oid, database_id=_database_id, request=request
+    )
+    assert actual_response == expect_response


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3779

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
