### PR TITLE
Fixes server errors when RPC exceptions are thrown while rendering common_data

### DIFF
--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -54,18 +54,16 @@ urlpatterns = [
     path('administration/users/', views.admin_home, name='admin_users_home'),
     path('administration/users/<int:user_id>/', views.admin_home, name='admin_users_edit'),
     path('administration/update/', views.admin_home, name='admin_update'),
-    path('shares/tables/<slug>/', views.shared_table, name='shared_table'),
-    path('shares/explorations/<slug>/', views.shared_query, name='shared_query'),
-    path('databases/', views.databases, name='databases'),
+    path('databases/', views.databases_list_route, name='databases_list_route'),
     path('i18n/', include('django.conf.urls.i18n')),
     re_path(
         r'^db/(?P<database_id>\d+)/schemas/(?P<schema_id>\d+)/',
-        views.schemas_home,
-        name='schema_home'
+        views.schema_route,
+        name='schema_route'
     ),
     re_path(
         r'^db/(?P<database_id>\d+)/((schemas|settings)/)?',
-        views.schemas,
-        name='schemas'
+        views.database_route,
+        name='database_route'
     ),
 ]

--- a/mathesar/views.py
+++ b/mathesar/views.py
@@ -1,8 +1,11 @@
+from functools import wraps
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render, redirect
 from modernrpc.views import RPCEntryPoint
+from modernrpc.exceptions import RPCException
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -12,15 +15,35 @@ from mathesar.rpc.explorations import list_ as explorations_list
 from mathesar.rpc.schemas import list_ as schemas_list
 from mathesar.rpc.servers.configured import list_ as get_servers_list
 from mathesar.rpc.tables import list_with_metadata as tables_list
-from mathesar.api.serializers.tables import TableSerializer
-from mathesar.api.serializers.queries import QuerySerializer
 from mathesar.api.ui.serializers.users import UserSerializer
-from mathesar.api.utils import is_valid_uuid_v4
-from mathesar.models.shares import SharedTable, SharedQuery
 from mathesar.state import reset_reflection
 from mathesar import __version__
 
 
+def get_database_list(request):
+    return databases_list(request=request)
+
+
+def wrap_data_and_rpc_exceptions(f):
+    @wraps(f)
+    def safe_func(*args, **kwargs):
+        try:
+            return {
+                'state': 'success',
+                'data': f(*args, **kwargs)
+            }
+        except RPCException as exp:
+            return {
+                'state': 'failure',
+                'error': {
+                    'code': exp.code,
+                    'message': exp.message
+                }
+            }
+    return safe_func
+
+
+@wrap_data_and_rpc_exceptions
 def get_schema_list(request, database_id):
     if database_id is not None:
         return schemas_list(request=request, database_id=database_id)
@@ -28,10 +51,7 @@ def get_schema_list(request, database_id):
         return []
 
 
