### PR TITLE
Get explorations CRUD working again

### DIFF
--- a/mathesar/views.py
+++ b/mathesar/views.py
@@ -8,6 +8,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from mathesar.rpc.databases.configured import list_ as databases_list
+from mathesar.rpc.explorations import list_ as explorations_list
 from mathesar.rpc.schemas import list_ as schemas_list
 from mathesar.rpc.servers.configured import list_ as get_servers_list
 from mathesar.rpc.tables import list_with_metadata as tables_list
@@ -44,9 +45,8 @@ def get_table_list(request, database_id, schema_oid):
         return []
 
 
-def get_queries_list(request, schema_id):
-    # TODO_BETA: Fill this method
-    return []
+def get_queries_list(request, database_id, schema_id):
+    return explorations_list(request=request, database_id=database_id, schema_oid=schema_id)
 
 
 def get_ui_type_list(request, database_id):
@@ -104,7 +104,7 @@ def get_common_data(request, database_id=None, schema_id=None):
     return {
         **_get_base_data_all_routes(request, database_id, schema_id),
         'tables': get_table_list(request, database_id, schema_id),
-        'queries': get_queries_list(request, schema_id),
+        'queries': get_queries_list(request, database_id, schema_id),
         'routing_context': 'normal',
     }
 

--- a/mathesar_ui/src/pages/schema/SchemaOverview.svelte
+++ b/mathesar_ui/src/pages/schema/SchemaOverview.svelte
@@ -10,7 +10,7 @@
   import type { Schema } from '@mathesar/models/Schema';
   import type { Table } from '@mathesar/models/Table';
   import { getDataExplorerPageUrl } from '@mathesar/routes/urls';
-  import { refetchQueriesForSchema } from '@mathesar/stores/queries';
+  import { refetchExplorationsForSchema } from '@mathesar/stores/queries';
   import { refetchTablesForSchema } from '@mathesar/stores/tables';
   import { AnchorButton, Button } from '@mathesar-component-library';
 
@@ -88,7 +88,7 @@
           <div>
             <SpinnerButton
               onClick={async () => {
-                await refetchQueriesForSchema(schema.oid);
+                await refetchExplorationsForSchema(schema);
               }}
               label={$_('retry')}
               icon={iconRefresh}

--- a/mathesar_ui/src/routes/DataExplorerRoute.svelte
+++ b/mathesar_ui/src/routes/DataExplorerRoute.svelte
@@ -4,8 +4,8 @@
   import { router } from 'tinro';
 
   import type {
+    MaybeSavedExploration,
     SavedExploration,
-    UnsavedExploration,
   } from '@mathesar/api/rpc/explorations';
   import type { CancellablePromise } from '@mathesar/component-library';
   import AppendBreadcrumb from '@mathesar/components/breadcrumb/AppendBreadcrumb.svelte';
@@ -19,7 +19,7 @@
     getExplorationEditorPageUrl,
   } from '@mathesar/routes/urls';
   import { abstractTypesMap } from '@mathesar/stores/abstract-types';
