### PR TITLE
Make `records.get` work with stringified PK values

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -4775,10 +4775,14 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+DROP FUNCTION IF EXISTS msar.get_record_from_table(oid, anyelement);
+DROP FUNCTION IF EXISTS msar.get_record_from_table(oid, anyelement, boolean);
+DROP FUNCTION IF EXISTS msar.get_record_from_table(oid, text, boolean);
+DROP FUNCTION IF EXISTS msar.get_record_from_table(oid, numeric, boolean);
 CREATE OR REPLACE FUNCTION
 msar.get_record_from_table(
   tab_id oid,
-  rec_id anyelement,
+  rec_id text,
   return_record_summaries boolean DEFAULT false
 ) RETURNS jsonb AS $$/*
 Get single record from a table. Only columns to which the user has access are returned.
@@ -4802,6 +4806,14 @@ SELECT msar.list_records_from_table(
 )
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
 
+CREATE OR REPLACE FUNCTION
+msar.get_record_from_table(
+  tab_id oid,
+  rec_id numeric,
+  return_record_summaries boolean DEFAULT false
+) RETURNS jsonb AS $$
+SELECT msar.get_record_from_table(tab_id, rec_id::text, return_record_summaries);
+$$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION
 msar.delete_records_from_table(tab_id oid, rec_ids jsonb) RETURNS integer AS $$/*

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -3957,41 +3957,17 @@ DECLARE
 BEGIN
   PERFORM __setup_list_records_table();
   rel_id := 'atable'::regclass::oid;
+  
+  -- We should be able to retrieve a single record
   RETURN NEXT is(
-    msar.get_record_from_table(rel_id, 2),
-    $j${
-      "count": 1,
-      "results": [
-        {"1": 2, "2": 34, "3": "sdflfflsk", "4": null, "5": [1, 2, 3, 4]}
-      ],
-      "grouping": null,
-      "linked_record_summaries": null,
-      "record_summaries": null
-    }$j$ || jsonb_build_object(
-      'query', concat(
-        'SELECT msar.format_data(id) AS "1", msar.format_data(col1) AS "2",',
-        ' msar.format_data(col2) AS "3", msar.format_data(col3) AS "4",',
-        ' msar.format_data(col4) AS "5" FROM public.atable WHERE (id) = (''2'')',
-        ' ORDER BY "1" ASC LIMIT NULL OFFSET NULL'
-      )
-    )
+    msar.get_record_from_table(rel_id, 2) -> 'results',
+    '[{"1": 2, "2": 34, "3": "sdflfflsk", "4": null, "5": [1, 2, 3, 4]}]'::jsonb
   );
+
+  -- We should get an empty array if the record does not exist
   RETURN NEXT is(
-    msar.get_record_from_table(rel_id, 200),
-    $j${
-      "count": 0,
-      "results": [],
-      "grouping": null,
-      "linked_record_summaries": null,
-      "record_summaries": null
-    }$j$ || jsonb_build_object(
-      'query', concat(
-        'SELECT msar.format_data(id) AS "1", msar.format_data(col1) AS "2",',
-        ' msar.format_data(col2) AS "3", msar.format_data(col3) AS "4",',
-        ' msar.format_data(col4) AS "5" FROM public.atable WHERE (id) = (''200'')',
-        ' ORDER BY "1" ASC LIMIT NULL OFFSET NULL'
-      )
-    )
+    msar.get_record_from_table(rel_id, 200) -> 'results',
+    '[]'::jsonb
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -3954,21 +3954,27 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION test_get_record_from_table() RETURNS SETOF TEXT AS $$
 DECLARE
   rel_id oid;
+  record_2_results jsonb := '[
+    {
+      "1": 2,
+      "2": 34,
+      "3": "sdflfflsk",
+      "4": null,
+      "5": [1, 2, 3, 4]
+    }
+  ]'::jsonb;
 BEGIN
   PERFORM __setup_list_records_table();
   rel_id := 'atable'::regclass::oid;
   
   -- We should be able to retrieve a single record
-  RETURN NEXT is(
-    msar.get_record_from_table(rel_id, 2) -> 'results',
-    '[{"1": 2, "2": 34, "3": "sdflfflsk", "4": null, "5": [1, 2, 3, 4]}]'::jsonb
-  );
+  RETURN NEXT is(msar.get_record_from_table(rel_id, 2) -> 'results', record_2_results);
+
+  -- We should be able to retrieve a record via stringified primary key
+  RETURN NEXT is(msar.get_record_from_table(rel_id, '2') -> 'results', record_2_results);
 
   -- We should get an empty array if the record does not exist
-  RETURN NEXT is(
-    msar.get_record_from_table(rel_id, 200) -> 'results',
-    '[]'::jsonb
-  );
+  RETURN NEXT is(msar.get_record_from_table(rel_id, 200) -> 'results', '[]'::jsonb);
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION

Fixes #3844


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

