### PR TITLE
Refactor SQL install script

### DIFF
--- a/db/sql/install.py
+++ b/db/sql/install.py
@@ -1,25 +1,35 @@
 import os
+
 from db.connection import load_file_with_conn
-from db.types.custom import uri
+from db.types.custom.uri import install_tld_lookup_table
 
 FILE_DIR = os.path.abspath(os.path.dirname(__file__))
-MSAR_SQL = os.path.join(FILE_DIR, '00_msar.sql')
-MSAR_JOIN_SQL = os.path.join(FILE_DIR, '10_msar_joinable_tables.sql')
-MSAR_AGGREGATE_SQL = os.path.join(FILE_DIR, '30_msar_custom_aggregates.sql')
-MSAR_TYPES = os.path.join(FILE_DIR, '40_msar_types.sql')
-MSAR_PERMS = os.path.join(FILE_DIR, '50_msar_permissions.sql')
+
+
+def _install_sql_file(file_name):
+    """
+    Return a function that installs the SQL file with the given name. The
+    returned function accepts a psycopg2 connection as its only argument.
+    """
+
+    def _install(conn):
+        with open(os.path.join(FILE_DIR, file_name)) as file_handle:
+            load_file_with_conn(conn, file_handle)
+
+    return _install
+
+
+INSTALL_STEPS = [
+    _install_sql_file("00_msar.sql"),
+    _install_sql_file("10_msar_joinable_tables.sql"),
+    _install_sql_file("30_msar_custom_aggregates.sql"),
+    _install_sql_file("40_msar_types.sql"),
+    install_tld_lookup_table,
+    _install_sql_file("50_msar_permissions.sql"),
+]
 
 
 def install(conn):
     """Install SQL pieces using the given conn."""
-    with open(MSAR_SQL) as file_handle:
-        load_file_with_conn(conn, file_handle)
-    with open(MSAR_JOIN_SQL) as file_handle:
-        load_file_with_conn(conn, file_handle)
-    with open(MSAR_AGGREGATE_SQL) as custom_aggregates:
-        load_file_with_conn(conn, custom_aggregates)
-    with open(MSAR_TYPES) as file_handle:
-        load_file_with_conn(conn, file_handle)
-    uri.install_tld_lookup_table(conn)
-    with open(MSAR_PERMS) as file_handle:
-        load_file_with_conn(conn, file_handle)
+    for step in INSTALL_STEPS:
+        step(conn)


### PR DESCRIPTION

@mathemancer I'd like to be able to add/remove/re-order the SQL installation steps without so much boilerplate, so I'm proposing this improved structure. Going forward, edits to installation steps can be made more simply within the `INSTALL_STEPS` list.

Is this okay with you?

I had actually written something similar in f1b074478cc59f64d9a120a1f7531393d6b5394c way back in May as part of #3561. I wanted to put this work in a separate PR now so that we can merge it independently of other work. Then I'd like to base the record summary work on top of this (because I'd like to put that SQL code in its own file).


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