-  import { getQuery } from '@mathesar/stores/queries';
+  import { getExploration } from '@mathesar/stores/queries';
   import {
     QueryManager,
     QueryModel,
@@ -36,7 +36,7 @@
   let queryLoadPromise: CancellablePromise<SavedExploration>;
   let query: Readable<QueryModel | undefined> = readable(undefined);
 
-  function createQueryManager(queryInstance: UnsavedExploration) {
+  function createQueryManager(queryInstance: MaybeSavedExploration) {
     queryManager?.destroy();
     queryManager = new QueryManager({
       query: new QueryModel(queryInstance),
@@ -80,6 +80,7 @@
         router.location.hash.clear();
         createQueryManager({
           database_id: database.id,
+          schema_oid: schema.oid,
           ...(newQueryModel ?? {}),
         });
         return;
@@ -88,7 +89,7 @@
         console.error('Unable to create query model from hash', hash);
       }
     }
-    createQueryManager({ database_id: database.id });
+    createQueryManager({ database_id: database.id, schema_oid: schema.oid });
   }
 
   async function loadSavedQuery(_queryId: number) {
@@ -103,7 +104,7 @@
     }
 
     queryLoadPromise?.cancel();
-    queryLoadPromise = getQuery(_queryId);
+    queryLoadPromise = getExploration(_queryId);
     try {
       const queryInstance = await queryLoadPromise;
       createQueryManager(queryInstance);

--- a/mathesar_ui/src/systems/data-explorer/QueryListEntry.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryListEntry.ts
@@ -1,7 +1,7 @@
-import type { UnsavedExploration } from '@mathesar/api/rpc/explorations';
+import type { MaybeSavedExploration } from '@mathesar/api/rpc/explorations';
 
 export default class QueryListEntry {
-  queryJSON: UnsavedExploration;
+  queryJSON: MaybeSavedExploration;
 
   isValid: boolean;
 
@@ -9,7 +9,7 @@ export default class QueryListEntry {
 
   prev: QueryListEntry | undefined = undefined;
 
-  constructor(queryJSON: UnsavedExploration, isValid: boolean) {
+  constructor(queryJSON: MaybeSavedExploration, isValid: boolean) {
     this.queryJSON = queryJSON;
     this.isValid = isValid;
   }

--- a/mathesar_ui/src/systems/data-explorer/QueryModel.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryModel.ts
@@ -1,9 +1,9 @@
 import type {
   AnonymousExploration,
   InitialColumn,
+  MaybeSavedExploration,
   QueryInstanceTransformation,
   SavedExploration,
-  UnsavedExploration,
 } from '@mathesar/api/rpc/explorations';
 import { assertExhaustive } from '@mathesar-component-library';
 
@@ -22,7 +22,7 @@ export interface QueryModelUpdateDiff {
     | 'initialColumnName'
     | 'transformations'
     | 'initialColumnsAndTransformations';
-  diff: Partial<UnsavedExploration>;
+  diff: Partial<MaybeSavedExploration>;
 }
 
 export type QueryTransformationModel =
@@ -61,15 +61,17 @@ function validate(
 }
 
 export default class QueryModel {
-  readonly database_id: UnsavedExploration['database_id'];
+  readonly database_id: MaybeSavedExploration['database_id'];
 
-  readonly base_table_oid: UnsavedExploration['base_table_oid'];
+  readonly schema_oid: MaybeSavedExploration['schema_oid'];
 
-  readonly id: UnsavedExploration['id'];
+  readonly base_table_oid: MaybeSavedExploration['base_table_oid'];
 
-  readonly name: UnsavedExploration['name'];
+  readonly id: MaybeSavedExploration['id'];
 
-  readonly description: UnsavedExploration['description'];
+  readonly name: MaybeSavedExploration['name'];
+
+  readonly description: MaybeSavedExploration['description'];
 
   readonly initial_columns: InitialColumn[];
 
@@ -81,8 +83,9 @@ export default class QueryModel {
 
   readonly isRunnable: boolean;
 
-  constructor(model: UnsavedExploration | QueryModel) {
+  constructor(model: MaybeSavedExploration | QueryModel) {
     this.database_id = model.database_id;
+    this.schema_oid = model.schema_oid;
     this.base_table_oid = model.base_table_oid;
     this.id = model.id;
     this.name = model.name;
@@ -108,6 +111,7 @@ export default class QueryModel {
   withBaseTable(base_table?: number): QueryModelUpdateDiff {
     const model = new QueryModel({
       database_id: this.database_id,
+      schema_oid: this.schema_oid,
       base_table_oid: base_table,
       id: this.id,
       name: this.name,
@@ -235,7 +239,7 @@ export default class QueryModel {
       model,
       type: 'transformations',
       diff: {
-        transformations: model.toJson().transformations,
+        transformations: model.toMaybeSavedExploration().transformations,
       },
     };
   }
@@ -279,7 +283,7 @@ export default class QueryModel {
       model,
       type: 'transformations',
       diff: {
-        transformations: model.toJson().transformations,
+        transformations: model.toMaybeSavedExploration().transformations,
       },
     };
   }
@@ -298,7 +302,7 @@ export default class QueryModel {
       model,
       type: 'transformations',
       diff: {
-        transformations: model.toJson().transformations,
+        transformations: model.toMaybeSavedExploration().transformations,
       },
     };
   }
@@ -382,7 +386,7 @@ export default class QueryModel {
       type: 'initialColumnsAndTransformations',
       diff: {
         initial_columns: initialColumns,
-        transformations: model.toJson().transformations,
+        transformations: model.toMaybeSavedExploration().transformations,
       },
     };
   }
@@ -447,6 +451,7 @@ export default class QueryModel {
       : this.transformationModels.filter((transform) => transform.isValid());
     return {
       database_id: this.database_id,
+      schema_oid: this.schema_oid,
       base_table_oid: this.base_table_oid,
       initial_columns: this.initial_columns,
       transformations: transformations.map((entry) => entry.toJson()),
@@ -458,9 +463,10 @@ export default class QueryModel {
     return this.initial_columns.filter((entry) => entry.attnum === id).length;
   }
 
-  toJson(): UnsavedExploration {
+  toMaybeSavedExploration(): MaybeSavedExploration {
     return {
       database_id: this.database_id,
+      schema_oid: this.schema_oid,
       id: this.id,
       name: this.name,
       description: this.description,

--- a/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
@@ -13,7 +13,7 @@ import Plane from '@mathesar/components/sheet/selection/Plane';
 import Series from '@mathesar/components/sheet/selection/Series';
 import SheetSelectionStore from '@mathesar/components/sheet/selection/SheetSelectionStore';
 import type { AbstractTypesMap } from '@mathesar/stores/abstract-types/types';
-import { fetchQueryResults } from '@mathesar/stores/queries';
+import { runSavedExploration } from '@mathesar/stores/queries';
 import Pagination from '@mathesar/utils/Pagination';
 import type { ShareConsumer } from '@mathesar/utils/shares';
 import { CancellablePromise, ImmutableMap } from '@mathesar-component-library';
@@ -188,7 +188,7 @@ export default class QueryRunner {
           });
           return undefined;
         }
-        this.runPromise = fetchQueryResults(queryModel.id, {
+        this.runPromise = runSavedExploration(queryModel.id, {
           ...paginationParams,
           ...this.shareConsumer?.getQueryParams(),
         });

--- a/mathesar_ui/src/systems/data-explorer/QueryUndoRedoManager.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryUndoRedoManager.ts
@@ -1,4 +1,4 @@
-import type { UnsavedExploration } from '@mathesar/api/rpc/explorations';
+import type { MaybeSavedExploration } from '@mathesar/api/rpc/explorations';
 
 import QueryListEntry from './QueryListEntry';
 import QueryModel from './QueryModel';
@@ -10,8 +10,8 @@ export default class QueryUndoRedoManager {
     if (queryInfo) {
       const { query, isValid } = queryInfo;
       const json = JSON.parse(
-        JSON.stringify(query.toJson()),
-      ) as UnsavedExploration;
+        JSON.stringify(query.toMaybeSavedExploration()),
+      ) as MaybeSavedExploration;
       this.current = new QueryListEntry(json, isValid);
     }
   }
@@ -21,8 +21,8 @@ export default class QueryUndoRedoManager {
       this.current.next.prev = undefined;
     }
     const json = JSON.parse(
-      JSON.stringify(query.toJson()),
-    ) as UnsavedExploration;
+      JSON.stringify(query.toMaybeSavedExploration()),
+    ) as MaybeSavedExploration;
     const newNode = new QueryListEntry(json, isValid);
     if (this.current && !this.current.isValid) {
       newNode.prev = this.current.prev;

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationTab.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationTab.svelte
@@ -7,7 +7,11 @@
   import FormField from '@mathesar/components/FormField.svelte';
   import { iconDeleteMajor } from '@mathesar/icons';
   import { confirmDelete } from '@mathesar/stores/confirmation';
-  import { deleteQuery, putQuery, queries } from '@mathesar/stores/queries';
+  import {
+    deleteExploration,
+    queries,
+    replaceExploration,
+  } from '@mathesar/stores/queries';
   import { toast } from '@mathesar/stores/toast';
   import { getAvailableName } from '@mathesar/utils/db';
   import {
@@ -74,7 +78,9 @@
         .withName(name)
         .model.withDescription(description).model;
       // TODO: Write better utility methods to identify saved instances
-      await putQuery(updatedQuery.toJson() as SavedExploration);
+      await replaceExploration(
+        updatedQuery.toMaybeSavedExploration() as SavedExploration,
+      );
       query.set(updatedQuery);
     } catch (err) {
       const message =
@@ -89,7 +95,7 @@
       void confirmDelete({
         identifierType: 'Exploration',
         onProceed: async () => {
-          await deleteQuery(queryId);
+          await deleteExploration(queryId);
           dispatch('delete');
         },
       });

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/TableActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/TableActions.svelte
@@ -37,6 +37,7 @@
       table.schema.oid,
       {
         databaseId: table.schema.database.id,
+        schemaOid: table.schema.oid,
         baseTable: table,
         columns: $columns,
         terseGrouping: $grouping.terse(),


### PR DESCRIPTION
Fixes #3865
Fixes #3621


This PR makes the front end changes necessary for explorations adding, replacing, getting, listing, and deleting to work. And it handles running saved explorations too.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

