### PR TITLE
Add `table_privileges.replace_for_roles` RPC function

### DIFF
--- a/db/roles/operations/update.py
+++ b/db/roles/operations/update.py
@@ -13,3 +13,10 @@ def replace_schema_privileges_for_roles(conn, schema_oid, privileges):
         conn, 'replace_schema_privileges_for_roles',
         schema_oid, json.dumps(privileges)
     ).fetchone()[0]
+
+
+def replace_table_privileges_for_roles(conn, table_oid, privileges):
+    return exec_msar_func(
+        conn, 'replace_table_privileges_for_roles',
+        table_oid, json.dumps(privileges)
+    ).fetchone()[0]

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1249,6 +1249,53 @@ END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 
+CREATE OR REPLACE FUNCTION
+msar.build_table_privilege_replace_expr(tab_id regclass, rol_id regrole, privileges_ jsonb)
+  RETURNS TEXT AS $$
+SELECT string_agg(
+  format(
+    concat(
+      CASE WHEN privileges_ ? val THEN 'GRANT' ELSE 'REVOKE' END,
+      ' %1$s ON TABLE %2$I.%3$I ',
+      CASE WHEN privileges_ ? val THEN 'TO' ELSE 'FROM' END,
+      ' %4$I'
+    ),
+    val,
+    msar.get_relation_schema_name(tab_id),
+    msar.get_relation_name(tab_id),
+    msar.get_role_name(rol_id)
+  ),
+  E';\n'
+) || E';\n'
+FROM unnest(ARRAY['INSERT', 'SELECT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']) as x(val);
+$$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
+
+
+CREATE OR REPLACE FUNCTION
+msar.replace_table_privileges_for_roles(tab_id regclass, priv_spec jsonb) RETURNS jsonb AS $$/*
+Grant/Revoke privileges for a set of roles on the given table.
+
+Args:
+  tab_id The OID of the table for which we're setting privileges for roles.
+  priv_spec: An array defining the privileges to grant or revoke for each role.
+
+Each object in the priv_spec should have the form:
+{role_oid: <int>, privileges: SET<"INSERT"|"SELECT"|"UPDATE"|"DELETE"|"TRUNCATE"|"REFERENCES"|"TRIGGER">}
+
+Any privilege that exists in the privileges subarray will be granted. Any which is missing will be
+revoked.
+*/
+BEGIN
+EXECUTE string_agg(
+  msar.build_table_privilege_replace_expr(tab_id, role_oid, direct),
+  E';\n'
+) || ';'
+FROM jsonb_to_recordset(priv_spec) AS x(role_oid regrole, direct jsonb);
+RETURN msar.list_table_privileges(tab_id);
+END;
+$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
+
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 -- ALTER SCHEMA FUNCTIONS

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -4673,3 +4673,131 @@ BEGIN
   );
 END;
 $$ LANGUAGE plpgsql;
