### PR TITLE
Fix browser console warnings

### DIFF
--- a/mathesar_ui/src/component-library/common/utils/EventHandler.ts
+++ b/mathesar_ui/src/component-library/common/utils/EventHandler.ts
@@ -40,13 +40,7 @@ export default class EventHandler<Events extends Record<string, unknown>> {
     value?: Events[EventName],
   ): Promise<void> {
     const callbacks = this.listeners.get(eventName);
-    if (!callbacks) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `No listeners found when dispatching event '${String(eventName)}'.`,
-      );
-      return;
-    }
+    if (!callbacks) return;
     await Promise.all(
       [...callbacks.values()].map((callback) => callback(value)),
     );


### PR DESCRIPTION
Fixes #3929

## Notes

- This PR removes the code that throws console warnings. I don't think we need the warnings. I think it's okay if an event gets called on an EventHandler when not listeners are attached.

- The EventHandler subclass is defined in `SheetSelectionStore.ts`, and its event is (expectedly) called `'focus'`. A `SheetSelectionStore` instance dispatches this event to pass a message to its containing scope that the active cell should be imperatively focused via browser DOM APIs.

- The event dispatch code is in `SheetSelectionStore.ts`

    ```ts
    this.selection = new PreventableEffectsStore(new SheetSelection(), {
      focus: () => this.focus(), // which calls `void this.dispatch('focus');`
    });
    ```

    Due to the way that `PreventableEffectsStore` works, the focus event gets dispatched (almost) whenever `this.selection` changes.
    
    (I say "almost" because it's also possible to update the selection while _preventing_ that effect, which is necessary in a couple places and probably not relevant to explain here.)

- The event handler function is in `Sheet.svelte`:

    ```ts
    onMount(() =>
      selection?.on('focus', async () => {
        if (!sheetElement) return;
        await tick();
        focusActiveCell(sheetElement);
      }),
    );
    ```

    Without that event handler code, the active cell would not get focused when the selection changes via the keyboard arrow keys.

- The reason the event gets dispatched before it has any listeners/handlers is that we're holding a `SheetSelectionStore` instance higher up in the component tree and passing it down into `Sheet`. So the selection ends up getting updated before the `Sheet` component is mounted. I think this is fine and we can safely ignore it.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>




  