### PR TITLE
Add `mathesar_rpc_method` decorator

### DIFF
--- a/mathesar/rpc/collaborators.py
+++ b/mathesar/rpc/collaborators.py
@@ -1,11 +1,8 @@
 from typing import TypedDict
 
-from modernrpc.core import rpc_method
-from modernrpc.auth.basic import http_basic_auth_login_required, http_basic_auth_superuser_required
-
 from mathesar.models.base import UserDatabaseRoleMap, Database, ConfiguredRole
 from mathesar.models.users import User
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class CollaboratorInfo(TypedDict):
@@ -33,9 +30,7 @@ class CollaboratorInfo(TypedDict):
         )
 
 
-@rpc_method(name="collaborators.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="collaborators.list", auth="login")
 def list_(*, database_id: int = None, **kwargs) -> list[CollaboratorInfo]:
     """
     List information about collaborators. Exposed as `list`.
@@ -56,9 +51,7 @@ def list_(*, database_id: int = None, **kwargs) -> list[CollaboratorInfo]:
     return [CollaboratorInfo.from_model(db_model) for db_model in user_database_role_map_qs]
 
 
-@rpc_method(name='collaborators.add')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="collaborators.add")
 def add(
         *,
         database_id: int,
@@ -86,9 +79,7 @@ def add(
     return CollaboratorInfo.from_model(collaborator)
 
 
-@rpc_method(name='collaborators.delete')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="collaborators.delete")
 def delete(*, collaborator_id: int, **kwargs):
     """
     Delete a collaborator from a database.
@@ -100,9 +91,7 @@ def delete(*, collaborator_id: int, **kwargs):
     collaborator.delete()
 
 
-@rpc_method(name='collaborators.set_role')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="collaborators.set_role")
 def set_role(
         *,
         collaborator_id: int,

--- a/mathesar/rpc/columns/base.py
+++ b/mathesar/rpc/columns/base.py
@@ -3,8 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing table columns.
 """
 from typing import Literal, Optional, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.columns import (
     add_columns_to_table,
@@ -13,7 +12,7 @@ from db.columns import (
     get_column_info_for_table,
 )
 from mathesar.rpc.columns.metadata import ColumnMetaDataBlob
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 from mathesar.utils.columns import get_columns_meta_data
 
@@ -195,9 +194,7 @@ class ColumnInfo(TypedDict):
         )
 
 
-@rpc_method(name="columns.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.list", auth="login")
 def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ColumnInfo]:
     """
     List information about columns for a table. Exposed as `list`.
@@ -215,9 +212,7 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ColumnInfo]:
     return [ColumnInfo.from_dict(col) for col in raw_column_info]
 
 
