### PR TITLE
Implement users.delete RPC function to replace DELETE /api/ui/v0/users/{userId}/ endpoint

### DIFF
--- a/mathesar/api/rpc/users/base.py
+++ b/mathesar/api/rpc/users/base.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -7,10 +5,11 @@ from mathesar.api.exceptions import APIError
 from mathesar.api.decorators import (
     rpc_method,
     http_basic_auth_superuser_required,
-    handle_rpc_exceptions
+    handle_rpc_exceptions,
 )
 
 User = get_user_model()
+
 
 @rpc_method(name='users.delete')
 @http_basic_auth_superuser_required
@@ -19,10 +18,8 @@ def delete(
         *,
         user_id: int,
 ) -> None:
-
     try:
         user = User.objects.get(id=user_id)
-        
 
         if user.is_superuser:
             superuser_count = User.objects.filter(is_superuser=True).count()
@@ -32,9 +29,9 @@ def delete(
                     code="last_superuser_deletion_attempted",
                     status_code=400
                 )
-        
+
         user.delete()
-        
+
     except ObjectDoesNotExist:
         raise APIError(
             f"User with ID {user_id} not found.",

--- a/mathesar/api/rpc/users/base.py
+++ b/mathesar/api/rpc/users/base.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+
+from mathesar.api.exceptions import APIError
+from mathesar.api.decorators import (
+    rpc_method,
+    http_basic_auth_superuser_required,
+    handle_rpc_exceptions
+)
+
+User = get_user_model()
+
+@rpc_method(name='users.delete')
+@http_basic_auth_superuser_required
+@handle_rpc_exceptions
+def delete(
+        *,
+        user_id: int,
+) -> None:
+
+    try:
+        user = User.objects.get(id=user_id)
+        
+
+        if user.is_superuser:
+            superuser_count = User.objects.filter(is_superuser=True).count()
+            if superuser_count <= 1:
+                raise APIError(
+                    "Cannot delete the last superuser.",
+                    code="last_superuser_deletion_attempted",
+                    status_code=400
+                )
+        
+        user.delete()
+        
+    except ObjectDoesNotExist:
+        raise APIError(
+            f"User with ID {user_id} not found.",
+            code="user_not_found",
+            status_code=404
+        )


### PR DESCRIPTION
Fixes #4000 

This pull request implements the users.delete RPC function to replace the existing DELETE /api/ui/v0/users/{userId}/ endpoint. The function follows the specified signature and includes necessary decorators for authorization and error handling. This change enhances the API's structure by moving user model manipulations to the RPC layer, improving maintainability and scalability.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
