### PR TITLE
Implement `roles.set_members` RPC endpoint

### DIFF
--- a/db/roles/operations/membership.py
+++ b/db/roles/operations/membership.py
@@ -1,0 +1,5 @@
+from db.connection import exec_msar_func
+
+
+def set_members_to_role(parent_role_oid, members, conn):
+    return exec_msar_func(conn, 'set_members_to_role', parent_role_oid, members).fetchone()[0]

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1193,6 +1193,68 @@ $$ LANGUAGE SQL STABLE;
 
 
 CREATE OR REPLACE FUNCTION
+msar.build_grant_membership_expr(parent_rol_id regrole, g_roles bigint[]) RETURNS TEXT AS $$
+SELECT string_agg(
+  format(
+    'GRANT %1$s TO %2$s',
+    msar.get_role_name(parent_rol_id),
+    msar.get_role_name(rol_id)
+  ),
+  E';\n'
+) || E';\n'
+FROM unnest(g_roles) as x(rol_id);
+$$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
+
+
+CREATE OR REPLACE FUNCTION
+msar.build_revoke_membership_expr(parent_rol_id regrole, r_roles bigint[]) RETURNS TEXT AS $$
+SELECT string_agg(
+  format(
+    'REVOKE %1$s FROM %2$s',
+    msar.get_role_name(parent_rol_id),
+    msar.get_role_name(rol_id)
+  ),
+  E';\n'
+) || E';\n'
+FROM unnest(r_roles) as x(rol_id);
+$$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
+
+
+CREATE OR REPLACE FUNCTION msar.set_members_to_role(parent_rol_id regrole, members bigint[]) RETURNS jsonb AS $$
+DECLARE
+  parent_role_info jsonb := msar.get_role(parent_rol_id::regrole::text);
+  all_members_array bigint[];
+  revoke_members_array bigint[];
+  set_members_expr text;
+BEGIN
+  -- Get all the members of parent_role.
+  SELECT array_agg(x.oid)
+    FROM jsonb_to_recordset(
+      CASE WHEN parent_role_info ->> 'members' IS NOT NULL
+      THEN parent_role_info -> 'members'
+      ELSE NULL END
+    ) AS x(oid oid, admin boolean)
+  INTO all_members_array;
+  -- Find all the roles whose membership we want to revoke.
+  SELECT ARRAY(
+    SELECT unnest(all_members_array)
+    EXCEPT
+    SELECT unnest(members)
+  ) INTO revoke_members_array;
+  -- REVOKE/GRANT membership for parent_role.
+  set_members_expr := concat_ws(
+    E'\n',
+    msar.build_revoke_membership_expr(parent_rol_id, revoke_members_array),
+    msar.build_grant_membership_expr(parent_rol_id, members)
+  );
+  EXECUTE set_members_expr;
+  -- Return the updated parent_role info including membership details.
+  RETURN msar.get_role(parent_rol_id::regrole::text);
+END;
+$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
+
+CREATE OR REPLACE FUNCTION
 msar.get_current_role() RETURNS jsonb AS $$/*
 Returns a JSON object describing the current_role and the parent role(s) whose
 privileges are immediately available to current_role without doing SET ROLE.

--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -256,6 +256,7 @@ To use an RPC function:
       - add
       - delete
       - get_current_role
+      - set_members
       - RoleInfo
       - RoleMember
 

--- a/mathesar/rpc/roles/base.py
+++ b/mathesar/rpc/roles/base.py
@@ -178,7 +178,7 @@ def set_members(
     Grant/Revoke direct membership to/from roles.
 
     Args:
-      parent_rol_id: The OID of role whose membership will be granted/revoked to/from other roles.
+      parent_role_oid: The OID of role whose membership will be granted/revoked to/from other roles.
       members: An array of role OID(s) whom we want to grant direct membership of the parent role.
                Only the OID(s) present in the array will be granted membership of parent role,
                Membership will be revoked for existing members not present in this array.

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -275,6 +275,11 @@ METHODS = [
         "roles.get_current_role",
         [user_is_authenticated]
     ),
+    (
+        roles.set_members,
+        "roles.set_members",
+        [user_is_authenticated]
+    ),
 
     (
         roles.configured.add,

--- a/mathesar/tests/rpc/test_roles.py
+++ b/mathesar/tests/rpc/test_roles.py
@@ -187,3 +187,45 @@ def test_get_current_role(rf, monkeypatch):
     monkeypatch.setattr(roles.base, 'connect', mock_connect)
     monkeypatch.setattr(roles.base, 'get_current_role_from_db', mock_get_current_role)
     roles.get_current_role(database_id=_database_id, request=request)
+
+
+def test_roles_set_members(rf, monkeypatch):
+    _username = 'alice'
+    _password = 'pass1234'
+    _database_id = 2
+    _parent_role_oid = 10
+    _members = [2573031, 2573040]
+    request = rf.post('/api/rpc/v0/', data={})
+    request.user = User(username=_username, password=_password)
+
+    @contextmanager
+    def mock_connect(database_id, user):
+        if database_id == _database_id and user.username == _username:
+            try:
+                yield True
+            finally:
+                pass
+        else:
+            raise AssertionError('incorrect parameters passed')
+
+    def mock_set_roles(parent_role_oid, members, conn):
+        if (
+            parent_role_oid != _parent_role_oid
+            or members != _members
+        ):
+            raise AssertionError('incorrect parameters passed')
+        return {
+            'oid': 10,
+            'name': 'mathesar',
+            'login': True,
+            'super': True,
+            'members': [{'oid': 2573031, 'admin': False}, {'oid': 2573040, 'admin': False}],
+            'inherits': True,
+            'create_db': True,
+            'create_role': True,
+            'description': None
+        }
+
+    monkeypatch.setattr(roles.base, 'connect', mock_connect)
+    monkeypatch.setattr(roles.base, 'set_members_to_role', mock_set_roles)
+    roles.set_members(parent_role_oid=_parent_role_oid, database_id=_database_id, members=_members, request=request)

--- a/mathesar_ui/src/api/rpc/roles.ts
+++ b/mathesar_ui/src/api/rpc/roles.ts
@@ -47,7 +47,7 @@ export const roles = {
   set_members: rpcMethodTypeContainer<
     {
       database_id: RawDatabase['id'];
-      role_oid: RawRole['oid'];
+      parent_role_oid: RawRole['oid'];
       members: RawRole['oid'][];
     },
     RawRole

--- a/mathesar_ui/src/models/Role.ts
+++ b/mathesar_ui/src/models/Role.ts
@@ -85,7 +85,7 @@ export class Role {
     const promise = api.roles
       .set_members({
         database_id: this.database.id,
-        role_oid: this.oid,
+        parent_role_oid: this.oid,
         members: [...memberOids],
       })
       .run();


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3733

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
