### PR TITLE
Small bug fixes in record summary DB code

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -4889,7 +4889,11 @@ BEGIN
         IF ref_column_name IS NOT NULL THEN
           expr_parts := array_append(
             expr_parts,
-            concat('msar.format_data(', prev_alias,'.', quote_ident(ref_column_name), ')')
+            concat(
+              'COALESCE(msar.format_data(',
+              prev_alias, '.', quote_ident(ref_column_name),
+              E')::text, \'\')'
+            )
           );
         END IF;
 

--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -4968,7 +4968,7 @@ SELECT msar.build_record_summary_query_from_template(
   tab_id,
   COALESCE(key_col_id, msar.get_selectable_pkey_attnum(tab_id)),
   COALESCE(
-    table_record_summary_templates -> tab_id::text,
+    NULLIF(table_record_summary_templates -> tab_id::text, 'null'::jsonb),
     msar.auto_generate_record_summary_template(tab_id)
   )
 );

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -4665,6 +4665,29 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION test_record_summary_with_null_template() RETURNS SETOF TEXT AS $$
+BEGIN
+  PERFORM __setup_preview_fkey_cols();
+
+  -- Passing a JSON null template should cause the record summary to fall back to the default. This
+  -- is necessary to ensure that the front end can render a preview of the default template when a
+  -- customized template is already saved.
+  RETURN NEXT is(
+    msar.get_record_from_table(
+      tab_id => '"Students"'::regclass::oid,
+      rec_id => 2,
+      return_record_summaries => true,
+      table_record_summary_templates => jsonb_build_object(
+        '"Students"'::regclass::oid,
+        'null'::jsonb
+      )
+    ) -> 'record_summaries' ->> '2', 
+    'Gabby Gabberson'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION test_record_summary_for_non_pk_table() RETURNS SETOF TEXT AS $$
 BEGIN
   PERFORM __setup_preview_fkey_cols();

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -4505,14 +4505,15 @@ BEGIN
       return_record_summaries => true
     ),
     $j${
-      "count": 6,
+      "count": 7,
       "results": [
         {"1": 1, "2": 2.345, "3": 3, "4": "Fred Fredrickson", "5": 95, "6": "ffredrickson@example.edu"},
         {"1": 2, "2": 1.234, "3": 1, "4": "Gabby Gabberson", "5": 100, "6": "ggabberson@example.edu"},
         {"1": 3, "2": 1.234, "3": 2, "4": "Hank Hankson", "5": 75, "6": "hhankson@example.edu"},
         {"1": 4, "2": 2.345, "3": 1, "4": "Ida Idalia", "5": 90, "6": "iidalia@example.edu"},
         {"1": 5, "2": 2.345, "3": 2, "4": "James Jameson", "5": 80, "6": "jjameson@example.edu"},
-        {"1": 6, "2": 1.234, "3": 3, "4": "Kelly Kellison", "5": 80, "6": "kkellison@example.edu"}
+        {"1": 6, "2": 1.234, "3": 3, "4": "Kelly Kellison", "5": 80, "6": "kkellison@example.edu"},
+        {"1": 7, "2": 1.234, "3": 4, "4": "Arnold Baker", "5": null, "6": "ab@example.edu"}
       ],
       "grouping": null,
       "linked_record_summaries": {
@@ -4523,7 +4524,8 @@ BEGIN
         "3": {
           "1": "Carol Carlson",
           "2": "Dave Davidson",
-          "3": "Eve Evilson"
+          "3": "Eve Evilson",
+          "4": "Neil Smith"
         }
       },
       "record_summaries":  {
@@ -4532,7 +4534,8 @@ BEGIN
         "3": "Hank Hankson",
         "4": "Ida Idalia",
         "5": "James Jameson",
-        "6": "Kelly Kellison"
+        "6": "Kelly Kellison",
+        "7": "Arnold Baker"
       }
     }$j$ || jsonb_build_object(
       'query', concat(
@@ -4553,7 +4556,7 @@ BEGIN
       group_ => null
     ),
     $j${
-      "count": 6,
+      "count": 7,
       "results": [
         {"1": 2, "2": 1.234, "3": 1, "4": "Gabby Gabberson", "5": 100, "6": "ggabberson@example.edu"},
         {"1": 3, "2": 1.234, "3": 2, "4": "Hank Hankson", "5": 75, "6": "hhankson@example.edu"},
@@ -4590,7 +4593,7 @@ BEGIN
       group_ => '{"columns": [2]}'
     ),
     $j${
-      "count": 6,
+      "count": 7,
       "results": [
         {"1": 2, "2": 1.234, "3": 1, "4": "Gabby Gabberson", "5": 100, "6": "ggabberson@example.edu"},
         {"1": 3, "2": 1.234, "3": 2, "4": "Hank Hankson", "5": 75, "6": "hhankson@example.edu"}
@@ -4598,7 +4601,7 @@ BEGIN
       "grouping": {
         "columns": [2],
         "preproc": null,
-        "groups": [{"id": 1, "count": 3, "results_eq": {"2": 1.234}, "result_indices": [0, 1]}]
+        "groups": [{"id": 1, "count": 4, "results_eq": {"2": 1.234}, "result_indices": [0, 1]}]
       },
       "linked_record_summaries": {
         "2": {
@@ -4722,13 +4725,13 @@ BEGIN
     ),
     $a${
       "results": [
-        {"1": 7, "2": 2.345, "3": 1, "4": "Larry Laurelson", "5": 70, "6": "llaurelson@example.edu"}
+        {"1": 8, "2": 2.345, "3": 1, "4": "Larry Laurelson", "5": 70, "6": "llaurelson@example.edu"}
       ],
       "linked_record_summaries": {
         "2": {"2.345": "Bob Bobinson"},
         "3": {"1": "Carol Carlson"}
       },
-      "record_summaries": {"7": "Larry Laurelson"}
+      "record_summaries": {"8": "Larry Laurelson"}
     }$a$
   );
 END;


### PR DESCRIPTION
This PR fixes two bugs in the db-layer record summary code:

- Previously, `NULL` values in cells were causing the entire record summary string to short circuit to `NULL`. Now `NULL` is rendered as a empty string, with the remainder of the record summary string kept intact.

- Previously, the code was properly handling missing templates when the template was a _PostgreSQL_ `NULL`. But it was _not_ properly handling missing templates when the template value was a _jsonb_ `null`. Now such cases are handled by falling back to the default template.

Tests are included for both.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


