### PR TITLE
Change response for `tables.add` and `tables.import`

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -2918,7 +2918,7 @@ Each returned JSON object will have the form:
 
 Args:
   sch_id: The OID of the schema where the table will be created.
-  tab_name: The unquoted name for the new table.
+  tab_name (optional): The unquoted name for the new table.
   col_defs: The columns for the new table, in order.
   header: Whether or not the file contains a header line with the names of each column in the file.
   delimiter: The character that separates columns within each row (line) of the file.

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -2888,8 +2888,8 @@ BEGIN
   PERFORM msar.comment_on_table(created_table_id, comment_);
   RETURN jsonb_build_object(
     'oid', created_table_id::bigint,
-    'name', created_table_id::regclass::text
-  );
+    'name', relname
+  ) FROM pg_catalog.pg_class WHERE oid = created_table_id;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -2961,8 +2961,8 @@ BEGIN
   RETURN jsonb_build_object(
     'copy_sql', copy_sql,
     'table_oid', rel_id::bigint,
-    'table_name', rel_id::regclass::text
-  );
+    'table_name', relname
+  ) FROM pg_catalog.pg_class WHERE oid = rel_id;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -2887,7 +2887,7 @@ BEGIN
   created_table_id := fq_table_name::regclass::oid;
   PERFORM msar.comment_on_table(created_table_id, comment_);
   RETURN jsonb_build_object(
-    'oid', created_table_id,
+    'oid', created_table_id::bigint,
     'name', created_table_id::regclass::text
   );
 END;
