### PR TITLE
Bugfix msar.set_members

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1246,7 +1246,8 @@ Args:
            Membership will be revoked for existing members not present in this array.
 */
 DECLARE
-  parent_role_info jsonb := msar.get_role(parent_rol_id::regrole::text);
+  parent_role_name text := msar.get_role_name(parent_rol_id);
+  parent_role_info jsonb := msar.get_role(parent_role_name);
   all_members_array bigint[];
   revoke_members_array bigint[];
   set_members_expr text;
@@ -1273,7 +1274,7 @@ BEGIN
   );
   EXECUTE set_members_expr;
   -- Return the updated parent_role info including membership details.
-  RETURN msar.get_role(parent_rol_id::regrole::text);
+  RETURN msar.get_role(parent_role_name);
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- Concisely describe what the pull request does. -->

https://github.com/user-attachments/assets/0af62654-b598-4f7a-9b45-c57d4569957b


**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
We were using quoted name as the input for `msar.get_role` in `msar.set_members_for_role`, This PR changes that behavior and passes the unquoted unqoted name to `msar.get_role` instead.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
