### PR TITLE
Require all Svelte components to have a TS script block

### DIFF
--- a/mathesar_ui/.eslintrc.cjs
+++ b/mathesar_ui/.eslintrc.cjs
@@ -77,6 +77,15 @@ module.exports = {
         ignoreDeclarationSort: true,
       },
     ],
+    'svelte/block-lang': [
+      'error',
+      {
+        enforceScriptPresent: true,
+        enforceStylePresent: false,
+        script: ['ts'],
+        style: ['scss', null],
+      },
+    ],
   },
   overrides: [
     {
@@ -225,6 +234,12 @@ module.exports = {
         '@typescript-eslint/no-unused-expressions': 'off',
         '@typescript-eslint/semi': 'off',
         '@typescript-eslint/comma-dangle': 'off',
+      },
+    },
+    {
+      files: ['**/__meta__/*.svelte'],
+      rules: {
+        'svelte/block-lang': 'off',
       },
     },
   ],

--- a/mathesar_ui/src/component-library/badge/Badge.svelte
+++ b/mathesar_ui/src/component-library/badge/Badge.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="badge">
   <slot />
 </span>

--- a/mathesar_ui/src/component-library/margin-trim/MarginTrim.svelte
+++ b/mathesar_ui/src/component-library/margin-trim/MarginTrim.svelte
@@ -1,6 +1,7 @@
 <!--
   @component Trims the outer margins of its children.
 -->
+<script lang="ts"></script>
 
 <div class="margin-trim">
   <slot />

--- a/mathesar_ui/src/component-library/match-highlighter/Match.svelte
+++ b/mathesar_ui/src/component-library/match-highlighter/Match.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="match"><slot /></span>
 
 <style>

--- a/mathesar_ui/src/component-library/menu/MenuDivider.svelte
+++ b/mathesar_ui/src/component-library/menu/MenuDivider.svelte
@@ -1,1 +1,3 @@
+<script lang="ts"></script>
+
 <div class="menu-divider" />

--- a/mathesar_ui/src/component-library/menu/MenuHeading.svelte
+++ b/mathesar_ui/src/component-library/menu/MenuHeading.svelte
@@ -1,1 +1,3 @@
+<script lang="ts"></script>
+
 <div class="menu-heading" {...$$restProps}><slot /></div>

--- a/mathesar_ui/src/components/Default.svelte
+++ b/mathesar_ui/src/components/Default.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import PostgresKeyword from './PostgresKeyword.svelte';
 </script>
 

--- a/mathesar_ui/src/components/EntityType.svelte
+++ b/mathesar_ui/src/components/EntityType.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="entity-type"><slot /></span>
 
 <style>

--- a/mathesar_ui/src/components/Form.svelte
+++ b/mathesar_ui/src/components/Form.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="form">
   <slot />
 </div>

--- a/mathesar_ui/src/components/Identifier.svelte
+++ b/mathesar_ui/src/components/Identifier.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="identifier"><slot /></span>
 
 <style>

--- a/mathesar_ui/src/components/InsetPageSection.svelte
+++ b/mathesar_ui/src/components/InsetPageSection.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="inset-page-section">
   {#if $$slots.header}
     <div class="header"><slot name="header" /></div>

--- a/mathesar_ui/src/components/KeyboardKey.svelte
+++ b/mathesar_ui/src/components/KeyboardKey.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="keyboard-key"><slot /></span>
 
 <style>

--- a/mathesar_ui/src/components/Logo.svelte
+++ b/mathesar_ui/src/components/Logo.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <svg width="1em" height="1em" viewBox="0 0 26 26">
   <path
     class="outer"

--- a/mathesar_ui/src/components/Null.svelte
+++ b/mathesar_ui/src/components/Null.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import PostgresKeyword from './PostgresKeyword.svelte';
 </script>
 

--- a/mathesar_ui/src/components/PostgresKeyword.svelte
+++ b/mathesar_ui/src/components/PostgresKeyword.svelte
@@ -1,1 +1,3 @@
+<script lang="ts"></script>
+
 <span class="postgres-keyword"><slot /></span>

--- a/mathesar_ui/src/components/form/FieldHelp.svelte
+++ b/mathesar_ui/src/components/form/FieldHelp.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="field-help"><slot /></span>
 
 <style>

--- a/mathesar_ui/src/components/form/FieldLayout.svelte
+++ b/mathesar_ui/src/components/form/FieldLayout.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <span class="field" {...$$restProps}>
   <slot />
 </span>

--- a/mathesar_ui/src/components/form/FormBox.svelte
+++ b/mathesar_ui/src/components/form/FormBox.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="form-box"><slot /></div>
 
 <style>

--- a/mathesar_ui/src/components/grid-form/GridFormDivider.svelte
+++ b/mathesar_ui/src/components/grid-form/GridFormDivider.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="divider" />
 <div class="divider" />
 

--- a/mathesar_ui/src/components/grid-table/GridTable.svelte
+++ b/mathesar_ui/src/components/grid-table/GridTable.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="grid-table" {...$$restProps}>
   <slot />
 </div>

--- a/mathesar_ui/src/pages/database/settings/SettingsContentLayout.svelte
+++ b/mathesar_ui/src/pages/database/settings/SettingsContentLayout.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="settings-content">
   <header>
     <div class="title">

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/TableMode.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/TableMode.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { _ } from 'svelte-i18n';
 
   import { getTabularDataStoreFromContext } from '@mathesar/stores/table-data';


### PR DESCRIPTION
This PR adds a lint rule requiring all Svelte components to have a `<script lang="ts">` block.

The motivation is to fix a minor dev-tooling annoyance I've been having. For some reason, VS Code started showing errors like this a few months ago:

![Screenshot_20241030_105234](https://github.com/user-attachments/assets/ab510868-ae81-4bfc-b851-ae6541d6d06d)

I finally figured out why — it's because some components don't have a `<script>` block, or they don't have one with `lang="ts"`.

I haven't spent time trying to figure out why I didn't get this error before or how to get it to go away without code changes, but I did notice this lint rule [svelte/block-lang](https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang/) that fixes it. Since there aren't that many offending components, I figure it might be worth enabling this. Is this okay with you, @pavish?



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