-@rpc_method(name="columns.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.add", auth="login")
 def add(
         *,
         column_data_list: list[CreatableColumnInfo],
@@ -245,9 +240,7 @@ def add(
         return add_columns_to_table(table_oid, column_data_list, conn)
 
 
-@rpc_method(name="columns.patch")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.patch", auth="login")
 def patch(
         *,
         column_data_list: list[SettableColumnInfo],
@@ -273,9 +266,7 @@ def patch(
         return alter_columns_in_table(table_oid, column_data_list, conn)
 
 
-@rpc_method(name="columns.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.delete", auth="login")
 def delete(
         *, column_attnums: list[int], table_oid: int, database_id: int, **kwargs
 ) -> int:
@@ -295,9 +286,7 @@ def delete(
         return drop_columns_from_table(table_oid, column_attnums, conn)
 
 
-@rpc_method(name="columns.list_with_metadata")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.list_with_metadata", auth="login")
 def list_with_metadata(*, table_oid: int, database_id: int, **kwargs) -> list:
     """
     List information about columns for a table, along with the metadata associated with each column.

--- a/mathesar/rpc/columns/metadata.py
+++ b/mathesar/rpc/columns/metadata.py
@@ -3,10 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing column metadata.
 """
 from typing import Literal, Optional, TypedDict
 
-from modernrpc.core import rpc_method
-from modernrpc.auth.basic import http_basic_auth_login_required
-
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.utils.columns import get_columns_meta_data, set_columns_meta_data
 
 
@@ -128,9 +125,7 @@ class ColumnMetaDataBlob(TypedDict):
         )
 
 
-@rpc_method(name="columns.metadata.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.metadata.list", auth="login")
 def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ColumnMetaDataRecord]:
     """
     List metadata associated with columns for a table. Exposed as `list`.
@@ -148,9 +143,7 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ColumnMetaDataR
     ]
 
 
-@rpc_method(name="columns.metadata.set")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="columns.metadata.set", auth="login")
 def set_(
     *,
     column_meta_data_list: list[ColumnMetaDataBlob],

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -3,15 +3,14 @@ Classes and functions exposed to the RPC endpoint for managing table constraints
 """
 from typing import Optional, TypedDict, Union
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.constraints import (
     get_constraints_for_table,
     create_constraint,
     drop_constraint_via_oid,
 )
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 
 
@@ -113,9 +112,7 @@ class ConstraintInfo(TypedDict):
         )
 
 
-@rpc_method(name="constraints.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="constraints.list", auth="login")
 def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]:
     """
     List information about constraints in a table. Exposed as `list`.
@@ -133,9 +130,7 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
         return [ConstraintInfo.from_dict(con) for con in con_info]
 
 
-@rpc_method(name="constraints.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
     table_oid: int,
@@ -158,9 +153,7 @@ def add(
         return create_constraint(table_oid, constraint_def_list, conn)
 
 
-@rpc_method(name="constraints.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:
     """
     Delete a constraint from a table.

--- a/mathesar/rpc/data_modeling.py
+++ b/mathesar/rpc/data_modeling.py
@@ -3,17 +3,14 @@ Classes and functions exposed to the RPC endpoint for managing data models.
 """
 from typing import TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db import links, tables
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 
 
-@rpc_method(name="data_modeling.add_foreign_key_column")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="data_modeling.add_foreign_key_column", auth="login")
 def add_foreign_key_column(
         *,
         column_name: str,
@@ -52,9 +49,7 @@ class MappingColumn(TypedDict):
     referent_table_oid: int
 
 
-@rpc_method(name="data_modeling.add_mapping_table")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="data_modeling.add_mapping_table", auth="login")
 def add_mapping_table(
         *,
         table_name: str,
@@ -82,9 +77,7 @@ def add_mapping_table(
         )
 
 
-@rpc_method(name="data_modeling.suggest_types")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="data_modeling.suggest_types", auth="login")
 def suggest_types(*, table_oid: int, database_id: int, **kwargs) -> dict:
     """
     Infer the best type for each column in the table.
@@ -118,9 +111,7 @@ class SplitTableInfo(TypedDict):
     new_fkey_attnum: int
 
 
-@rpc_method(name="data_modeling.split_table")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="data_modeling.split_table", auth="login")
 def split_table(
     *,
     table_oid: int,
@@ -154,9 +145,7 @@ def split_table(
         )
 
 
-@rpc_method(name="data_modeling.move_columns")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="data_modeling.move_columns", auth="login")
 def move_columns(
     *,
     source_table_oid: int,

--- a/mathesar/rpc/databases/base.py
+++ b/mathesar/rpc/databases/base.py
@@ -1,15 +1,11 @@
 from typing import Literal, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import (
-    http_basic_auth_login_required,
-    http_basic_auth_superuser_required,
-)
+from modernrpc.core import REQUEST_KEY
 
 from db.databases import get_database, drop_database
 from mathesar.models.base import Database
 from mathesar.rpc.utils import connect
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class DatabaseInfo(TypedDict):
@@ -26,7 +22,7 @@ class DatabaseInfo(TypedDict):
     oid: int
     name: str
     owner_oid: int
-    current_role_priv: list[Literal['CONNECT', 'CREATE', 'TEMPORARY']]
+    current_role_priv: list[Literal["CONNECT", "CREATE", "TEMPORARY"]]
     current_role_owns: bool
 
     @classmethod
@@ -40,9 +36,7 @@ class DatabaseInfo(TypedDict):
         )
 
 
-@rpc_method(name="databases.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.get", auth="login")
 def get(*, database_id: int, **kwargs) -> DatabaseInfo:
     """
     Get information about a database.
@@ -59,9 +53,7 @@ def get(*, database_id: int, **kwargs) -> DatabaseInfo:
     return DatabaseInfo.from_dict(db_info)
 
 
-@rpc_method(name="databases.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.delete", auth="login")
 def delete(*, database_oid: int, database_id: int, **kwargs) -> None:
     """
     Drop a database from the server.
@@ -75,9 +67,7 @@ def delete(*, database_oid: int, database_id: int, **kwargs) -> None:
         drop_database(database_oid, conn)
 
 
-@rpc_method(name="databases.upgrade_sql")
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.upgrade_sql")
 def upgrade_sql(
         *, database_id: int, username: str = None, password: str = None
 ) -> None:

--- a/mathesar/rpc/databases/configured.py
+++ b/mathesar/rpc/databases/configured.py
@@ -1,10 +1,9 @@
 from typing import TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required, http_basic_auth_superuser_required
+from modernrpc.core import REQUEST_KEY
 
 from mathesar.models.base import Database
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class ConfiguredDatabaseInfo(TypedDict):
@@ -37,9 +36,7 @@ class ConfiguredDatabaseInfo(TypedDict):
         )
 
 