-def get_database_list(request):
-    return databases_list(request=request)
-
-
+@wrap_data_and_rpc_exceptions
 def get_table_list(request, database_id, schema_oid):
     if database_id is not None and schema_oid is not None:
         return tables_list(
@@ -76,71 +96,32 @@ def _get_internal_db_meta():
         return {'type': 'sqlite'}
 
 
-def _get_base_data_all_routes(request, database_id=None, schema_id=None):
+def get_common_data(request, database_id=None, schema_oid=None):
+    databases = get_database_list(request)
+    database_id_int = int(database_id) if database_id else None
+    current_database = next((database for database in databases if database['id'] == database_id_int), None)
+    current_database_id = current_database['id'] if current_database else None
+
+    schemas = get_schema_list(request, current_database_id)
+    schema_oid_int = int(schema_oid) if schema_oid else None
+    schemas_data = schemas['data'] if 'data' in schemas else []
+    current_schema = next((schema for schema in schemas_data if schema['oid'] == schema_oid_int), None)
+    current_schema_oid = current_schema['oid'] if current_schema else None
+
     return {
-        'current_database': int(database_id) if database_id else None,
-        'current_schema': int(schema_id) if schema_id else None,
+        'current_database': current_database_id,
+        'current_schema': current_schema_oid,
         'current_release_tag_name': __version__,
-        'databases': get_database_list(request),
-        'servers': get_servers_list(),
+        'databases': databases,
         'internal_db': _get_internal_db_meta(),
         'is_authenticated': not request.user.is_anonymous,
-        'queries': [],
-        'schemas': get_schema_list(request, database_id),
+        'servers': get_servers_list(),
+        'schemas': schemas,
         'supported_languages': dict(getattr(settings, 'LANGUAGES', [])),
-        'tables': [],
-        'user': get_user_data(request)
-    }
-
-
-def get_common_data(request, database_id=None, schema_id=None):
-    return {
-        **_get_base_data_all_routes(request, database_id, schema_id),
-        'tables': get_table_list(request, database_id, schema_id),
-        'queries': get_queries_list(request, database_id, schema_id),
+        'tables': get_table_list(request, current_database_id, current_schema_oid),
+        'user': get_user_data(request),
+        'queries': get_queries_list(request, current_database_id, current_schema_oid),
         'routing_context': 'normal',
-    }
-
-
-def get_common_data_for_shared_entity(request, schema=None):
-    # TODO: Provide only authorized schemas & databases
-    # database = schema.database if schema else None
-    # schemas = [schema] if schema else []
-    # databases = [database] if database else []
-    return {
-        # **_get_base_data_all_routes(request, database, schema),
-        # 'schemas': serialized_schemas,
-        # 'databases': serialized_databases,
-        **_get_base_data_all_routes(request),
-        'routing_context': 'anonymous',
-    }
-
-
-def get_common_data_for_shared_table(request, table):
-    tables = [table] if table else []
-    serialized_tables = TableSerializer(
-        tables,
-        many=True,
-        context={'request': request}
-    ).data
-    schema = table.schema if table else None
-    return {
-        **get_common_data_for_shared_entity(request, schema),
-        'tables': serialized_tables,
-    }
-
-
-def get_common_data_for_shared_query(request, query):
-    queries = [query] if query else []
-    serialized_queries = QuerySerializer(
-        queries,
-        many=True,
-        context={'request': request}
-    ).data
-    schema = query.base_table.schema if query else None
-    return {
-        **get_common_data_for_shared_entity(request, schema),
-        'queries': serialized_queries,
     }
 
 
@@ -160,10 +141,10 @@ def home(request):
     database_list = get_database_list(request)
     number_of_databases = len(database_list)
     if number_of_databases > 1:
-        return redirect('databases')
+        return redirect('databases_list_route')
     elif number_of_databases == 1:
         db = database_list[0]
-        return redirect('schemas', database_id=db['id'])
+        return redirect('database_route', database_id=db['id'])
     else:
         return render(request, 'mathesar/index.html', {
             'common_data': get_common_data(request)
@@ -171,7 +152,7 @@ def home(request):
 
 
 @login_required
-def databases(request):
+def databases_list_route(request):
     return render(request, 'mathesar/index.html', {
         'common_data': get_common_data(request)
     })
@@ -192,40 +173,16 @@ def admin_home(request, **kwargs):
 
 
 @login_required
-def schemas(request, database_id, **kwargs):
+def database_route(request, database_id, **kwargs):
     return render(request, 'mathesar/index.html', {
         'common_data': get_common_data(request, database_id, None)
     })
 
 
 @login_required
-def schemas_home(request, database_id, schema_id, **kwargs):
+def schema_route(request, database_id, schema_id, **kwargs):
     return render(request, 'mathesar/index.html', {
         'common_data': get_common_data(request, database_id, schema_id)
-    })
-
-
-def shared_table(request, slug):
-    shared_table_link = SharedTable.get_by_slug(slug) if is_valid_uuid_v4(slug) else None
-    table = shared_table_link.table if shared_table_link else None
-
-    return render(request, 'mathesar/index.html', {
-        'common_data': get_common_data_for_shared_table(request, table),
-        'route_specific_data': {
-            'shared_table': {'table_id': table.id if table else None}
-        }
-    })
-
-
-def shared_query(request, slug):
-    shared_query_link = SharedQuery.get_by_slug(slug) if is_valid_uuid_v4(slug) else None
-    query = shared_query_link.query if shared_query_link else None
-
-    return render(request, 'mathesar/index.html', {
-        'common_data': get_common_data_for_shared_query(request, query),
-        'route_specific_data': {
-            'shared_query': {'query_id': query.id if query else None}
-        }
     })
 
 

--- a/mathesar_ui/src/stores/schemas.ts
+++ b/mathesar_ui/src/stores/schemas.ts
@@ -152,7 +152,18 @@ export const schemas = collapse(
     const $schemasStore = get(schemasStore);
     if ($schemasStore.databaseId !== $currentDatabase?.id) {
       if (preload && commonData.current_database === $currentDatabase?.id) {
-        setSchemasInStore($currentDatabase, commonData.schemas);
+        if (commonData.schemas.state === 'success') {
+          setSchemasInStore($currentDatabase, commonData.schemas.data);
+        } else {
+          schemasStore.set({
+            databaseId: $currentDatabase.id,
+            requestStatus: {
+              state: 'failure',
+              errors: [getErrorMessage(commonData.schemas.error)],
+            },
+            data: new Map(),
+          });
+        }
       } else {
         void fetchSchemasForCurrentDatabase();
       }

--- a/mathesar_ui/src/stores/tables.ts
+++ b/mathesar_ui/src/stores/tables.ts
@@ -395,7 +395,19 @@ export const currentTablesData = collapse(
         commonData.current_schema === $currentSchema?.oid &&
         commonData.current_database === $currentSchema?.database.id
       ) {
-        setTablesStore($currentSchema, commonData.tables);
+        if (commonData.tables.state === 'success') {
+          setTablesStore($currentSchema, commonData.tables.data);
+        } else {
+          tablesStore.set({
+            databaseId: $currentSchema.database.id,
+            schemaOid: $currentSchema.oid,
+            tablesMap: new Map(),
+            requestStatus: {
+              state: 'failure',
+              errors: [getErrorMessage(commonData.tables.error)],
+            },
+          });
+        }
       } else {
         void fetchTablesForCurrentSchema();
       }

--- a/mathesar_ui/src/utils/preloadData.ts
+++ b/mathesar_ui/src/utils/preloadData.ts
@@ -5,11 +5,24 @@ import type { RawSchema } from '@mathesar/api/rpc/schemas';
 import type { RawServer } from '@mathesar/api/rpc/servers';
 import type { RawTableWithMetadata } from '@mathesar/api/rpc/tables';
 
+type WithStatus<D> =
+  | {
+      state: 'success';
+      data: D;
+    }
+  | {
+      state: 'failure';
+      error: {
+        code: number;
+        message: string;
+      };
+    };
+
 export interface CommonData {
   databases: RawDatabase[];
   servers: RawServer[];
-  schemas: RawSchema[];
-  tables: RawTableWithMetadata[];
+  schemas: WithStatus<RawSchema[]>;
+  tables: WithStatus<RawTableWithMetadata[]>;
   queries: SavedExploration[];
   current_database: RawDatabase['id'] | null;
   internal_db: {


### PR DESCRIPTION
Fixes #3903 

This PR fixes a few bugs that arise due to RPC exceptions while rendering common_data:
* 500 while starting Mathesar when only one database is present and the admin is not a collaborator on it.
* 500 when opening urls for objects that're not present such as `/db/10000/schemas` or `/db/10000/schemas/12000/` (assuming the database `10000` and schema `12000` are not present).
  - Note: This happens when directly modifying the browser url.
* 500 when opening a url for a database that the Mathesar admin is not a collaborator of.
  - Note: This happens when directly modifying the browser url.

The PR also removes the shares urls since I didn't want to spend time refactoring them.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