@@ -2960,7 +2960,7 @@ BEGIN
   copy_sql := format('COPY %I.%I (%s) FROM STDIN CSV %s', sch_name, rel_name, col_names_sql, options_sql);
   RETURN jsonb_build_object(
     'copy_sql', copy_sql,
-    'table_oid', rel_id,
+    'table_oid', rel_id::bigint,
     'table_name', rel_id::regclass::text
   );
 END;

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -2907,12 +2907,13 @@ msar.prepare_table_for_import(
   comment_ text
 ) RETURNS jsonb AS $$/*
 Add a table, with a default id column, returning a JSON object containing
-a properly formatted SQL statement to carry out `COPY FROM` and also contains table_oid of the created table.
+a properly formatted SQL statement to carry out `COPY FROM`, table_oid & table_name of the created table.
 
 Each returned JSON object will have the form:
   {
     "copy_sql": <str>,
-    "table_oid": <int>
+    "table_oid": <int>,
+    "table_name": <str>
   }
 
 Args:

--- a/db/tables/operations/create.py
+++ b/db/tables/operations/create.py
@@ -30,7 +30,7 @@ def create_mathesar_table(engine, table_name, schema_oid, columns=[], constraint
         json.dumps(columns),
         json.dumps(constraints),
         comment
-    ).fetchone()[0]
+    ).fetchone()[0]["oid"]
 
 
 def create_table_on_database(
@@ -52,7 +52,7 @@ def create_table_on_database(
         comment: The comment for the new table. (optional)
 
     Returns:
-        Returns the OID of the created table.
+        Returns the OID and name of the created table.
     """
     return exec_msar_func(
         conn,

--- a/db/tables/operations/create.py
+++ b/db/tables/operations/create.py
@@ -122,7 +122,8 @@ def prepare_table_for_import(
     ).fetchone()[0]
     return (
         import_info['copy_sql'],
-        import_info['table_oid']
+        import_info['table_oid'],
+        import_info['table_name']
     )
 
 

--- a/db/tables/operations/import_.py
+++ b/db/tables/operations/import_.py
@@ -25,7 +25,7 @@ def import_csv(data_file_id, table_name, schema_oid, conn, comment=None):
     with open(file_path, 'rb') as csv_file:
         csv_reader = get_sv_reader(csv_file, header, dialect)
         column_names = process_column_names(csv_reader.fieldnames)
-    copy_sql, table_oid = prepare_table_for_import(
+    copy_sql, table_oid, table_name = prepare_table_for_import(
         table_name,
         schema_oid,
         column_names,
@@ -44,7 +44,7 @@ def import_csv(data_file_id, table_name, schema_oid, conn, comment=None):
         conversion_encoding,
         conn
     )
-    return table_oid
+    return {"oid": table_oid, "name": table_name}
 
 
 def insert_csv_records(

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -127,6 +127,7 @@ To use an RPC function:
       - get_import_preview
       - list_joinable
       - TableInfo
+      - AddedTableInfo
       - SettableTableInfo
       - JoinableTableRecord
       - JoinableTableInfo

--- a/mathesar/rpc/tables/base.py
+++ b/mathesar/rpc/tables/base.py
@@ -51,6 +51,18 @@ class TableInfo(TypedDict):
     current_role_owns: bool
 
 
+class AddedTableInfo(TypedDict):
+    """
+    Information about a newly created table.
+
+    Attributes:
+        oid: The `oid` of the table in the schema.
+        name: The name of the table.
+    """
+    oid: int
+    name: str
+
+
 class SettableTableInfo(TypedDict):
     """
     Information about a table, restricted to settable fields.
@@ -191,7 +203,7 @@ def add(
     constraint_data_list: list[CreatableConstraintInfo] = [],
     comment: str = None,
     **kwargs
-) -> int:
+) -> AddedTableInfo:
     """
     Add a table with a default id column.
 
@@ -204,7 +216,7 @@ def add(
         comment: The comment for the new table.
 
     Returns:
-        The `oid` of the created table.
+        The `oid` & `name` of the created table.
     """
     user = kwargs.get(REQUEST_KEY).user
     with connect(database_id, user) as conn:
@@ -264,24 +276,24 @@ def patch(
 def import_(
     *,
     data_file_id: int,
-    table_name: str,
     schema_oid: int,
     database_id: int,
+    table_name: str = None,
     comment: str = None,
     **kwargs
-) -> int:
+) -> AddedTableInfo:
     """
     Import a CSV/TSV into a table.
 
     Args:
         data_file_id: The Django id of the DataFile containing desired CSV/TSV.
-        table_name: Name of the table to be imported.
         schema_oid: Identity of the schema in the user's database.
         database_id: The Django id of the database containing the table.
+        table_name: Name of the table to be imported.
         comment: The comment for the new table.
 
     Returns:
-        The `oid` of the created table.
+        The `oid` and `name` of the created table.
     """
     user = kwargs.get(REQUEST_KEY).user
     with connect(database_id, user) as conn:

--- a/mathesar/tests/rpc/tables/test_t_base.py
+++ b/mathesar/tests/rpc/tables/test_t_base.py
@@ -148,11 +148,11 @@ def test_tables_add(rf, monkeypatch):
     def mock_table_add(table_name, _schema_oid, conn, column_data_list, constraint_data_list, comment):
         if _schema_oid != schema_oid:
             raise AssertionError('incorrect parameters passed')
-        return 1964474
+        return {"oid": 1964474, "name": "newtable"}
     monkeypatch.setattr(tables.base, 'connect', mock_connect)
     monkeypatch.setattr(tables.base, 'create_table_on_database', mock_table_add)
-    actual_table_oid = tables.add(table_name='newtable', schema_oid=2200, database_id=11, request=request)
-    assert actual_table_oid == 1964474
+    actual_table_info = tables.add(table_name='newtable', schema_oid=2200, database_id=11, request=request)
+    assert actual_table_info == {"oid": 1964474, "name": "newtable"}
 
 
 def test_tables_patch(rf, monkeypatch):
@@ -215,17 +215,17 @@ def test_tables_import(rf, monkeypatch):
     def mock_table_import(_data_file_id, table_name, _schema_oid, conn, comment):
         if _schema_oid != schema_oid and _data_file_id != data_file_id:
             raise AssertionError('incorrect parameters passed')
-        return 1964474
+        return {"oid": 1964474, "name": "imported_table"}
     monkeypatch.setattr(tables.base, 'connect', mock_connect)
     monkeypatch.setattr(tables.base, 'import_csv', mock_table_import)
-    imported_table_oid = tables.import_(
+    imported_table_info = tables.import_(
         data_file_id=10,
         table_name='imported_table',
         schema_oid=2200,
         database_id=11,
         request=request
     )
-    assert imported_table_oid == 1964474
+    assert imported_table_info == {"oid": 1964474, "name": "imported_table"}
 
 
 def test_tables_preview(rf, monkeypatch):


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number]

Old:
```
123456
```

New:
```json
{
    "oid": 123456,
    "name": "newtable"
}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