-@rpc_method(name="databases.configured.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.configured.list", auth='login')
 def list_(*, server_id: int = None, **kwargs) -> list[ConfiguredDatabaseInfo]:
     """
     List information about databases for a server. Exposed as `list`.
@@ -68,9 +65,7 @@ def list_(*, server_id: int = None, **kwargs) -> list[ConfiguredDatabaseInfo]:
     return [ConfiguredDatabaseInfo.from_model(db_model) for db_model in database_qs]
 
 
-@rpc_method(name="databases.configured.disconnect")
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.configured.disconnect")
 def disconnect(*, database_id: int, **kwargs) -> None:
     """
     Disconnect a configured database.

--- a/mathesar/rpc/databases/privileges.py
+++ b/mathesar/rpc/databases/privileges.py
@@ -1,7 +1,6 @@
 from typing import Literal, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.roles import (
     list_db_priv,
@@ -10,7 +9,7 @@ from db.roles import (
 )
 from mathesar.rpc.databases.base import DatabaseInfo
 from mathesar.rpc.utils import connect
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class DBPrivileges(TypedDict):
@@ -32,9 +31,7 @@ class DBPrivileges(TypedDict):
         )
 
 
-@rpc_method(name="databases.privileges.list_direct")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.privileges.list_direct", auth="login")
 def list_direct(*, database_id: int, **kwargs) -> list[DBPrivileges]:
     """
     List database privileges for non-inherited roles.
@@ -51,9 +48,7 @@ def list_direct(*, database_id: int, **kwargs) -> list[DBPrivileges]:
     return [DBPrivileges.from_dict(i) for i in raw_db_priv]
 
 
-@rpc_method(name="databases.privileges.replace_for_roles")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.privileges.replace_for_roles", auth="login")
 def replace_for_roles(
         *, privileges: list[DBPrivileges], database_id: int, **kwargs
 ) -> list[DBPrivileges]:
@@ -84,9 +79,7 @@ def replace_for_roles(
     return [DBPrivileges.from_dict(i) for i in raw_db_priv]
 
 
-@rpc_method(name="databases.privileges.transfer_ownership")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="databases.privileges.transfer_ownership", auth="login")
 def transfer_ownership(*, new_owner_oid: int, database_id: int, **kwargs) -> DatabaseInfo:
     """
     Transfers ownership of the current database to a new owner.

--- a/mathesar/rpc/databases/setup.py
+++ b/mathesar/rpc/databases/setup.py
@@ -3,14 +3,13 @@ RPC functions for setting up database connections.
 """
 from typing import TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_superuser_required
+from modernrpc.core import REQUEST_KEY
 
 from mathesar.utils import permissions
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 from mathesar.rpc.servers.configured import ConfiguredServerInfo
 from mathesar.rpc.databases.configured import ConfiguredDatabaseInfo
 from mathesar.rpc.roles.configured import ConfiguredRoleInfo
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class DatabaseConnectionResult(TypedDict):
@@ -38,9 +37,7 @@ class DatabaseConnectionResult(TypedDict):
         )
 
 
-@rpc_method(name='databases.setup.create_new')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='databases.setup.create_new')
 def create_new(
         *,
         database: str,
@@ -66,9 +63,7 @@ def create_new(
     return DatabaseConnectionResult.from_model(result)
 
 
-@rpc_method(name='databases.setup.connect_existing')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='databases.setup.connect_existing')
 def connect_existing(
         *,
         host: str,

--- a/mathesar/rpc/decorators.py
+++ b/mathesar/rpc/decorators.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from modernrpc.core import rpc_method
 from modernrpc.auth.basic import (
     http_basic_auth_login_required,
@@ -23,6 +22,7 @@ def mathesar_rpc_method(*, name, auth="superuser"):
         auth_wrap = http_basic_auth_superuser_required
     else:
         raise Exception("`auth` must be 'superuser' or 'login'")
+
     def combo_decorator(f):
         return rpc_method(name=name)(auth_wrap(handle_rpc_exceptions(f)))
     return combo_decorator

--- a/mathesar/rpc/decorators.py
+++ b/mathesar/rpc/decorators.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from modernrpc.core import rpc_method
+from modernrpc.auth.basic import (
+    http_basic_auth_login_required,
+    http_basic_auth_superuser_required,
+)
+from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+
+
+def mathesar_rpc_method(*, name, auth="superuser"):
+    """
+    Construct a decorator to add RPC functionality to functions.
+
+    Args:
+        name: the name of the function that exposed at the RPC endpoint.
+        auth: the authorization wrapper for the function.
+            - "superuser" (default): only superusers can call it.
+            - "login": any logged in user can call it.
+    """
+    if auth == "login":
+        auth_wrap = http_basic_auth_login_required
+    elif auth == "superuser":
+        auth_wrap = http_basic_auth_superuser_required
+    else:
+        raise Exception("`auth` must be 'superuser' or 'login'")
+    def combo_decorator(f):
+        return rpc_method(name=name)(auth_wrap(handle_rpc_exceptions(f)))
+    return combo_decorator

--- a/mathesar/rpc/explorations.py
+++ b/mathesar/rpc/explorations.py
@@ -3,11 +3,10 @@ Classes and functions exposed to the RPC endpoint for managing explorations.
 """
 from typing import Optional, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from mathesar.models.base import Explorations
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 from mathesar.utils.explorations import (
     list_explorations,
@@ -120,9 +119,7 @@ class ExplorationResult(TypedDict):
         )
 
 
