### PR TITLE
Docs and tests for `users.*` RPC endpoints

### DIFF
--- a/docs/docs/api/rpc.md
+++ b/docs/docs/api/rpc.md
@@ -317,3 +317,19 @@ Unrecognized errors from a given library return a "round number" code, so an unk
       - replace_for_roles
       - transfer_ownership
       - TablePrivileges
+
+## Users
+
+::: users
+    options:
+      members:
+      - list_
+      - get
+      - add
+      - delete
+      - patch_self
+      - patch_other
+      - replace_own
+      - revoke
+      - UserInfo
+      - UserDef

--- a/mathesar/rpc/users.py
+++ b/mathesar/rpc/users.py
@@ -231,7 +231,7 @@ def replace_own(
     """
     user = kwargs.get(REQUEST_KEY).user
     if not user.check_password(old_password):
-        raise Exception('Old password is not correct')
+        raise Exception('Old password is incorrect')
     change_password(user.id, new_password)
 
 

--- a/mathesar/rpc/users.py
+++ b/mathesar/rpc/users.py
@@ -22,6 +22,17 @@ from mathesar.utils.users import (
 
 
 class UserInfo(TypedDict):
+    """
+    Information about a mathesar user.
+
+    Attributes:
+        id: The Django id of the user.
+        username: The username of the user.
+        is_superuser: Specifies whether the user is a superuser.
+        email: The email of the user.
+        full_name: The full name of the user.
+        display_language: Specifies the display language for the user, can be either `en` or `ja`.
+    """
     id: int
     username: str
     is_superuser: bool
@@ -42,6 +53,17 @@ class UserInfo(TypedDict):
 
 
 class UserDef(TypedDict):
+    """
+    Definition for creating a mathesar user.
+
+    Attributes:
+        username: The username of the user.
+        password: The password of the user.
+        is_superuser: Whether the user is a superuser.
+        email: The email of the user.
+        full_name: The full name of the user.
+        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+    """
     username: str
     password: str
     is_superuser: bool
@@ -54,6 +76,18 @@ class UserDef(TypedDict):
 @http_basic_auth_superuser_required
 @handle_rpc_exceptions
 def add(*, user_def: UserDef) -> UserInfo:
+    """
+    Add a new mathesar user.
+
+    Args:
+        user_def: A dict describing the user to create.
+
+    Privileges:
+        This endpoint requires the caller to be a superuser.
+
+    Returns:
+        The information of the created user.
+    """
     user = add_user(user_def)
     return UserInfo.from_model(user)
 
@@ -62,6 +96,15 @@ def add(*, user_def: UserDef) -> UserInfo:
 @http_basic_auth_superuser_required
 @handle_rpc_exceptions
 def delete(*, user_id: int) -> None:
+    """
+    Delete a mathesar user.
+
+    Args:
+        user_id: The Django id of the user to delete.
+
+    Privileges:
+        This endpoint requires the caller to be a superuser.
+    """
     delete_user(user_id)
 
 
@@ -69,6 +112,15 @@ def delete(*, user_id: int) -> None:
 @http_basic_auth_login_required
 @handle_rpc_exceptions
 def get(*, user_id: int) -> UserInfo:
+    """
+    List information about a mathesar user.
+
+    Args:
+        user_id: The Django id of the user.
+
+    Returns:
+        User information for a given user_id.
+    """
     user = get_user(user_id)
     return UserInfo.from_model(user)
 
@@ -77,6 +129,12 @@ def get(*, user_id: int) -> UserInfo:
 @http_basic_auth_login_required
 @handle_rpc_exceptions
 def list_() -> list[UserInfo]:
+    """
+    List information about all mathesar users. Exposed as `list`.
+
+    Returns:
+        A list of information about mathesar users.
+    """
     users = list_users()
     return [UserInfo.from_model(user) for user in users]
 
@@ -92,6 +150,18 @@ def patch_self(
     display_language: str,
     **kwargs
 ) -> UserInfo:
+    """
+    Alter details of currently logged in mathesar user.
+
+    Args:
+        username: The username of the user.
+        email: The email of the user.
+        full_name: The full name of the user.
+        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+
+    Returns:
+        Updated user information of the caller.
+    """
     user = kwargs.get(REQUEST_KEY).user
     updated_user_info = update_self_user_info(
         user_id=user.id,
@@ -115,6 +185,23 @@ def patch_other(
     full_name: str,
     display_language: str
 ) -> UserInfo:
+    """
+    Alter details of a mathesar user, given its user_id.
+
+    Args:
+        user_id: The Django id of the user.
+        username: The username of the user.
+        email: The email of the user.
+        is_superuser: Specifies whether to set the user as a superuser.
+        full_name: The full name of the user.
+        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+
+    Privileges:
+        This endpoint requires the caller to be a superuser.
+
+    Returns:
+        Updated user information for a given user_id.
+    """
     updated_user_info = update_other_user_info(
         user_id=user_id,
         username=username,
@@ -135,6 +222,13 @@ def replace_own(
     new_password: str,
     **kwargs
 ) -> None:
+    """
+    Alter password of currently logged in mathesar user.
+
+    Args:
+        old_password: Old password of the currently logged in user.
+        new_password: New password of the user to set.
+    """
     user = kwargs.get(REQUEST_KEY).user
     if not user.check_password(old_password):
         raise Exception('Old password is not correct')
@@ -149,4 +243,14 @@ def revoke(
     user_id: int,
     new_password: str,
 ) -> None:
+    """
+    Alter password of a mathesar user, given its user_id.
+
+    Args:
+        user_id: The Django id of the user.
+        new_password: New password of the user to set.
+
+    Privileges:
+        This endpoint requires the caller to be a superuser.
+    """
     revoke_password(user_id, new_password)

--- a/mathesar/tests/rpc/test_users.py
+++ b/mathesar/tests/rpc/test_users.py
@@ -1,0 +1,262 @@
+"""
+This file tests the users RPC functions.
+
+Fixtures:
+    rf(pytest-django): Provides mocked `Request` objects.
+    monkeypatch(pytest): Lets you monkeypatch an object for testing.
+"""
+from mathesar.rpc import users
+from mathesar.models.users import User
+
+
+def test_users_list(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(username='alice', password='pass1234')
+
+    def mock_list_users():
+        return [
+            User(
+                id=1,
+                username='alice',
+                is_superuser=True,
+                email='alice@mathesar.org',
+                full_name='Alice Liddell',
+                display_language='en'
+            ),
+            User(
+                id=2,
+                username='bob',
+                is_superuser=False,
+                email='bob@mathesar.org',
+                full_name='Bob Marley',
+                display_language='ja'
+            )
+        ]
+    monkeypatch.setattr(users, 'list_users', mock_list_users)
+    expected_users_list = [
+        {
+            'id': 1,
+            'username': 'alice',
+            'is_superuser': True,
+            'email': 'alice@mathesar.org',
+            'full_name': 'Alice Liddell',
+            'display_language': 'en'
+        },
+        {
+            'id': 2,
+            'username': 'bob',
+            'is_superuser': False,
+            'email': 'bob@mathesar.org',
+            'full_name': 'Bob Marley',
+            'display_language': 'ja'
+        }
+    ]
+    actual_users_list = users.list_()
+    assert actual_users_list == expected_users_list
+
+
+def test_users_get(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(username='alice', password='pass1234')
+    user_id = 1
+
+    def mock_get_user(_user_id):
+        if _user_id != user_id:
+            raise AssertionError('incorrect parameters passed')
+        return User(
+            id=1,
+            username='alice',
+            is_superuser=True,
+            email='alice@mathesar.org',
+            full_name='Alice Liddell',
+            display_language='en'
+        )
+    monkeypatch.setattr(users, 'get_user', mock_get_user)
+    expected_user_info = {
+        'id': 1,
+        'username': 'alice',
+        'is_superuser': True,
+        'email': 'alice@mathesar.org',
+        'full_name': 'Alice Liddell',
+        'display_language': 'en'
+    }
+    actual_user_info = users.get(user_id=user_id)
+    assert actual_user_info == expected_user_info
+
+
+def test_users_add(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(username='alice', password='pass1234')
+    user_def = {
+        'username': 'Bob',
+        'password': 'bobspassword',
+        'is_superuser': False,
+        'email': 'bob@mathesar.org',
+        'full_name': 'Bob Marley',
+        'display_language': 'en'
+    }
+
+    def mock_add_user(_user_def):
+        if _user_def != user_def:
+            raise AssertionError('incorrect parameters passed')
+        return User(
+            id=2,
+            username='Bob',
+            is_superuser=False,
+            email='bob@mathesar.org',
+            full_name='Bob Marley',
+            display_language='en'
+        )
+    monkeypatch.setattr(users, 'add_user', mock_add_user)
+    expected_user_info = {
+        'id': 2,
+        'username': 'Bob',
+        'is_superuser': False,
+        'email': 'bob@mathesar.org',
+        'full_name': 'Bob Marley',
+        'display_language': 'en'
+    }
+    actual_user_info = users.add(user_def=user_def)
+    assert actual_user_info == expected_user_info
+
+
+def test_users_delete(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(username='alice', password='pass1234')
+    user_id = 2
+
+    def mock_delete_user(_user_id):
+        if _user_id != user_id:
+            raise AssertionError('incorrect parameters passed')
+
+    monkeypatch.setattr(users, 'delete_user', mock_delete_user)
+    users.delete(user_id=user_id)
+
+
+def test_users_patch_self(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=2, username='alice', password='pass1234')
+    _user_id = 2
+    _username = 'alice_liddell'
+    _email = 'alice@mathesar.org'
+    _full_name = 'Alice liddell'
+    _display_language = 'en'
+
+    def mock_patch_self(user_id, username, email, full_name, display_language):
+        if (
+            _user_id != user_id
+            and _username != username
+            and _email != email
+            and _full_name != full_name
+            and _display_language != display_language
+        ):
+            raise AssertionError('incorrect parameters passed')
+        return User(
+            id=2,
+            username='alice_liddell',
+            is_superuser=False,
+            email='alice@mathesar.org',
+            full_name='Alice liddell',
+            display_language='en'
+        )
+    monkeypatch.setattr(users, 'update_self_user_info', mock_patch_self)
+    expected_user_info = {
+        'id': 2,
+        'username': 'alice_liddell',
+        'is_superuser': False,
+        'email': 'alice@mathesar.org',
+        'full_name': 'Alice liddell',
+        'display_language': 'en'
+    }
+    actual_user_info = users.patch_self(
+        username=_username,
+        email=_email,
+        full_name=_full_name,
+        display_language=_display_language,
+        request=request
+    )
+    assert actual_user_info == expected_user_info
+
+
+def test_users_other(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=1, username='alice', password='pass1234')
+    _user_id = 2
+    _username = 'bob_marley'
+    _is_superuser = False
+    _email = 'bobm@mathesar.org'
+    _full_name = 'bob Marley'
+    _display_language = 'ja'
+
+    def mock_patch_other(user_id, username, is_superuser, email, full_name, display_language):
+        if (
+            _user_id != user_id
+            and _username != username
+            and _is_superuser != is_superuser
+            and _email != email
+            and _full_name != full_name
+            and _display_language != display_language
+        ):
+            raise AssertionError('incorrect parameters passed')
+        return User(
+            id=2,
+            username='bob_marley',
+            is_superuser=False,
+            email='bobm@mathesar.org',
+            full_name='bob Marley',
+            display_language='ja'
+        )
+    monkeypatch.setattr(users, 'update_other_user_info', mock_patch_other)
+    expected_user_info = {
+        'id': 2,
+        'username': 'bob_marley',
+        'is_superuser': False,
+        'email': 'bobm@mathesar.org',
+        'full_name': 'bob Marley',
+        'display_language': 'ja'
+    }
+    actual_user_info = users.patch_other(
+        user_id=_user_id,
+        username=_username,
+        is_superuser=_is_superuser,
+        email=_email,
+        full_name=_full_name,
+        display_language=_display_language
+    )
+    assert actual_user_info == expected_user_info
+
+
+def test_users_replace_own(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=2, username='bob', password='bobs_old_password')
+    request.user.set_password('bobs_old_password')
+    _user_id = 2
+    _old_password = 'bobs_old_password'
+    _new_password = 'bobs_new_password'
+
+    def mock_change_password(user_id, new_password):
+        if (
+            _user_id != user_id
+            and _new_password != new_password
+        ):
+            raise AssertionError('incorrect parameters passed')
+
+    monkeypatch.setattr(users, 'change_password', mock_change_password)
+    users.replace_own(old_password=_old_password, new_password=_new_password, request=request)
+
+
+def test_users_revoke(rf, monkeypatch):
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=1, username='alice', password='pass1234')
+    _user_id = 3
+    _new_password = 'bobs_new_password'
+
+    def mock_revoke_password(user_id, new_password):
+        if (
+            _user_id != user_id
+            and _new_password != new_password
+        ):
+            raise AssertionError('incorrect parameters passed')
+
+    monkeypatch.setattr(users, 'revoke', mock_revoke_password)
+    users.revoke(user_id=_user_id, new_password=_new_password)


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4029

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
