### PR TITLE
Nginx configuration for dev and prod environments

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,22 @@
+# Useful when we need to build a single dockerfile to run a complete webservice
+ARG BASE_IMAGE=python:3.9-buster
+FROM $BASE_IMAGE as base_image
+
+ENV PORT=8000
+
+RUN apt-get update && \
+    apt-get install -y nginx
+
+
+RUN mkdir -p /etc/nginx/ssl
+RUN mkdir -p /etc/nginx/
+
+#COPY conf.d /etc/nginx/conf.d
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY localhost.pem /etc/nginx/ssl/localhost.pem
+COPY localhost-key.pem /etc/nginx/ssl/localhost-key.pem
+
+EXPOSE 80
+EXPOSE 443
+
+CMD ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]

--- a/Dockerfile.nginx_local
+++ b/Dockerfile.nginx_local
@@ -1,0 +1,30 @@
+# Useful when we need to build a single dockerfile to run a complete webservice
+ARG BASE_IMAGE=python:3.9-buster
+FROM $BASE_IMAGE as base_image
+
+ENV PORT=8000
+
+RUN apt-get update && \
+    apt-get install -y nginx libnss3-tools curl && \
+    # Install mkcert
+    curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && \
+    chmod +x mkcert-v* && \
+    mv mkcert-v* /usr/local/bin/mkcert && \
+    mkcert -install
+
+
+RUN mkdir -p /etc/nginx/ssl
+RUN mkdir -p /etc/nginx/
+
+#COPY conf.d /etc/nginx/conf.d
+COPY nginx.conf /etc/nginx/nginx.conf
+
+WORKDIR /etc/nginx/ssl
+RUN mkcert localhost
+
+RUN ls -lrt
+
+EXPOSE 80
+EXPOSE 443
+
+CMD ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]

--- a/Dockerfile.nginx_local
+++ b/Dockerfile.nginx_local
@@ -16,7 +16,6 @@ RUN apt-get update && \
 RUN mkdir -p /etc/nginx/ssl
 RUN mkdir -p /etc/nginx/
 
-#COPY conf.d /etc/nginx/conf.d
 COPY nginx.conf /etc/nginx/nginx.conf
 
 WORKDIR /etc/nginx/ssl

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,6 +64,15 @@ services:
       - "8000:8000"
       - "3000:3000"
       - "6006:6006"
+  dev_service_secured:
+    container_name: mathesar_service_dev_secured
+    image: nginx:latest
+    # This service needs the config variables defined above.
+    environment: 
+      - DOMAIN_NAME=localhost
+    ports:
+      - "80:80"
+      - "443:443"
   test-service:
     container_name: mathesar_service_test
     image: mathesar/mathesar-test:latest

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,78 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+env DOMAIN;
+env REVERSE_PROXY_DOMAIN;
+
+http {
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types {
+        text/html html;
+        text/css css;
+        text/xml xml;
+        image/gif gif;
+        image/jpeg jpg;
+        application/x-javascript js;
+        application/atom+xml atom;
+        application/rss+xml rss;
+        text/mathml mml;
+        text/plain txt;
+        text/vnd.wap.wml wml;
+        image/png png;
+        image/svg+xml svg;
+        image/x-icon ico;
+        image/x-jng jng;
+        image/x-webp webp;
+        application/java-archive jar war ear;
+        application/json json;
+        application/ld+json jsonld;
+        application/octet-stream bin exe;
+        application/ogg ogg;
+        application/pdf pdf;
+        application/zip zip;
+        application/x-7z-compressed 7z;
+    }
+
+    # Redirect HTTP to HTTPS
+    server {
+        listen 80;
+        server_name $DOMAIN;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS server block
+    server {
+        listen 443 ssl;
+        server_name $DOMAIN;
+
+        ssl_certificate /etc/nginx/ssl/localhost.pem;
+        ssl_certificate_key /etc/nginx/ssl/localhost-key.pem;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass http://$REVERSE_PROXY_DOMAIN:8000;  # Forward requests to the service running on localhost:8000
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,7 +7,6 @@ events {
 }
 
 env DOMAIN;
-env REVERSE_PROXY_DOMAIN;
 
 http {
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
@@ -68,7 +67,7 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
 
         location / {
-            proxy_pass http://$REVERSE_PROXY_DOMAIN:8000;  # Forward requests to the service running on localhost:8000
+            proxy_pass http://172.17.0.1:8000;  # Forward requests to the service running on localhost:8000
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/steps_for_using_nginx.md
+++ b/steps_for_using_nginx.md
@@ -25,3 +25,5 @@ For **Linux**: Copy the CA to **/usr/local/share/ca-certificates/** and **run su
 ## Steps to build the docker image of nginx for mathesar service is as follows (Production environment)
 
 Generate the certs using any standard format. Once available, pls. update the Dockerfile.nginx with cert location from where they have to be copied on to docker volume and update the relative paths in the nginx.conf if you wish so. 
+
+> **Note:** Proxy_pass has to be updated to DOMAIN

--- a/steps_for_using_nginx.md
+++ b/steps_for_using_nginx.md
@@ -5,9 +5,11 @@
 **docker build -f Dockerfile.nginx_local -t nginx .**
 
 we are opening ports 443 for HTTPS and 80 for HTTP which will help redirect the requests
-
-**docker run -d -p 443:443 -p 80:80 -e DOMAIN=localhost nginx**
-
+```
+docker run -d -p 443:443 -p 80:80 -e DOMAIN=localhost nginx
+                    or
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up dev_service_secured
+```
 
 Since the certs are being built on the local and not universal trusted, we need to follow extra steps of moving the root CA from docker image to development host and whitelist the same under the truststore. 
 

--- a/steps_for_using_nginx.md
+++ b/steps_for_using_nginx.md
@@ -1,0 +1,27 @@
+> **Note:** Follow the steps defined in the DEVELOPER_GUIDE.md, before proceeding with the further steps.
+
+## Steps to build the docker image of nginx for mathesar service is as follows (in development mode)
+
+**docker build -f Dockerfile.nginx_local -t nginx .**
+
+we are opening ports 443 for HTTPS and 80 for HTTP which will help redirect the requests
+
+**docker run -d -p 443:443 -p 80:80 -e DOMAIN=localhost nginx**
+
+
+Since the certs are being built on the local and not universal trusted, we need to follow extra steps of moving the root CA from docker image to development host and whitelist the same under the truststore. 
+
+## steps to copy root CA from docker container to local host
+
+docker cp container_id:/path/to/mkcert/rootCA.pem .
+
+For **windows**: Use **certmgr.msc** to add the CA under **Trusted Root Certification Authorities**.
+
+For **macOS**: Add the CA to **Keychain Access** and mark it as trusted.
+
+For **Linux**: Copy the CA to **/usr/local/share/ca-certificates/** and **run sudo update-ca-certificates**.
+
+
+## Steps to build the docker image of nginx for mathesar service is as follows (Production environment)
+
+Generate the certs using any standard format. Once available, pls. update the Dockerfile.nginx with cert location from where they have to be copied on to docker volume and update the relative paths in the nginx.conf if you wish so. 


### PR DESCRIPTION
Fixes https://github.com/mathesar-foundation/mathesar/issues/3601

This OR has been opeend to address the issue ID# 360. 

By following the steps mentioned in the steps_for_using_nginx we should be able to run the nginx reverse proxy in local/prod environments. 

If you are comfortable with the change, we can enrich this to handle SWAG reverse proxy as well (since it uses nginx under the hood)