-@rpc_method(name="explorations.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.list", auth="login")
 def list_(*, database_id: int, schema_oid: int = None, **kwargs) -> list[ExplorationInfo]:
     """
     List information about explorations for a database. Exposed as `list`.
@@ -138,9 +135,7 @@ def list_(*, database_id: int, schema_oid: int = None, **kwargs) -> list[Explora
     return [ExplorationInfo.from_model(exploration) for exploration in explorations]
 
 
-@rpc_method(name="explorations.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.get", auth="login")
 def get(*, exploration_id: int, **kwargs) -> ExplorationInfo:
     """
     List information about an exploration.
@@ -155,9 +150,7 @@ def get(*, exploration_id: int, **kwargs) -> ExplorationInfo:
     return ExplorationInfo.from_model(exploration)
 
 
-@rpc_method(name="explorations.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.delete", auth="login")
 def delete(*, exploration_id: int, **kwargs) -> None:
     """
     Delete an exploration.
@@ -168,9 +161,7 @@ def delete(*, exploration_id: int, **kwargs) -> None:
     delete_exploration(exploration_id)
 
 
-@rpc_method(name="explorations.run")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.run", auth="login")
 def run(*, exploration_def: ExplorationDef, limit: int = 100, offset: int = 0, **kwargs) -> ExplorationResult:
     """
     Run an exploration.
