### PR TITLE
Fix row height calculation during grouping removal

### DIFF
--- a/mathesar_ui/src/systems/table-view/Body.svelte
+++ b/mathesar_ui/src/systems/table-view/Body.svelte
@@ -15,7 +15,7 @@
   } from '@mathesar/stores/table-data';
 
   import Row from './row/Row.svelte';
-  import ScrollAndResetHandler from './ScrollAndResetHandler.svelte';
+  import ScrollAndRowHeightHandler from './ScrollAndRowHeightHandler.svelte';
 
   const tabularData = getTabularDataStoreFromContext();
 
@@ -62,7 +62,7 @@
       let:items
       let:api
     >
-      <ScrollAndResetHandler {api} />
+      <ScrollAndRowHeightHandler {api} />
       {#each items as item (item.key)}
         {#if $displayableRecords[item.index] && !(isPlaceholderRow($displayableRecords[item.index]) && !canAddRow)}
           <Row style={item.style} bind:row={$displayableRecords[item.index]} />

--- a/mathesar_ui/src/systems/table-view/ScrollAndResetHandler.svelte
+++ b/mathesar_ui/src/systems/table-view/ScrollAndResetHandler.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { beforeUpdate, tick } from 'svelte';
 
-  import type { States } from '@mathesar/api/rest/utils/requestUtils';
+  import { States } from '@mathesar/api/rest/utils/requestUtils';
   import type { SheetVirtualRowsApi } from '@mathesar/components/sheet/types';
   import {
     type Filtering,
@@ -51,8 +51,8 @@
 
   async function resetIndex(_recordState: States, _displayableRecords: Row[]) {
     if (
-      prevGrouping !== $grouping ||
-      ($grouping.entries.length > 0 && prevRecordState !== _recordState)
+      _recordState !== States.Loading &&
+      (prevGrouping !== $grouping || $grouping.entries.length > 0)
     ) {
       await tick();
       // Reset if grouping is active


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3768 

**Technical details**
* Currently, a group header is the only scenario where a row height differs from the default.
* Row height needs to be recalculated when grouping is added, removed, or any request is made while grouping is active.
* https://github.com/mathesar-foundation/mathesar/commit/a8e6f6da1e87678a9690c33c986f868bc37bea05 fixes the bug, it's a 2 line change.
* https://github.com/mathesar-foundation/mathesar/commit/6a2c10262b8afd8d9bfc6c0e461eac5ef8859a28 attempts to make the function more readable.

**Cause of the bug**
* When `$state` changes to `loading` once a group is removed, `resetIndex` is called and `prevGrouping = $grouping` is executed.
* This results in the `api.recalculateHeightsAfterIndex(0);` not being called after `$state` changes to `done`, when we expect it to be called.
* I did not dig deep into exactly how it managed to work in 0.1.7, it might have been a race condition where `$state` and `$displayableRecords` where updated together and the `api.recalculateHeightsAfterIndex(0);` was called only once after `$state` is `done`, or `$grouping` not being updated when `$state` is `loading`.
* This fix ignores the loading state where we do not really want the rows to be recalculated and explicitly checks if the state is not `loading` instead of `prevState !== state`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
