### PR TITLE
Add `roles.get_current_role` RPC function

### DIFF
--- a/db/roles/operations/select.py
+++ b/db/roles/operations/select.py
@@ -5,6 +5,10 @@ def list_roles(conn):
     return exec_msar_func(conn, 'list_roles').fetchone()[0]
 
 
+def get_current_role_from_db(conn):
+    return exec_msar_func(conn, 'get_current_role').fetchone()[0]
+
+
 def list_db_priv(db_name, conn):
     return exec_msar_func(conn, 'list_db_priv', db_name).fetchone()[0]
 

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -919,7 +919,6 @@ FROM (
 $$ LANGUAGE SQL;
 
 
-DROP FUNCTION IF EXISTS msar.role_info_table();
 CREATE OR REPLACE FUNCTION msar.list_schema_privileges(sch_id regnamespace) RETURNS jsonb AS $$/*
 Given a schema, returns a json array of objects with direct, non-default schema privileges
 
@@ -946,6 +945,7 @@ SELECT COALESCE(jsonb_agg(priv_cte.p), '[]'::jsonb) FROM priv_cte;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
 
 
+DROP FUNCTION IF EXISTS msar.role_info_table();
 CREATE OR REPLACE FUNCTION msar.role_info_table() RETURNS TABLE
 (
   oid bigint, -- The OID of the role.
@@ -1034,6 +1034,25 @@ The returned JSON object has the form:
 SELECT to_jsonb(role_data)
 FROM msar.role_info_table() AS role_data
 WHERE role_data.name = rolename;
+$$ LANGUAGE SQL STABLE;
+
+
+CREATE OR REPLACE FUNCTION
+msar.get_current_role() RETURNS TEXT AS $$/*
+Returns a JSON object describing the current_role and the parent role(s) it inherits from.
+*/
+SELECT jsonb_build_object(
+  'current_role', msar.get_role(current_role),
+  'parent_roles', array_remove(
+    array_agg(
+      CASE WHEN pg_has_role(role_data.name, current_role, 'MEMBER')
+      THEN msar.get_role(role_data.name) END
+    ), NULL
+  )
+)
+FROM msar.role_info_table() AS role_data
+WHERE role_data.name NOT LIKE 'pg_%'
+AND role_data.name != current_role;
 $$ LANGUAGE SQL STABLE;
 
 

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1038,14 +1038,15 @@ $$ LANGUAGE SQL STABLE;
 
 
 CREATE OR REPLACE FUNCTION
-msar.get_current_role() RETURNS TEXT AS $$/*
-Returns a JSON object describing the current_role and the parent role(s) it inherits from.
+msar.get_current_role() RETURNS jsonb AS $$/*
+Returns a JSON object describing the current_role and the parent role(s) whose
+privileges are immediately available to current_role without doing SET ROLE.
 */
 SELECT jsonb_build_object(
   'current_role', msar.get_role(current_role),
   'parent_roles', array_remove(
     array_agg(
-      CASE WHEN pg_has_role(role_data.name, current_role, 'MEMBER')
+      CASE WHEN pg_has_role(role_data.name, current_role, 'USAGE')
       THEN msar.get_role(role_data.name) END
     ), NULL
   )

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -249,6 +249,7 @@ To use an RPC function:
       members:
       - list_
       - add
+      - get_current_role
       - RoleInfo
       - RoleMember
 

--- a/mathesar/rpc/roles.py
+++ b/mathesar/rpc/roles.py
@@ -8,7 +8,7 @@ from modernrpc.auth.basic import http_basic_auth_login_required
 
 from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 from mathesar.rpc.utils import connect
-from db.roles.operations.select import list_roles
+from db.roles.operations.select import list_roles, get_current_role_from_db
 from db.roles.operations.create import create_role
 
 
@@ -116,3 +116,26 @@ def add(
     with connect(database_id, user) as conn:
         role = create_role(rolename, password, login, conn)
     return RoleInfo.from_dict(role)
+
+
+@rpc_method(name="roles.get_current_role")
+@http_basic_auth_login_required
+@handle_rpc_exceptions
+def get_current_role(*, database_id: int, **kwargs) -> dict:
+    """
+    Get information about the current role and all the parent role(s) it inherits from.
+    Requires a database id inorder to connect to the server.
+
+    Args:
+        database_id: The Django id of the database.
+
+    Returns:
+        A dict describing the current role.
+    """
+    user = kwargs.get(REQUEST_KEY).user
+    with connect(database_id, user) as conn:
+        current_role = get_current_role_from_db(conn)
+    return {
+        "current_role": RoleInfo.from_dict(current_role["current_role"]),
+        "parent_roles": [RoleInfo.from_dict(role) for role in current_role["parent_roles"]]
+    }

--- a/mathesar/rpc/roles.py
+++ b/mathesar/rpc/roles.py
@@ -123,8 +123,8 @@ def add(
 @handle_rpc_exceptions
 def get_current_role(*, database_id: int, **kwargs) -> dict:
     """
-    Get information about the current role and all the parent role(s) it inherits from.
-    Requires a database id inorder to connect to the server.
+    Get information about the current role and all the parent role(s) whose
+    privileges are immediately available to current role without doing SET ROLE.
 
     Args:
         database_id: The Django id of the database.

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -254,6 +254,11 @@ METHODS = [
         [user_is_authenticated]
     ),
     (
+        roles.get_current_role,
+        "roles.get_current_role",
+        [user_is_authenticated]
+    ),
+    (
         schemas.add,
         "schemas.add",
         [user_is_authenticated]


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3777

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