@@ -184,14 +175,12 @@ def run(*, exploration_def: ExplorationDef, limit: int = 100, offset: int = 0, *
         The result of the exploration run.
     """
     user = kwargs.get(REQUEST_KEY).user
-    with connect(exploration_def['database_id'], user) as conn:
+    with connect(exploration_def["database_id"], user) as conn:
         exploration_result = run_exploration(exploration_def, conn, limit, offset)
     return ExplorationResult.from_dict(exploration_result)
 
 
-@rpc_method(name='explorations.run_saved')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.run_saved", auth="login")
 def run_saved(*, exploration_id: int, limit: int = 100, offset: int = 0, **kwargs) -> ExplorationResult:
     """
     Run a saved exploration.
@@ -211,9 +200,7 @@ def run_saved(*, exploration_id: int, limit: int = 100, offset: int = 0, **kwarg
     return ExplorationResult.from_dict(exploration_result)
 
 
-@rpc_method(name='explorations.replace')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.replace", auth="login")
 def replace(*, new_exploration: ExplorationInfo) -> ExplorationInfo:
     """
     Replace a saved exploration.
@@ -228,9 +215,7 @@ def replace(*, new_exploration: ExplorationInfo) -> ExplorationInfo:
     return ExplorationInfo.from_model(replaced_exp_model)
 
 
-@rpc_method(name='explorations.add')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="explorations.add", auth="login")
 def add(*, exploration_def: ExplorationDef) -> ExplorationInfo:
     """
     Add a new exploration.

--- a/mathesar/rpc/records.py
+++ b/mathesar/rpc/records.py
@@ -3,8 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing table records.
 """
 from typing import Any, Literal, Optional, TypedDict, Union
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.records import (
     list_records_from_table,
@@ -14,7 +13,7 @@ from db.records import (
     add_record_to_table,
     patch_record_in_table,
 )
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 from mathesar.utils.tables import get_table_record_summary_templates
 
@@ -196,9 +195,7 @@ class RecordAdded(TypedDict):
         )
 
 
-@rpc_method(name="records.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.list", auth="login")
 def list_(
         *,
         table_oid: int,
@@ -245,9 +242,7 @@ def list_(
     return RecordList.from_dict(record_info)
 
 
-@rpc_method(name="records.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.get", auth="login")
 def get(
         *,
         record_id: Any,
@@ -291,9 +286,7 @@ def get(
     return RecordList.from_dict(record_info)
 
 
-@rpc_method(name="records.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.add", auth="login")
 def add(
         *,
         record_def: dict,
@@ -334,9 +327,7 @@ def add(
     return RecordAdded.from_dict(record_info)
 
 
-@rpc_method(name="records.patch")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.patch", auth="login")
 def patch(
         *,
         record_def: dict,
@@ -379,9 +370,7 @@ def patch(
     return RecordAdded.from_dict(record_info)
 
 
-@rpc_method(name="records.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.delete", auth="login")
 def delete(
         *,
         record_ids: list[Any],
@@ -410,9 +399,7 @@ def delete(
     return num_deleted
 
 
-@rpc_method(name="records.search")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="records.search", auth="login")
 def search(
         *,
         table_oid: int,

--- a/mathesar/rpc/roles/base.py
+++ b/mathesar/rpc/roles/base.py
@@ -3,11 +3,8 @@ Classes and functions exposed to the RPC endpoint for managing table columns.
 """
 from typing import Optional, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
-from mathesar.rpc.utils import connect
 from db.roles import (
     create_role,
     drop_role,
@@ -15,6 +12,8 @@ from db.roles import (
     list_roles,
     set_members_to_role,
 )
+from mathesar.rpc.decorators import mathesar_rpc_method
+from mathesar.rpc.utils import connect
 
 
 class RoleMember(TypedDict):
@@ -74,9 +73,7 @@ class RoleInfo(TypedDict):
         )
 
 
-@rpc_method(name="roles.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.list", auth="login")
 def list_(*, database_id: int, **kwargs) -> list[RoleInfo]:
     """
     List information about roles for a database server. Exposed as `list`.
@@ -94,9 +91,7 @@ def list_(*, database_id: int, **kwargs) -> list[RoleInfo]:
     return [RoleInfo.from_dict(role) for role in roles]
 
 
-@rpc_method(name="roles.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.add", auth="login")
 def add(
     *,
     rolename: str,
@@ -123,9 +118,7 @@ def add(
     return RoleInfo.from_dict(role)
 
 
-@rpc_method(name="roles.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.delete", auth="login")
 def delete(
     *,
     role_oid: int,
@@ -144,9 +137,7 @@ def delete(
         drop_role(role_oid, conn)
 
 
-@rpc_method(name="roles.get_current_role")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.get_current_role", auth="login")
 def get_current_role(*, database_id: int, **kwargs) -> dict:
     """
     Get information about the current role and all the parent role(s) whose
@@ -167,9 +158,7 @@ def get_current_role(*, database_id: int, **kwargs) -> dict:
     }
 
 
-@rpc_method(name="roles.set_members")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.set_members", auth="login")
 def set_members(
     *,
     parent_role_oid: int,

--- a/mathesar/rpc/roles/configured.py
+++ b/mathesar/rpc/roles/configured.py
@@ -1,10 +1,7 @@
 from typing import TypedDict
 
-from modernrpc.core import rpc_method
-from modernrpc.auth.basic import http_basic_auth_login_required, http_basic_auth_superuser_required
-
 from mathesar.models.base import ConfiguredRole, Server
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class ConfiguredRoleInfo(TypedDict):
@@ -29,9 +26,7 @@ class ConfiguredRoleInfo(TypedDict):
         )
 
 
-@rpc_method(name="roles.configured.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="roles.configured.list", auth="login")
 def list_(*, server_id: int, **kwargs) -> list[ConfiguredRoleInfo]:
     """
     List information about roles configured in Mathesar. Exposed as `list`.
@@ -47,9 +42,7 @@ def list_(*, server_id: int, **kwargs) -> list[ConfiguredRoleInfo]:
     return [ConfiguredRoleInfo.from_model(db_model) for db_model in configured_role_qs]
 
 
-@rpc_method(name='roles.configured.add')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='roles.configured.add')
 def add(
         *,
         server_id: int,
@@ -77,9 +70,7 @@ def add(
     return ConfiguredRoleInfo.from_model(configured_role)
 
 
-@rpc_method(name='roles.configured.delete')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='roles.configured.delete')
 def delete(*, configured_role_id: int, **kwargs):
     """
     Delete a configured role for a server.
@@ -91,9 +82,7 @@ def delete(*, configured_role_id: int, **kwargs):
     configured_role.delete()
 
 
-@rpc_method(name='roles.configured.set_password')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='roles.configured.set_password')
 def set_password(
         *,
         configured_role_id: int,

--- a/mathesar/rpc/schemas/base.py
+++ b/mathesar/rpc/schemas/base.py
@@ -3,8 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing schemas.
 """
 from typing import Literal, Optional, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.constants import INTERNAL_SCHEMAS
 from db.schemas import (
@@ -14,7 +13,7 @@ from db.schemas import (
     list_schemas,
     patch_schema,
 )
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
 
 
@@ -52,9 +51,7 @@ class SchemaPatch(TypedDict):
     description: Optional[str]
 
 
-@rpc_method(name="schemas.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.add", auth="login")
 def add(
     *,
     name: str,
@@ -85,9 +82,7 @@ def add(
         )
 
 
-@rpc_method(name="schemas.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.list", auth="login")
 def list_(*, database_id: int, **kwargs) -> list[SchemaInfo]:
     """
     List information about schemas in a database. Exposed as `list`.
@@ -105,9 +100,7 @@ def list_(*, database_id: int, **kwargs) -> list[SchemaInfo]:
     return [s for s in schemas if s['name'] not in INTERNAL_SCHEMAS]
 
 
-@rpc_method(name="schemas.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.get", auth="login")
 def get(*, schema_oid: int, database_id: int, **kwargs) -> SchemaInfo:
     """
     Get information about a schema in a database.
@@ -125,9 +118,7 @@ def get(*, schema_oid: int, database_id: int, **kwargs) -> SchemaInfo:
     return schema_info
 
 
-@rpc_method(name="schemas.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.delete", auth="login")
 def delete(*, schema_oid: int, database_id: int, **kwargs) -> None:
     """
     Delete a schema, given its OID.
@@ -140,9 +131,7 @@ def delete(*, schema_oid: int, database_id: int, **kwargs) -> None:
         drop_schema_via_oid(conn, schema_oid)
 
 
-@rpc_method(name="schemas.patch")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.patch", auth="login")
 def patch(*, schema_oid: int, database_id: int, patch: SchemaPatch, **kwargs) -> SchemaInfo:
     """
     Patch a schema, given its OID.

--- a/mathesar/rpc/schemas/privileges.py
+++ b/mathesar/rpc/schemas/privileges.py
@@ -1,15 +1,14 @@
 from typing import Literal, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.roles import (
     list_schema_privileges,
     replace_schema_privileges_for_roles,
     transfer_schema_ownership,
 )
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 from mathesar.rpc.schemas.base import SchemaInfo
 
 
@@ -32,9 +31,7 @@ class SchemaPrivileges(TypedDict):
         )
 
 
-@rpc_method(name="schemas.privileges.list_direct")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.privileges.list_direct", auth="login")
 def list_direct(
         *, schema_oid: int, database_id: int, **kwargs
 ) -> list[SchemaPrivileges]:
@@ -54,9 +51,7 @@ def list_direct(
     return [SchemaPrivileges.from_dict(i) for i in raw_priv]
 
 
-@rpc_method(name="schemas.privileges.replace_for_roles")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.privileges.replace_for_roles", auth="login")
 def replace_for_roles(
         *,
         privileges: list[SchemaPrivileges], schema_oid: int, database_id: int,
@@ -90,9 +85,7 @@ def replace_for_roles(
     return [SchemaPrivileges.from_dict(i) for i in raw_priv]
 
 
-@rpc_method(name="schemas.privileges.transfer_ownership")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="schemas.privileges.transfer_ownership", auth="login")
 def transfer_ownership(*, schema_oid: int, new_owner_oid: int, database_id: int, **kwargs) -> SchemaInfo:
     """
     Transfers ownership of a given schema to a new owner.

--- a/mathesar/rpc/servers/configured.py
+++ b/mathesar/rpc/servers/configured.py
@@ -1,10 +1,7 @@
 from typing import TypedDict
 
-from modernrpc.core import rpc_method
-from modernrpc.auth.basic import http_basic_auth_login_required
-
 from mathesar.models.base import Server
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 
 
 class ConfiguredServerInfo(TypedDict):
@@ -29,9 +26,7 @@ class ConfiguredServerInfo(TypedDict):
         )
 
 
-@rpc_method(name="servers.configured.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="servers.configured.list", auth="login")
 def list_() -> list[ConfiguredServerInfo]:
     """
     List information about servers. Exposed as `list`.

--- a/mathesar/rpc/tables/base.py
+++ b/mathesar/rpc/tables/base.py
@@ -3,8 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing tables in a datab
 """
 from typing import Literal, Optional, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.tables import (
     alter_table_on_database,
@@ -18,7 +17,7 @@ from db.tables import (
 from mathesar.imports.csv import import_csv
 from mathesar.rpc.columns import CreatableColumnInfo, SettableColumnInfo, PreviewableColumnInfo
 from mathesar.rpc.constraints import CreatableConstraintInfo
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.tables.metadata import TableMetaDataBlob
 from mathesar.rpc.utils import connect
 from mathesar.utils.tables import list_tables_meta_data, get_table_meta_data
@@ -154,9 +153,7 @@ class JoinableTableInfo(TypedDict):
         )
 
 
-@rpc_method(name="tables.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.list", auth="login")
 def list_(*, schema_oid: int, database_id: int, **kwargs) -> list[TableInfo]:
     """
     List information about tables for a schema. Exposed as `list`.
@@ -176,9 +173,7 @@ def list_(*, schema_oid: int, database_id: int, **kwargs) -> list[TableInfo]:
     ]
 
 
-@rpc_method(name="tables.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.get", auth="login")
 def get(*, table_oid: int, database_id: int, **kwargs) -> TableInfo:
     """
     List information about a table for a schema.
@@ -196,9 +191,7 @@ def get(*, table_oid: int, database_id: int, **kwargs) -> TableInfo:
     return TableInfo(raw_table_info)
 
 
-@rpc_method(name="tables.add")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.add", auth="login")
 def add(
     *,
     schema_oid: int,
@@ -234,9 +227,7 @@ def add(
     return created_table_oid
 
 
-@rpc_method(name="tables.delete")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.delete", auth="login")
 def delete(
     *, table_oid: int, database_id: int, cascade: bool = False, **kwargs
 ) -> str:
@@ -256,9 +247,7 @@ def delete(
         return drop_table_from_database(table_oid, conn, cascade)
 
 
-@rpc_method(name="tables.patch")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.patch", auth="login")
 def patch(
     *, table_oid: str, table_data_dict: SettableTableInfo, database_id: int, **kwargs
 ) -> str:
@@ -278,9 +267,7 @@ def patch(
         return alter_table_on_database(table_oid, table_data_dict, conn)
 
 
-@rpc_method(name="tables.import")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.import", auth="login")
 def import_(
     *,
     data_file_id: int,
@@ -308,9 +295,7 @@ def import_(
         return import_csv(data_file_id, table_name, schema_oid, conn, comment)
 
 
-@rpc_method(name="tables.get_import_preview")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.get_import_preview", auth="login")
 def get_import_preview(
     *,
     table_oid: int,
@@ -336,9 +321,7 @@ def get_import_preview(
         return get_preview(table_oid, columns, conn, limit)
 
 
-@rpc_method(name="tables.list_joinable")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.list_joinable", auth="login")
 def list_joinable(
     *,
     table_oid: int,
@@ -363,9 +346,7 @@ def list_joinable(
         return JoinableTableInfo.from_dict(joinable_dict)
 
 
-@rpc_method(name="tables.list_with_metadata")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.list_with_metadata", auth="login")
 def list_with_metadata(*, schema_oid: int, database_id: int, **kwargs) -> list:
     """
     List tables in a schema, along with the metadata associated with each table
@@ -389,9 +370,7 @@ def list_with_metadata(*, schema_oid: int, database_id: int, **kwargs) -> list:
     return [table | {"metadata": metadata_map.get(table["oid"])} for table in tables]
 
 
-@rpc_method(name="tables.get_with_metadata")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.get_with_metadata", auth="login")
 def get_with_metadata(*, table_oid: int, database_id: int, **kwargs) -> dict:
     """
     Get information about a table in a schema, along with the associated table metadata.

--- a/mathesar/rpc/tables/metadata.py
+++ b/mathesar/rpc/tables/metadata.py
@@ -3,10 +3,7 @@ Classes and functions exposed to the RPC endpoint for managing table metadata.
 """
 from typing import Optional, TypedDict, Union
 
-from modernrpc.core import rpc_method
-from modernrpc.auth.basic import http_basic_auth_login_required
-
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.utils.tables import list_tables_meta_data, set_table_meta_data
 
 
@@ -71,9 +68,7 @@ class TableMetaDataBlob(TypedDict):
         )
 
 
-@rpc_method(name="tables.metadata.list")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.metadata.list", auth="login")
 def list_(*, database_id: int, **kwargs) -> list[TableMetaDataRecord]:
     """
     List metadata associated with tables for a database.
@@ -90,9 +85,7 @@ def list_(*, database_id: int, **kwargs) -> list[TableMetaDataRecord]:
     ]
 
 
-@rpc_method(name="tables.metadata.set")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.metadata.set", auth="login")
 def set_(
     *, table_oid: int, metadata: TableMetaDataBlob, database_id: int, **kwargs
 ) -> None:

--- a/mathesar/rpc/tables/privileges.py
+++ b/mathesar/rpc/tables/privileges.py
@@ -1,15 +1,14 @@
 from typing import Literal, TypedDict
 
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import http_basic_auth_login_required
+from modernrpc.core import REQUEST_KEY
 
 from db.roles import (
     transfer_table_ownership,
     list_table_privileges,
     replace_table_privileges_for_roles,
 )
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.rpc.utils import connect
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
 from mathesar.rpc.tables.base import TableInfo
 
 
@@ -31,9 +30,7 @@ class TablePrivileges(TypedDict):
         )
 
 
-@rpc_method(name="tables.privileges.list_direct")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.privileges.list_direct", auth="login")
 def list_direct(
         *, table_oid: int, database_id: int, **kwargs
 ) -> list[TablePrivileges]:
@@ -51,9 +48,7 @@ def list_direct(
     return [TablePrivileges.from_dict(i) for i in raw_priv]
 
 
-@rpc_method(name="tables.privileges.replace_for_roles")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.privileges.replace_for_roles", auth="login")
 def replace_for_roles(
     *,
     privileges: list[TablePrivileges], table_oid: int, database_id: int,
@@ -87,9 +82,7 @@ def replace_for_roles(
     return [TablePrivileges.from_dict(i) for i in raw_priv]
 
 
-@rpc_method(name="tables.privileges.transfer_ownership")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="tables.privileges.transfer_ownership", auth="login")
 def transfer_ownership(*, table_oid: int, new_owner_oid: int, database_id: int, **kwargs) -> TableInfo:
     """
     Transfers ownership of a given table to a new owner.

--- a/mathesar/rpc/users.py
+++ b/mathesar/rpc/users.py
@@ -2,13 +2,9 @@
 Classes and functions exposed to the RPC endpoint for managing mathesar users.
 """
 from typing import Optional, TypedDict
-from modernrpc.core import rpc_method, REQUEST_KEY
-from modernrpc.auth.basic import (
-    http_basic_auth_login_required,
-    http_basic_auth_superuser_required
-)
+from modernrpc.core import REQUEST_KEY
 
-from mathesar.rpc.exceptions.handlers import handle_rpc_exceptions
+from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.utils.users import (
     get_user,
     list_users,
@@ -72,9 +68,7 @@ class UserDef(TypedDict):
     display_language: Optional[str]
 
 
-@rpc_method(name='users.add')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.add')
 def add(*, user_def: UserDef) -> UserInfo:
     """
     Add a new mathesar user.
@@ -92,9 +86,7 @@ def add(*, user_def: UserDef) -> UserInfo:
     return UserInfo.from_model(user)
 
 
-@rpc_method(name='users.delete')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.delete')
 def delete(*, user_id: int) -> None:
     """
     Delete a mathesar user.
@@ -108,9 +100,7 @@ def delete(*, user_id: int) -> None:
     delete_user(user_id)
 
 
-@rpc_method(name="users.get")
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name="users.get", auth="login")
 def get(*, user_id: int) -> UserInfo:
     """
     List information about a mathesar user.
@@ -125,9 +115,7 @@ def get(*, user_id: int) -> UserInfo:
     return UserInfo.from_model(user)
 
 
-@rpc_method(name='users.list')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.list', auth="login")
 def list_() -> list[UserInfo]:
     """
     List information about all mathesar users. Exposed as `list`.
@@ -139,9 +127,7 @@ def list_() -> list[UserInfo]:
     return [UserInfo.from_model(user) for user in users]
 
 
-@rpc_method(name='users.patch_self')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.patch_self', auth="login")
 def patch_self(
     *,
     username: str,
@@ -173,9 +159,7 @@ def patch_self(
     return UserInfo.from_model(updated_user_info)
 
 
-@rpc_method(name='users.patch_other')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.patch_other')
 def patch_other(
     *,
     user_id: int,
@@ -213,9 +197,7 @@ def patch_other(
     return UserInfo.from_model(updated_user_info)
 
 
-@rpc_method(name='users.password.replace_own')
-@http_basic_auth_login_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.password.replace_own', auth="login")
 def replace_own(
     *,
     old_password: str,
@@ -235,9 +217,7 @@ def replace_own(
     change_password(user.id, new_password)
 
 
-@rpc_method(name='users.password.revoke')
-@http_basic_auth_superuser_required
-@handle_rpc_exceptions
+@mathesar_rpc_method(name='users.password.revoke')
 def revoke(
     *,
     user_id: int,


### PR DESCRIPTION
<!-- Concisely describe what the pull request does. -->

This PR adds a new decorator, `mathesar_rpc_method`, that replaces the boilerplate decorator combination we used to use on RPC functions.
- The `name` parameter sets the exposed name of the RPC function
- The `auth` parameter, if given, determines which auth wrapper is used. See the docstring for details.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
