### PR TITLE
Improve front end linting

### DIFF
--- a/mathesar_ui/.eslintrc.cjs
+++ b/mathesar_ui/.eslintrc.cjs
@@ -48,9 +48,8 @@ module.exports = {
     'array-bracket-spacing': 'off',
     'no-restricted-syntax': 0,
     '@typescript-eslint/require-await': 'off',
-    // TODO_BETA: Add following eslint rules
-    // '@typescript-eslint/consistent-type-imports': 'error',
-    // 'no-duplicate-imports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    'no-duplicate-imports': 'error',
     'class-methods-use-this': 'off',
     'no-multiple-empty-lines': 1,
     'import/order': [

--- a/mathesar_ui/src/component-library/common/actions/clickOffBounds.ts
+++ b/mathesar_ui/src/component-library/common/actions/clickOffBounds.ts
@@ -1,6 +1,5 @@
 import type { ActionReturn } from 'svelte/action';
-import type { Readable } from 'svelte/store';
-import { get } from 'svelte/store';
+import { type Readable, get } from 'svelte/store';
 
 type CallbackFn = (e: Event) => void;
 interface Options {

--- a/mathesar_ui/src/component-library/common/utils/SortedImmutableMap.ts
+++ b/mathesar_ui/src/component-library/common/utils/SortedImmutableMap.ts
@@ -15,7 +15,7 @@ export default class SortedImmutableMap<Key, Value> extends ImmutableMap<
     this.sortFn = sortFn;
   }
 
-  protected getNewInstance(...args: any[]): this {
+  protected getNewInstance(...args: unknown[]): this {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     return new (this.constructor as any)(this.sortFn, ...args) as this;
   }

--- a/mathesar_ui/src/component-library/common/utils/WritableMap.ts
+++ b/mathesar_ui/src/component-library/common/utils/WritableMap.ts
@@ -1,10 +1,12 @@
-import type {
-  Readable,
-  Subscriber,
-  Unsubscriber,
-  Writable,
+import {
+  type Readable,
+  type Subscriber,
+  type Unsubscriber,
+  type Writable,
+  derived,
+  get,
+  writable,
 } from 'svelte/store';
-import { derived, get, writable } from 'svelte/store';
 
 import ImmutableMap from './ImmutableMap';
 

--- a/mathesar_ui/src/component-library/common/utils/WritableSet.ts
+++ b/mathesar_ui/src/component-library/common/utils/WritableSet.ts
@@ -1,10 +1,12 @@
-import type {
-  Readable,
-  Subscriber,
-  Unsubscriber,
-  Writable,
+import {
+  type Readable,
+  type Subscriber,
+  type Unsubscriber,
+  type Writable,
+  derived,
+  get,
+  writable,
 } from 'svelte/store';
-import { derived, get, writable } from 'svelte/store';
 
 import ImmutableSet from './ImmutableSet';
 

--- a/mathesar_ui/src/component-library/common/utils/__tests__/ruleExecutor.test.ts
+++ b/mathesar_ui/src/component-library/common/utils/__tests__/ruleExecutor.test.ts
@@ -1,5 +1,4 @@
-import type { Rule } from '../ruleExecuter';
-import { executeRule } from '../ruleExecuter';
+import { type Rule, executeRule } from '../ruleExecuter';
 
 describe('Rule executer', () => {
   test('Single term rule', () => {

--- a/mathesar_ui/src/component-library/common/utils/contextValidationUtil.ts
+++ b/mathesar_ui/src/component-library/common/utils/contextValidationUtil.ts
@@ -1,6 +1,5 @@
 import { getContext, hasContext, onDestroy, setContext } from 'svelte';
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 
 export type ValidationFunction = () => boolean;
 export type ValidationResultStore = Writable<boolean>;

--- a/mathesar_ui/src/component-library/common/utils/pauseableTweened.ts
+++ b/mathesar_ui/src/component-library/common/utils/pauseableTweened.ts
@@ -1,5 +1,4 @@
-import type { Tweened } from 'svelte/motion';
-import { tweened } from 'svelte/motion';
+import { type Tweened, tweened } from 'svelte/motion';
 import { get } from 'svelte/store';
 
 type Updater<T> = (target_value: T, value: T) => T;

--- a/mathesar_ui/src/component-library/confirmation/ConfirmationController.ts
+++ b/mathesar_ui/src/component-library/confirmation/ConfirmationController.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 
 import type { IconProps } from '@mathesar-component-library-dir/icon/IconTypes';
 import type { ModalController } from '@mathesar-component-library-dir/modal';

--- a/mathesar_ui/src/component-library/dropdown/AccompanyingElements.ts
+++ b/mathesar_ui/src/component-library/dropdown/AccompanyingElements.ts
@@ -1,5 +1,9 @@
-import type { Readable, Subscriber, Unsubscriber } from 'svelte/store';
-import { writable } from 'svelte/store';
+import {
+  type Readable,
+  type Subscriber,
+  type Unsubscriber,
+  writable,
+} from 'svelte/store';
 
 /**
  * AccompanyingElements stores references to any DOM nodes which "accompany" a

--- a/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
+++ b/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import type { SvelteComponent } from 'svelte';
 
-  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
-  import { getLabel as defaultGetLabel } from '@mathesar-component-library-dir/common/utils/formatUtils';
+  import {
+    type LabelGetter,
+    getLabel as defaultGetLabel,
+  } from '@mathesar-component-library-dir/common/utils/formatUtils';
   import LabeledInput from '@mathesar-component-library-dir/labeled-input/LabeledInput.svelte';
   import Render from '@mathesar-component-library-dir/render/Render.svelte';
   import StringOrComponent from '@mathesar-component-library-dir/string-or-component/StringOrComponent.svelte';

--- a/mathesar_ui/src/component-library/form-builder/formFactory.ts
+++ b/mathesar_ui/src/component-library/form-builder/formFactory.ts
@@ -1,5 +1,4 @@
-import type { Readable } from 'svelte/store';
-import { derived, get, readable, writable } from 'svelte/store';
+import { type Readable, derived, get, readable, writable } from 'svelte/store';
 
 import type {
   FormBuildConfiguration,

--- a/mathesar_ui/src/component-library/list-box/ListBox.svelte
+++ b/mathesar_ui/src/component-library/list-box/ListBox.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { createEventDispatcher, setContext } from 'svelte';
-  import type { Writable } from 'svelte/store';
-  import { writable } from 'svelte/store';
+  import { createEventDispatcher, onMount, setContext } from 'svelte';
+  import { type Writable, writable } from 'svelte/store';
 
   import { getLabel as defaultGetLabel } from '@mathesar-component-library-dir/common/utils/formatUtils';
 

--- a/mathesar_ui/src/component-library/modal/ModalController.ts
+++ b/mathesar_ui/src/component-library/modal/ModalController.ts
@@ -1,11 +1,11 @@
-import type {
-  Readable,
-  Subscriber,
-  Unsubscriber,
-  Updater,
-  Writable,
+import {
+  type Readable,
+  type Subscriber,
+  type Unsubscriber,
+  type Updater,
+  type Writable,
+  derived,
 } from 'svelte/store';
-import { derived } from 'svelte/store';
 
 import type ModalStack from './ModalStack';
 

--- a/mathesar_ui/src/component-library/modal/ModalMultiplexer.ts
+++ b/mathesar_ui/src/component-library/modal/ModalMultiplexer.ts
@@ -1,5 +1,4 @@
-import type { Readable, Writable } from 'svelte/store';
-import { derived, writable } from 'svelte/store';
+import { type Readable, type Writable, derived, writable } from 'svelte/store';
 
 import ModalController from './ModalController';
 import ModalStack from './ModalStack';

--- a/mathesar_ui/src/component-library/multi-select/MultiSelect.svelte
+++ b/mathesar_ui/src/component-library/multi-select/MultiSelect.svelte
@@ -4,8 +4,10 @@
 
   import BaseInput from '@mathesar-component-library-dir/common/base-components/BaseInput.svelte';
   import { getGloballyUniqueId } from '@mathesar-component-library-dir/common/utils/domUtils';
-  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
-  import { getLabel as defaultGetLabel } from '@mathesar-component-library-dir/common/utils/formatUtils';
+  import {
+    type LabelGetter,
+    getLabel as defaultGetLabel,
+  } from '@mathesar-component-library-dir/common/utils/formatUtils';
   import { AttachableDropdown } from '@mathesar-component-library-dir/dropdown';
   import Icon from '@mathesar-component-library-dir/icon/Icon.svelte';
   import {

--- a/mathesar_ui/src/component-library/number-input/number-formatter/AbstractNumberFormatter.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/AbstractNumberFormatter.ts
@@ -5,8 +5,12 @@ import type {
 } from '@mathesar-component-library-dir/formatted-input/FormattedInputTypes';
 import type { PartiallyMissingOrUndefined } from '@mathesar-component-library-dir/types';
 
-import type { DerivedOptions, Options } from './options';
-import { defaultOptions, getDerivedOptions } from './options';
+import {
+  type DerivedOptions,
+  type Options,
+  defaultOptions,
+  getDerivedOptions,
+} from './options';
 
 export default abstract class AbstractNumberFormatter<T>
   implements InputFormatter<T>

--- a/mathesar_ui/src/component-library/number-input/number-formatter/formatter.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/formatter.ts
@@ -1,6 +1,5 @@
 import { forceAsciiMinusSign } from './cleaners';
-import type { DerivedOptions } from './options';
-import { getDerivedOptions } from './options';
+import { type DerivedOptions, getDerivedOptions } from './options';
 
 type Parts = Intl.NumberFormatPart[];
 

--- a/mathesar_ui/src/component-library/toast/ToastController.ts
+++ b/mathesar_ui/src/component-library/toast/ToastController.ts
@@ -1,7 +1,6 @@
 import type { SvelteComponent } from 'svelte';
 import { linear } from 'svelte/easing';
-import type { Readable, Writable } from 'svelte/store';
-import { derived, writable } from 'svelte/store';
+import { type Readable, type Writable, derived, writable } from 'svelte/store';
 
 import {
   iconError,
@@ -9,8 +8,10 @@ import {
   iconLoading,
   iconSuccess,
 } from '@mathesar-component-library-dir/common/icons';
-import type { PauseableTweened } from '@mathesar-component-library-dir/common/utils/pauseableTweened';
-import { pauseableTweened } from '@mathesar-component-library-dir/common/utils/pauseableTweened';
+import {
+  type PauseableTweened,
+  pauseableTweened,
+} from '@mathesar-component-library-dir/common/utils/pauseableTweened';
 import type { IconProps } from '@mathesar-component-library-dir/icon/IconTypes';
 
 /**

--- a/mathesar_ui/src/components/abstract-type-control/AbstractTypeDBOptions.svelte
+++ b/mathesar_ui/src/components/abstract-type-control/AbstractTypeDBOptions.svelte
@@ -11,8 +11,7 @@
   import type { FormValues } from '@mathesar-component-library/types';
 
   import DbTypeIndicator from './DbTypeIndicator.svelte';
-  import type { ColumnWithAbstractType } from './utils';
-  import { constructDbForm } from './utils';
+  import { type ColumnWithAbstractType, constructDbForm } from './utils';
 
   export let selectedAbstractType: AbstractType;
   export let selectedDbType: DbType;

--- a/mathesar_ui/src/components/breadcrumb/breadcrumbUtils.ts
+++ b/mathesar_ui/src/components/breadcrumb/breadcrumbUtils.ts
@@ -1,6 +1,5 @@
 import { getContext, setContext } from 'svelte';
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 
 import { toAsciiLowerCase } from '@mathesar/component-library';
 

--- a/mathesar_ui/src/components/sheet/Sheet.svelte
+++ b/mathesar_ui/src/components/sheet/Sheet.svelte
@@ -2,8 +2,10 @@
   import { onMount, tick } from 'svelte';
   import { writable } from 'svelte/store';
 
-  import type { ClipboardHandler } from '@mathesar/stores/clipboard';
-  import { getClipboardHandlerStoreFromContext } from '@mathesar/stores/clipboard';
+  import {
+    type ClipboardHandler,
+    getClipboardHandlerStoreFromContext,
+  } from '@mathesar/stores/clipboard';
   import { getModifierKeyCombo } from '@mathesar/utils/pointerUtils';
   import { ImmutableMap } from '@mathesar-component-library/types';
 

--- a/mathesar_ui/src/components/sheet/cells/SheetPositionableCell.svelte
+++ b/mathesar_ui/src/components/sheet/cells/SheetPositionableCell.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import type { ColumnPosition } from '../utils';
-  import { getSheetContext } from '../utils';
+  import { type ColumnPosition, getSheetContext } from '../utils';
 
   const { stores } = getSheetContext();
   const { columnStyleMap } = stores;

--- a/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
+++ b/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
@@ -14,7 +14,7 @@ import {
   basisFromZeroEmptyColumns,
   emptyBasis,
 } from './basis';
-import { Direction, getColumnOffset } from './Direction';
+import { type Direction, getColumnOffset } from './Direction';
 import Plane from './Plane';
 import {
   type SheetCellDetails,
@@ -458,7 +458,11 @@ export default class SheetSelection {
   withActiveCellAdvanced(
     direction: 'forward' | 'back' = 'forward',
   ): SheetSelection {
-    throw new Error('Not implemented');
+    // TODO
+
+    // eslint-disable-next-line no-console
+    console.log(direction, 'Active cell advancing is not yet implemented');
+    return this;
   }
 
   /**
@@ -478,7 +482,9 @@ export default class SheetSelection {
    */
   resized(direction: Direction): SheetSelection {
     // TODO
-    console.log('Sheet selection resizing is not yet implemented');
+
+    // eslint-disable-next-line no-console
+    console.log(direction, 'Sheet selection resizing is not yet implemented');
     return this;
   }
 }

--- a/mathesar_ui/src/components/sheet/virtual-list/Resizer.svelte
+++ b/mathesar_ui/src/components/sheet/virtual-list/Resizer.svelte
@@ -12,8 +12,10 @@
 
   import { onMount } from 'svelte';
 
-  import type { ElementResizeDetector } from './detectElementResize';
-  import { createDetectElementResize } from './detectElementResize';
+  import {
+    type ElementResizeDetector,
+    createDetectElementResize,
+  } from './detectElementResize';
 
   let classes = 'default';
   export { classes as class };

--- a/mathesar_ui/src/components/sheet/virtual-list/VirtualList.svelte
+++ b/mathesar_ui/src/components/sheet/virtual-list/VirtualList.svelte
@@ -29,10 +29,8 @@
 
   import type { SheetVirtualRowsApi } from '../types';
 
-  import type { ItemInfo, Props } from './listUtils';
-  import listUtils from './listUtils';
-  import type { Timeout } from './timer';
-  import { cancelTimeout, requestTimeout } from './timer';
+  import listUtils, { type ItemInfo, type Props } from './listUtils';
+  import { type Timeout, cancelTimeout, requestTimeout } from './timer';
 
   const dispatch = createEventDispatcher();
 

--- a/mathesar_ui/src/icons/index.ts
+++ b/mathesar_ui/src/icons/index.ts
@@ -9,8 +9,6 @@ import {
   faCheck,
   faCheckSquare,
   faChevronRight,
-  faCircleArrowLeft,
-  faCircleArrowRight,
   faCircleExclamation,
   faCircleInfo,
   faClock,

--- a/mathesar_ui/src/pages/admin-users/EditUserPage.svelte
+++ b/mathesar_ui/src/pages/admin-users/EditUserPage.svelte
@@ -13,8 +13,10 @@
   import { confirmDelete } from '@mathesar/stores/confirmation';
   import { toast } from '@mathesar/stores/toast';
   import { getUserProfileStoreFromContext } from '@mathesar/stores/userProfile';
-  import type { UserModel } from '@mathesar/stores/users';
-  import { getUsersStoreFromContext } from '@mathesar/stores/users';
+  import {
+    type UserModel,
+    getUsersStoreFromContext,
+  } from '@mathesar/stores/users';
   import { PasswordChangeForm, UserDetailsForm } from '@mathesar/systems/users';
   import { Icon, SpinnerButton } from '@mathesar-component-library';
 

--- a/mathesar_ui/src/pages/admin-users/UserListingPage.svelte
+++ b/mathesar_ui/src/pages/admin-users/UserListingPage.svelte
@@ -7,8 +7,10 @@
   import { iconAddNew } from '@mathesar/icons';
   import { makeSimplePageTitle } from '@mathesar/pages/pageTitleUtils';
   import { ADMIN_USERS_PAGE_ADD_NEW_URL } from '@mathesar/routes/urls';
-  import type { UserModel } from '@mathesar/stores/users';
-  import { getUsersStoreFromContext } from '@mathesar/stores/users';
+  import {
+    type UserModel,
+    getUsersStoreFromContext,
+  } from '@mathesar/stores/users';
   import { AnchorButton, Icon } from '@mathesar-component-library';
 
   import UserRow from './UserRow.svelte';

--- a/mathesar_ui/src/pages/import/preview/importPreviewPageUtils.ts
+++ b/mathesar_ui/src/pages/import/preview/importPreviewPageUtils.ts
@@ -2,7 +2,6 @@ import { dataFilesApi } from '@mathesar/api/rest/dataFiles';
 import type { DataFile } from '@mathesar/api/rest/types/dataFiles';
 import type { Column } from '@mathesar/api/rpc/columns';
 import { getCellCap } from '@mathesar/components/cell-fabric/utils';
-import type { Database } from '@mathesar/models/Database';
 import type { Schema } from '@mathesar/models/Schema';
 import type { Table } from '@mathesar/models/Table';
 import { getAbstractTypeForDbType } from '@mathesar/stores/abstract-types';

--- a/mathesar_ui/src/routes/DatabaseSettingsRoute.svelte
+++ b/mathesar_ui/src/routes/DatabaseSettingsRoute.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { _ } from 'svelte-i18n';
   import { Route } from 'tinro';
 
   import EventfulRoute from '@mathesar/components/routing/EventfulRoute.svelte';

--- a/mathesar_ui/src/stores/AsyncRpcApiStore.ts
+++ b/mathesar_ui/src/stores/AsyncRpcApiStore.ts
@@ -9,6 +9,7 @@ import {
 
 import AsyncStore, { type AsyncStoreValue } from './AsyncStore';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type BatchRunner<T = any, U = any> = {
   send: RpcRequest<T>;
   beforeRequest: () => void;

--- a/mathesar_ui/src/stores/abstract-types/types.ts
+++ b/mathesar_ui/src/stores/abstract-types/types.ts
@@ -1,4 +1,3 @@
-import type { States } from '@mathesar/api/rest/utils/requestUtils';
 import type { Column } from '@mathesar/api/rpc/columns';
 import type { QuerySummarizationFunctionId } from '@mathesar/api/rpc/explorations';
 import type { DbType } from '@mathesar/AppTypes';

--- a/mathesar_ui/src/stores/confirmation.ts
+++ b/mathesar_ui/src/stores/confirmation.ts
@@ -3,8 +3,10 @@ import { _ } from 'svelte-i18n';
 
 import PhraseContainingIdentifier from '@mathesar/components/PhraseContainingIdentifier.svelte';
 import { iconDeleteMajor } from '@mathesar/icons';
-import type { ConfirmationProps } from '@mathesar-component-library';
-import { makeConfirm } from '@mathesar-component-library';
+import {
+  type ConfirmationProps,
+  makeConfirm,
+} from '@mathesar-component-library';
 
 import { modal } from './modal';
 import { toast } from './toast';

--- a/mathesar_ui/src/stores/table-data/TableStructure.ts
+++ b/mathesar_ui/src/stores/table-data/TableStructure.ts
@@ -1,5 +1,4 @@
-import type { Readable } from 'svelte/store';
-import { derived } from 'svelte/store';
+import { type Readable, derived } from 'svelte/store';
 
 import { States } from '@mathesar/api/rest/utils/requestUtils';
 import type { Column } from '@mathesar/api/rpc/columns';
@@ -9,10 +8,8 @@ import type { Table } from '@mathesar/models/Table';
 import type { AbstractTypesMap } from '@mathesar/stores/abstract-types/types';
 
 import { ColumnsDataStore } from './columns';
-import type { ConstraintsData } from './constraints';
-import { ConstraintsDataStore } from './constraints';
-import type { ProcessedColumnsStore } from './processedColumns';
-import { processColumn } from './processedColumns';
+import { type ConstraintsData, ConstraintsDataStore } from './constraints';
+import { type ProcessedColumnsStore, processColumn } from './processedColumns';
 
 export interface TableStructureProps {
   database: Pick<Database, 'id'>;

--- a/mathesar_ui/src/stores/table-data/__tests__/utils.test.ts
+++ b/mathesar_ui/src/stores/table-data/__tests__/utils.test.ts
@@ -2,8 +2,12 @@ import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
 import { ImmutableMap } from '@mathesar/component-library';
 
 import type { RowStatus } from '../meta';
-import type { CellKey, RowKey } from '../utils';
-import { ROW_HAS_CELL_ERROR_MSG, getRowStatus } from '../utils';
+import {
+  type CellKey,
+  ROW_HAS_CELL_ERROR_MSG,
+  type RowKey,
+  getRowStatus,
+} from '../utils';
 
 describe('getRowStatus', () => {
   interface TestCase {

--- a/mathesar_ui/src/stores/table-data/constraints.ts
+++ b/mathesar_ui/src/stores/table-data/constraints.ts
@@ -1,11 +1,13 @@
-import type {
-  Readable,
-  Subscriber,
-  Unsubscriber,
-  Updater,
-  Writable,
+import {
+  type Readable,
+  type Subscriber,
+  type Unsubscriber,
+  type Updater,
+  type Writable,
+  derived,
+  get as getStoreValue,
+  writable,
 } from 'svelte/store';
-import { derived, get as getStoreValue, writable } from 'svelte/store';
 
 import { States } from '@mathesar/api/rest/utils/requestUtils';
 import { api } from '@mathesar/api/rpc';

--- a/mathesar_ui/src/stores/table-data/display.ts
+++ b/mathesar_ui/src/stores/table-data/display.ts
@@ -1,5 +1,4 @@
-import type { Readable, Writable } from 'svelte/store';
-import { derived, writable } from 'svelte/store';
+import { type Readable, type Writable, derived, writable } from 'svelte/store';
 
 import { WritableMap } from '@mathesar-component-library';
 

--- a/mathesar_ui/src/stores/table-data/grouping.ts
+++ b/mathesar_ui/src/stores/table-data/grouping.ts
@@ -1,5 +1,4 @@
 import type { RecordsListParams } from '@mathesar/api/rpc/records';
-import { isDefinedNonNullable } from '@mathesar/component-library';
 
 export interface GroupEntry {
   readonly columnId: number;

--- a/mathesar_ui/src/stores/table-data/meta.ts
+++ b/mathesar_ui/src/stores/table-data/meta.ts
@@ -1,26 +1,26 @@
-import type { Readable, Writable } from 'svelte/store';
-import { derived, writable } from 'svelte/store';
+import { type Readable, type Writable, derived, writable } from 'svelte/store';
 
 import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
-import type { TersePagination } from '@mathesar/utils/Pagination';
-import Pagination from '@mathesar/utils/Pagination';
+import Pagination, { type TersePagination } from '@mathesar/utils/Pagination';
 import Url64 from '@mathesar/utils/Url64';
 import {
-  ImmutableMap,
+  type ImmutableMap,
   ImmutableSet,
   WritableMap,
 } from '@mathesar-component-library';
 
-import type { TerseFiltering } from './filtering';
-import { Filtering } from './filtering';
-import type { TerseGrouping } from './grouping';
-import { Grouping } from './grouping';
+import { Filtering, type TerseFiltering } from './filtering';
+import { Grouping, type TerseGrouping } from './grouping';
 import type { RecordsRequestParamsData } from './records';
 import { SearchFuzzy } from './searchFuzzy';
-import type { TerseSorting } from './sorting';
-import { Sorting } from './sorting';
-import type { CellKey, RowKey } from './utils';
-import { extractRowKeyFromCellKey, getRowStatus, getSheetState } from './utils';
+import { Sorting, type TerseSorting } from './sorting';
+import {
+  type CellKey,
+  type RowKey,
+  extractRowKeyFromCellKey,
+  getRowStatus,
+  getSheetState,
+} from './utils';
 
 /**
  * Unlike in `RequestStatus`, here the state and the error messages are

--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -13,14 +13,11 @@ import type { ShareConsumer } from '@mathesar/utils/shares';
 import { orderProcessedColumns } from '@mathesar/utils/tables';
 
 import { ColumnsDataStore } from './columns';
-import type { ConstraintsData } from './constraints';
-import { ConstraintsDataStore } from './constraints';
+import { type ConstraintsData, ConstraintsDataStore } from './constraints';
 import { Display } from './display';
 import { Meta } from './meta';
-import type { ProcessedColumnsStore } from './processedColumns';
-import { processColumn } from './processedColumns';
-import type { TableRecordsData } from './records';
-import { RecordsData } from './records';
+import { type ProcessedColumnsStore, processColumn } from './processedColumns';
+import { RecordsData, type TableRecordsData } from './records';
 
 export interface TabularDataProps {
   database: Pick<Database, 'id'>;

--- a/mathesar_ui/src/stores/table-data/utils.ts
+++ b/mathesar_ui/src/stores/table-data/utils.ts
@@ -1,12 +1,14 @@
 import { concat } from 'iter-tools';
 
-import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
-import { getMostImportantRequestStatusState } from '@mathesar/api/rest/utils/requestUtils';
+import {
+  type RequestStatus,
+  getMostImportantRequestStatusState,
+} from '@mathesar/api/rest/utils/requestUtils';
 import type { Column } from '@mathesar/api/rpc/columns';
 import {
   ImmutableMap,
   ImmutableSet,
-  WritableMap,
+  type WritableMap,
 } from '@mathesar-component-library';
 
 import type { RowStatus } from './meta';

--- a/mathesar_ui/src/systems/data-explorer/QueryManager.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryManager.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { get, writable } from 'svelte/store';
+import { type Writable, get, writable } from 'svelte/store';
 import { _ } from 'svelte-i18n';
 
 import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
@@ -15,13 +14,16 @@ import { addExploration, replaceExploration } from '@mathesar/stores/queries';
 import CacheManager from '@mathesar/utils/CacheManager';
 import type { CancellablePromise } from '@mathesar-component-library';
 
-import type { QueryModelUpdateDiff } from './QueryModel';
-import QueryModel from './QueryModel';
-import QueryRunner from './QueryRunner';
-import QuerySummarizationTransformationModel from './QuerySummarizationTransformationModel';
+import QueryModel, { type QueryModelUpdateDiff } from './QueryModel';
+import { QueryRunner } from './QueryRunner';
+import { QuerySummarizationTransformationModel } from './QuerySummarizationTransformationModel';
 import QueryUndoRedoManager from './QueryUndoRedoManager';
-import type { InputColumnsStoreSubstance, QueryTableStructure } from './utils';
-import { getInputColumns, getQueryTableStructure } from './utils';
+import {
+  type InputColumnsStoreSubstance,
+  type QueryTableStructure,
+  getInputColumns,
+  getQueryTableStructure,
+} from './utils';
 
 export default class QueryManager extends QueryRunner {
   private undoRedoManager: QueryUndoRedoManager;

--- a/mathesar_ui/src/systems/data-explorer/QueryModel.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryModel.ts
@@ -10,7 +10,7 @@ import { assertExhaustive } from '@mathesar-component-library';
 import QueryFilterTransformationModel from './QueryFilterTransformationModel';
 import QueryHideTransformationModel from './QueryHideTransformationModel';
 import QuerySortTransformationModel from './QuerySortTransformationModel';
-import QuerySummarizationTransformationModel from './QuerySummarizationTransformationModel';
+import { QuerySummarizationTransformationModel } from './QuerySummarizationTransformationModel';
 import type { ColumnWithLink } from './utils';
 
 export interface QueryModelUpdateDiff {

--- a/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
@@ -1,5 +1,10 @@
-import type { Readable, Writable } from 'svelte/store';
-import { derived, get, writable } from 'svelte/store';
+import {
+  type Readable,
+  type Writable,
+  derived,
+  get,
+  writable,
+} from 'svelte/store';
 
 import { ApiMultiError } from '@mathesar/api/rest/utils/errors';
 import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
@@ -16,7 +21,10 @@ import type { AbstractTypesMap } from '@mathesar/stores/abstract-types/types';
 import { runSavedExploration } from '@mathesar/stores/queries';
 import Pagination from '@mathesar/utils/Pagination';
 import type { ShareConsumer } from '@mathesar/utils/shares';
-import { CancellablePromise, ImmutableMap } from '@mathesar-component-library';
+import {
+  type CancellablePromise,
+  ImmutableMap,
+} from '@mathesar-component-library';
 
 import QueryInspector from './QueryInspector';
 import type QueryModel from './QueryModel';
@@ -45,7 +53,7 @@ export interface QueryRowsData {
 
 type QueryRunMode = 'queryId' | 'queryObject';
 
-export default class QueryRunner {
+export class QueryRunner {
   query: Writable<QueryModel>;
 
   abstractTypeMap: AbstractTypesMap;

--- a/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
+++ b/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
@@ -26,7 +26,7 @@ export interface QuerySummarizationTransformationEntry {
   aggregations: ImmutableMap<string, QuerySummarizationAggregationEntry>;
 }
 
-export default class QuerySummarizationTransformationModel
+export class QuerySummarizationTransformationModel
   implements QuerySummarizationTransformationEntry
 {
   type = 'summarize' as const;

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationInspector.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationInspector.svelte
@@ -4,7 +4,7 @@
 
   import type { ExplorationInspectorTab } from '../QueryInspector';
   import type QueryManager from '../QueryManager';
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
 
   import CellTab from './cell/CellTab.svelte';
   import ColumnTab from './column-tab/ColumnTab.svelte';

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationTab.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationTab.svelte
@@ -25,7 +25,7 @@
   } from '@mathesar-component-library';
 
   import QueryManager from '../QueryManager';
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
 
   const dispatch = createEventDispatcher();
 

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/WithExplorationInspector.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/WithExplorationInspector.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { dataExplorerRightSidebarWidth } from '@mathesar/stores/localStorage';
   import type QueryManager from '@mathesar/systems/data-explorer/QueryManager';
-  import type QueryRunner from '@mathesar/systems/data-explorer/QueryRunner';
+  import type { QueryRunner } from '@mathesar/systems/data-explorer/QueryRunner';
   import { WithPanel } from '@mathesar-component-library';
 
   import ExplorationInspector from './ExplorationInspector.svelte';

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/cell/CellTab.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/cell/CellTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CellInspector from '@mathesar/components/inspector/cell/CellInspector.svelte';
 
-  import type QueryRunner from '../../QueryRunner';
+  import type { QueryRunner } from '../../QueryRunner';
 
   import { getSelectedCellData } from './cellTabUtils';
 

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/column-tab/ColumnTab.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/column-tab/ColumnTab.svelte
@@ -11,7 +11,7 @@
   } from '@mathesar-component-library';
 
   import QueryManager from '../../QueryManager';
-  import type QueryRunner from '../../QueryRunner';
+  import type { QueryRunner } from '../../QueryRunner';
 
   import ColumnSource from './ColumnSource.svelte';
   import DeleteColumnAction from './DeleteColumnAction.svelte';

--- a/mathesar_ui/src/systems/data-explorer/index.ts
+++ b/mathesar_ui/src/systems/data-explorer/index.ts
@@ -1,6 +1,6 @@
 export { default as DataExplorer } from './DataExplorer.svelte';
 export { default as QueryManager } from './QueryManager';
-export { default as QueryRunner } from './QueryRunner';
+export { QueryRunner } from './QueryRunner';
 export { default as QueryModel } from './QueryModel';
 export { default as ExplorationResult } from './result-pane/Results.svelte';
 export * from './exploration-inspector';

--- a/mathesar_ui/src/systems/data-explorer/input-sidebar/transformations-pane/TransformationsPane.svelte
+++ b/mathesar_ui/src/systems/data-explorer/input-sidebar/transformations-pane/TransformationsPane.svelte
@@ -16,7 +16,7 @@
   import type QueryManager from '../../QueryManager';
   import type { QueryTransformationModel } from '../../QueryModel';
   import QuerySortTransformationModel from '../../QuerySortTransformationModel';
-  import QuerySummarizationTransformationModel from '../../QuerySummarizationTransformationModel';
+  import { QuerySummarizationTransformationModel } from '../../QuerySummarizationTransformationModel';
 
   import FilterTransformation from './FilterTransformation.svelte';
   import HideTransformation from './HideTransformation.svelte';

--- a/mathesar_ui/src/systems/data-explorer/input-sidebar/transformations-pane/summarization/SummarizationTransformation.svelte
+++ b/mathesar_ui/src/systems/data-explorer/input-sidebar/transformations-pane/summarization/SummarizationTransformation.svelte
@@ -10,8 +10,10 @@
     MultiSelect,
   } from '@mathesar-component-library';
 
-  import type QuerySummarizationTransformationModel from '../../../QuerySummarizationTransformationModel';
-  import type { QuerySummarizationAggregationEntry } from '../../../QuerySummarizationTransformationModel';
+  import type {
+    QuerySummarizationAggregationEntry,
+    QuerySummarizationTransformationModel,
+  } from '../../../QuerySummarizationTransformationModel';
   import type { ProcessedQueryResultColumnMap } from '../../../utils';
 
   import Aggregation from './Aggregation.svelte';

--- a/mathesar_ui/src/systems/data-explorer/result-pane/QueryRefreshButton.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/QueryRefreshButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import RefreshButton from '@mathesar/components/RefreshButton.svelte';
 
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
 
   export let queryRunner: QueryRunner;
 

--- a/mathesar_ui/src/systems/data-explorer/result-pane/QueryRunErrors.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/QueryRunErrors.svelte
@@ -10,7 +10,7 @@
   import { Button, hasProperty } from '@mathesar-component-library';
 
   import QueryManager from '../QueryManager';
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
 
   const { currentDatabase } = databasesStore;
 

--- a/mathesar_ui/src/systems/data-explorer/result-pane/ResultHeaderCell.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/ResultHeaderCell.svelte
@@ -6,7 +6,7 @@
   } from '@mathesar/components/sheet';
   import { Button } from '@mathesar-component-library';
 
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
   import type { ProcessedQueryOutputColumn } from '../utils';
 
   export let queryRunner: QueryRunner;

--- a/mathesar_ui/src/systems/data-explorer/result-pane/ResultPane.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/ResultPane.svelte
@@ -2,7 +2,7 @@
   import { _ } from 'svelte-i18n';
 
   import type QueryManager from '../QueryManager';
-  import type QueryRunner from '../QueryRunner';
+  import type { QueryRunner } from '../QueryRunner';
 
   import QueryRefreshButton from './QueryRefreshButton.svelte';
   import Results from './Results.svelte';

--- a/mathesar_ui/src/systems/data-explorer/result-pane/Results.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/Results.svelte
@@ -20,8 +20,7 @@
   import { ImmutableMap } from '@mathesar-component-library';
 
   import type QueryManager from '../QueryManager';
-  import type QueryRunner from '../QueryRunner';
-  import { getRowSelectionId } from '../QueryRunner';
+  import { type QueryRunner, getRowSelectionId } from '../QueryRunner';
 
   import QueryRefreshButton from './QueryRefreshButton.svelte';
   import QueryRunErrors from './QueryRunErrors.svelte';

--- a/mathesar_ui/src/systems/data-explorer/types.ts
+++ b/mathesar_ui/src/systems/data-explorer/types.ts
@@ -1,2 +1,2 @@
 export type { default as QueryManager } from './QueryManager';
-export type { default as QueryRunner } from './QueryRunner';
+export type { QueryRunner } from './QueryRunner';

--- a/mathesar_ui/src/systems/permissions/PermissionsModal.svelte
+++ b/mathesar_ui/src/systems/permissions/PermissionsModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { _ } from 'svelte-i18n';
-
   import {
     ControlledModal,
     type ModalController,

--- a/mathesar_ui/src/systems/permissions/overview/PermissionsOverview.svelte
+++ b/mathesar_ui/src/systems/permissions/overview/PermissionsOverview.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { _ } from 'svelte-i18n';
-
   import type { ModalController } from '@mathesar-component-library';
 
   import type {

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorDataCell.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorDataCell.svelte
@@ -5,7 +5,7 @@
   import {
     type ProcessedColumn,
     type RecordRow,
-    SearchFuzzy,
+    type SearchFuzzy,
     rowHasSavedRecord,
   } from '@mathesar/stores/table-data';
   import type RecordSummaryStore from '@mathesar/stores/table-data/record-summaries/RecordSummaryStore';

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorTable.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorTable.svelte
@@ -6,7 +6,7 @@
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import {
     type RecordRow,
-    TabularData,
+    type TabularData,
     constraintIsFk,
     setTabularDataStoreInContext,
   } from '@mathesar/stores/table-data';
@@ -18,11 +18,11 @@
 
   import Cell from './RecordSelectorCellWrapper.svelte';
   import RecordSelectorColumnHeaderCell from './RecordSelectorColumnHeaderCell.svelte';
-  import type {
-    RecordSelectorController,
-    RecordSelectorResult,
+  import {
+    type RecordSelectorController,
+    type RecordSelectorResult,
+    setRecordSelectorControllerInContext,
   } from './RecordSelectorController';
-  import { setRecordSelectorControllerInContext } from './RecordSelectorController';
   import RecordSelectorDataCell from './RecordSelectorDataCell.svelte';
   import RecordSelectorDataRow from './RecordSelectorDataRow.svelte';
   import RecordSelectorSubmitButton from './RecordSelectorSubmitButton.svelte';

--- a/mathesar_ui/src/systems/schemas/AddEditSchemaModal.svelte
+++ b/mathesar_ui/src/systems/schemas/AddEditSchemaModal.svelte
@@ -3,7 +3,6 @@
   import { _ } from 'svelte-i18n';
 
   import Identifier from '@mathesar/components/Identifier.svelte';
-  import InfoBox from '@mathesar/components/message-boxes/InfoBox.svelte';
   import NameAndDescInputModalForm from '@mathesar/components/NameAndDescInputModalForm.svelte';
   import { RichText } from '@mathesar/components/rich-text';
   import type { Database } from '@mathesar/models/Database';

--- a/mathesar_ui/src/systems/table-view/ScrollAndResetHandler.svelte
+++ b/mathesar_ui/src/systems/table-view/ScrollAndResetHandler.svelte
@@ -4,10 +4,10 @@
   import type { States } from '@mathesar/api/rest/utils/requestUtils';
   import type { SheetVirtualRowsApi } from '@mathesar/components/sheet/types';
   import {
-    Filtering,
-    Grouping,
+    type Filtering,
+    type Grouping,
     type Row,
-    Sorting,
+    type Sorting,
     getTabularDataStoreFromContext,
   } from '@mathesar/stores/table-data';
   import type Pagination from '@mathesar/utils/Pagination';

--- a/mathesar_ui/src/systems/table-view/constraints/NewUniqueConstraint.svelte
+++ b/mathesar_ui/src/systems/table-view/constraints/NewUniqueConstraint.svelte
@@ -12,8 +12,8 @@
   import { getColumnConstraintTypeByColumnId } from '@mathesar/utils/columnUtils';
   import { getAvailableName } from '@mathesar/utils/db';
   import { getErrorMessage } from '@mathesar/utils/errors';
-  import { CancelOrProceedButtonPair } from '@mathesar-component-library';
   import {
+    CancelOrProceedButtonPair,
     LabeledInput,
     MultiSelect,
     RadioGroup,

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -2,8 +2,10 @@
   import type { Writable } from 'svelte/store';
   import { _ } from 'svelte-i18n';
 
-  import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
-  import { States } from '@mathesar/api/rest/utils/requestUtils';
+  import {
+    type RequestStatus,
+    States,
+  } from '@mathesar/api/rest/utils/requestUtils';
   import type { TablePrivilege } from '@mathesar/api/rpc/tables';
   import CellFabric from '@mathesar/components/cell-fabric/CellFabric.svelte';
   import CellBackground from '@mathesar/components/CellBackground.svelte';
@@ -31,7 +33,7 @@
     LinkMenuItem,
     MenuDivider,
     MenuHeading,
-    WritableMap,
+    type WritableMap,
   } from '@mathesar-component-library';
 
   import ColumnHeaderContextMenu from '../header/header-cell/ColumnHeaderContextMenu.svelte';

--- a/mathesar_ui/src/systems/table-view/row/RowContextOptions.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowContextOptions.svelte
@@ -6,7 +6,7 @@
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import {
     type RecordRow,
-    RecordsData,
+    type RecordsData,
     rowHasRecord,
   } from '@mathesar/stores/table-data';
   import { getRowSelectionId } from '@mathesar/stores/table-data/records';

--- a/mathesar_ui/src/systems/table-view/table-inspector/record-summary/RecordSummaryConfig.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record-summary/RecordSummaryConfig.svelte
@@ -31,7 +31,7 @@
 
   $: ({ recordsData, columnsDataStore, isLoading } = tabularData);
   $: ({ columns } = columnsDataStore);
-  $: ({ savedRecords, linkedRecordSummaries: recordSummaries } = recordsData);
+  $: ({ savedRecords, linkedRecordSummaries } = recordsData);
   $: firstRow = $savedRecords[0] as RecordRow | undefined;
   $: initialCustomized = table.metadata?.record_summary_customized ?? false;
   $: initialTemplate = table.metadata?.record_summary_template ?? '';
@@ -56,7 +56,7 @@
     // return renderRecordSummaryForRow({
     //   template: $template,
     //   record,
-    //   transitiveData: $recordSummaries,
+    //   transitiveData: $linkedRecordSummaries,
     // });
     return '';
   })();

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/links/LinkSection.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/links/LinkSection.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { _ } from 'svelte-i18n';
-
   import type { IconProps } from '@mathesar/component-library/types';
   import { Icon } from '@mathesar-component-library';
 

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/links/LinksSectionContainer.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/links/LinksSectionContainer.svelte
@@ -2,8 +2,8 @@
   import { _ } from 'svelte-i18n';
 
   import type { JoinableTablesResult } from '@mathesar/api/rpc/tables';
-  import { iconAddNew } from '@mathesar/icons';
   import {
+    iconAddNew,
     iconLinksFromOtherTables,
     iconLinksInThisTable,
   } from '@mathesar/icons';

--- a/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
+++ b/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
@@ -1,6 +1,7 @@
 import DurationFormatter from '../DurationFormatter';
-import type { DurationConfig } from '../DurationSpecification';
-import DurationSpecification from '../DurationSpecification';
+import DurationSpecification, {
+  type DurationConfig,
+} from '../DurationSpecification';
 
 describe('parse', () => {
   // prettier-ignore


### PR DESCRIPTION



## This PR:

- fixes a bunch of existing lint warnings (and leaves a few in place for now)
- adds some new lint rules and fixes associated errors

## Notes

- Here was an interesting problem I faced:

    - In `QuerySummarizationTransformationModel.ts` we had a default export of `class QuerySummarizationTransformationModel`.

    - Then that _type_ was being imported into `SummarizationTransformation.svelte` along with another type via this code:

        ```ts
        import type QuerySummarizationTransformationModel from '../../../QuerySummarizationTransformationModel';
        import type { QuerySummarizationAggregationEntry } from '../../../QuerySummarizationTransformationModel';
        ```

        That code had to be changed because it violated the new `no-duplicate-imports` rule.

    - But I was unable to find a suitable alternative. I tried:


        ```ts
        import
          type QuerySummarizationTransformationModel,
          type { QuerySummarizationAggregationEntry }
        from '../../../QuerySummarizationTransformationModel';
        ```

        and:

        ```ts
        import
          type QuerySummarizationTransformationModel,
          { type QuerySummarizationAggregationEntry }
        from '../../../QuerySummarizationTransformationModel';
        ```

        For different reasons, neither of these worked.

    - So I ended up modifying `QuerySummarizationTransformationModel.ts` to change the _export_ from default to named. Then I was able to fix the import as:

        ```ts
        import {
          type QuerySummarizationAggregationEntry,
          type QuerySummarizationTransformationModel,
        } from '../../../QuerySummarizationTransformationModel';
        ```

    - Honestly I've never really like default export anyway. But that's another story. Here was an example of where I couldn't seem to figure out how to use a default export in conformance with these linting rules, so I had to use a named one.

    - We had the same problem with `default class QueryRunner` as exported from `QueryRunner.ts`, so I changed that to a named export as well.



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the cotribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