+
+
+-- msar.replace_table_privileges_for_roles --------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION
+test_replace_table_privileges_for_roles_basic() RETURNS SETOF TEXT AS $$/*
+Happy path, smoke test.
+*/
+DECLARE
+  table_id oid;
+  alice_id oid;
+  bob_id oid;
+BEGIN
+  CREATE TABLE restricted_table();
+  table_id := 'restricted_table'::regclass::oid;
+  CREATE ROLE "Alice";
+  CREATE ROLE bob;
+  alice_id := '"Alice"'::regrole::oid;
+  bob_id := 'bob'::regrole::oid;
+
+  RETURN NEXT set_eq(
+    format(
+      $t1$SELECT jsonb_array_elements_text(direct) FROM jsonb_to_recordset(
+        msar.replace_table_privileges_for_roles(%2$s, jsonb_build_array(jsonb_build_object(
+          'role_oid', %1$s, 'direct', jsonb_build_array('SELECT', 'UPDATE')))))
+        AS x(direct jsonb, role_oid regrole)
+      WHERE role_oid=%1$s $t1$,
+      alice_id,
+      table_id
+    ),
+    ARRAY['SELECT', 'UPDATE'],
+    'Response should contain updated role info in correct form'
+  );
+  RETURN NEXT set_eq(
+    concat(
+      'SELECT privilege_type FROM pg_class, LATERAL aclexplode(pg_class.relacl) acl',
+      format(' WHERE acl.grantee=%s;', alice_id)
+    ),
+    ARRAY['SELECT', 'UPDATE'],
+    'Privileges should be updated for actual table properly'
+  );
+  RETURN NEXT set_eq(
+    format(
+      $t2$SELECT jsonb_array_elements_text(direct) FROM jsonb_to_recordset(
+        msar.replace_table_privileges_for_roles(%2$s, jsonb_build_array(jsonb_build_object(
+              'role_oid', %1$s, 'direct', jsonb_build_array('INSERT', 'SELECT', 'DELETE')))))
+        AS x(direct jsonb, role_oid regrole)
+      WHERE role_oid=%1$s $t2$,
+      bob_id,
+      table_id
+    ),
+    ARRAY['INSERT', 'SELECT', 'DELETE'],
+    'Response should contain updated role info in correct form'
+  );
+  RETURN NEXT set_eq(
+    concat(
+      'SELECT privilege_type FROM pg_class, LATERAL aclexplode(pg_class.relacl) acl',
+      format(' WHERE acl.grantee=%s;', alice_id)
+    ),
+    ARRAY['SELECT', 'UPDATE'],
+    'Alice''s privileges should be left alone properly'
+  );
+  RETURN NEXT set_eq(
+    concat(
+      'SELECT privilege_type FROM pg_class, LATERAL aclexplode(pg_class.relacl) acl',
+      format(' WHERE acl.grantee=%s;', bob_id)
+    ),
+    ARRAY['INSERT', 'SELECT', 'DELETE'],
+    'Privileges should be updated for actual table properly'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION
+test_replace_table_privileges_for_roles_multi_ops() RETURNS SETOF TEXT AS $$/*
+Test that we can add/revoke multiple privileges to/from multiple roles simultaneously.
+*/
+DECLARE
+  table_id oid;
+  alice_id oid;
+  bob_id oid;
+BEGIN
+  CREATE TABLE "test Multiops table"();
+  table_id := '"test Multiops table"'::regclass::oid;
+
+  CREATE ROLE "Alice";
+  CREATE ROLE bob;
+  alice_id := '"Alice"'::regrole::oid;
+  bob_id := 'bob'::regrole::oid;
+
+  GRANT SELECT, DELETE ON TABLE "test Multiops table" TO "Alice";
+  GRANT INSERT, UPDATE ON TABLE "test Multiops table" TO bob;
+
+  RETURN NEXT set_eq(
+    -- Revoke CREATE from Alice, Grant CREATE to Bob.
+    format(
+      $t1$SELECT jsonb_array_elements_text(direct) FROM jsonb_to_recordset(
+        msar.replace_table_privileges_for_roles(%3$s, jsonb_build_array(
+          jsonb_build_object('role_oid', %1$s, 'direct', jsonb_build_array('INSERT', 'SELECT', 'UPDATE')),
+          jsonb_build_object('role_oid', %2$s, 'direct', jsonb_build_array('SELECT', 'DELETE')))))
+        AS x(direct jsonb, role_oid regrole)
+      WHERE role_oid=%1$s $t1$,
+      alice_id,
+      bob_id,
+      table_id
+    ),
+    ARRAY['INSERT', 'SELECT', 'UPDATE'], -- This only checks form of Alice's info in response.
+    'Response should contain updated role info in correct form'
+  );
+  RETURN NEXT set_eq(
+    concat(
+      'SELECT privilege_type FROM pg_class, LATERAL aclexplode(pg_class.relacl) acl',
+      format(' WHERE acl.grantee=%s;', alice_id)
+    ),
+    ARRAY['INSERT', 'SELECT', 'UPDATE'],
+    'Alice''s privileges should be updated for actual table properly'
+  );
+  RETURN NEXT set_eq(
+    concat(
+      'SELECT privilege_type FROM pg_class, LATERAL aclexplode(pg_class.relacl) acl',
+      format(' WHERE acl.grantee=%s;', bob_id)
+    ),
+    ARRAY['SELECT', 'DELETE'],
+    'Bob''s privileges should be updated for actual table properly'
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -4768,7 +4768,8 @@ BEGIN
   GRANT INSERT, UPDATE ON TABLE "test Multiops table" TO bob;
 
   RETURN NEXT set_eq(
-    -- Revoke CREATE from Alice, Grant CREATE to Bob.
+    -- Grant INSERT, SELECT and UPDATE to Alice, Revoke DELETE.
+    -- Grant SELECT and DELETE to Bob, Revoke INSERT and UPDATE.
     format(
       $t1$SELECT jsonb_array_elements_text(direct) FROM jsonb_to_recordset(
         msar.replace_table_privileges_for_roles(%3$s, jsonb_build_array(

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -142,6 +142,7 @@ To use an RPC function:
     options:
       members:
       - list_direct
+      - replace_for_roles
       - TablePrivileges
 
 ## Table Metadata

--- a/mathesar/rpc/table_privileges.py
+++ b/mathesar/rpc/table_privileges.py
@@ -4,6 +4,7 @@ from modernrpc.core import rpc_method, REQUEST_KEY
 from modernrpc.auth.basic import http_basic_auth_login_required
 
 from db.roles.operations.select import list_table_privileges
+from db.roles.operations.update import replace_table_privileges_for_roles
 from mathesar.rpc.utils import connect
 from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 
@@ -43,4 +44,40 @@ def list_direct(
     user = kwargs.get(REQUEST_KEY).user
     with connect(database_id, user) as conn:
         raw_priv = list_table_privileges(table_oid, conn)
+    return [TablePrivileges.from_dict(i) for i in raw_priv]
+
+
+@rpc_method(name="table_privileges.replace_for_roles")
+@http_basic_auth_login_required
+@handle_rpc_exceptions
+def replace_for_roles(
+    *,
+    privileges: list[TablePrivileges], table_oid: int, database_id: int,
+    **kwargs
+) -> list[TablePrivileges]:
+    """
+    Replace direct table privileges for roles.
+
+    Possible privileges are `INSERT`, `SELECT`, `UPDATE`, `DELETE`, `TRUNCATE`, `REFERENCES` and `TRIGGER`.
+
+    Only roles which are included in a passed `TablePrivileges` object
+    are affected.
+
+    WARNING: Any privilege included in the `direct` list for a role
+    is GRANTed, and any privilege not included is REVOKEd.
+
+    Args:
+        privileges: The new privilege sets for roles.
+        table_oid: The OID of the affected table.
+        database_id: The Django id of the database containing the table.
+
+    Returns:
+        A list of all non-default privileges on the table after the
+        operation.
+    """
+    user = kwargs.get(REQUEST_KEY).user
+    with connect(database_id, user) as conn:
+        raw_priv = replace_table_privileges_for_roles(
+            conn, table_oid, [TablePrivileges.from_dict(i) for i in privileges]
+        )
     return [TablePrivileges.from_dict(i) for i in raw_priv]

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -345,6 +345,11 @@ METHODS = [
         [user_is_authenticated]
     ),
     (
+        table_privileges.replace_for_roles,
+        "table_privileges.replace_for_roles",
+        [user_is_authenticated]
+    ),
+    (
         tables.metadata.list_,
         "tables.metadata.list",
         [user_is_authenticated]

--- a/mathesar/tests/rpc/test_table_privileges.py
+++ b/mathesar/tests/rpc/test_table_privileges.py
@@ -61,3 +61,58 @@ def test_table_privileges_list_direct(rf, monkeypatch):
         table_oid=_table_oid, database_id=_database_id, request=request
     )
     assert actual_response == expect_response
+
+
+def test_table_privileges_replace_for_roles(rf, monkeypatch):
+    _username = 'alice'
+    _password = 'pass1234'
+    _table_oid = 654321
+    _database_id = 2
+    _privileges = [{"role_oid": 12345, "direct": ["SELECT", "UPDATE", "DELETE"]}]
+    request = rf.post('/api/rpc/v0/', data={})
+    request.user = User(username=_username, password=_password)
+
+    @contextmanager
+    def mock_connect(database_id, user):
+        if database_id == _database_id and user.username == _username:
+            try:
+                yield True
+            finally:
+                pass
+        else:
+            raise AssertionError('incorrect parameters passed')
+
+    def mock_replace_privileges(
+            conn,
+            table_oid,
+            privileges,
+    ):
+        if privileges != _privileges or table_oid != _table_oid:
+            raise AssertionError('incorrect parameters passed')
+        return _privileges + [{
+            "role_oid": 67890,
+            "direct": [
+                "INSERT",
+                "SELECT",
+                "UPDATE",
+                "DELETE",
+                "TRUNCATE",
+                "REFERENCES",
+                "TRIGGER"
+            ]}]
+
+    monkeypatch.setattr(table_privileges, 'connect', mock_connect)
+    monkeypatch.setattr(
+        table_privileges,
+        'replace_table_privileges_for_roles',
+        mock_replace_privileges
+    )
+    expect_response = [
+        {"role_oid": 12345, "direct": ["SELECT", "UPDATE", "DELETE"]},
+        {"role_oid": 67890, "direct": ["INSERT", "SELECT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"]}
+    ]
+    actual_response = table_privileges.replace_for_roles(
+        privileges=_privileges, table_oid=_table_oid, database_id=_database_id,
+        request=request
+    )
+    assert actual_response == expect_response


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3790

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
