### PR TITLE
Allowed the record selector modal to remain open on double-clicking the selected FK cell

### DIFF
--- a/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
@@ -69,12 +69,12 @@
     return false; // Parent element not found in the hierarchy
   }
 
-  // Prevents the RecordSelector Modal from closing for 500ms
+  // Prevents the RecordSelector Modal from closing for 300ms
   // after mounting to preserve double click behaviour
   onMount(() => {
     setTimeout(() => {
       controllerCanCancel = true;
-    }, 500);
+    }, 300);
   });
 
 

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
@@ -77,7 +77,6 @@
     }, 300);
   });
 
-
   function onWindowClick(event: MouseEvent) {
     if ($nestedSelectorIsOpen) return;
 
@@ -90,8 +89,6 @@
 
     if (!isElementInside && controllerCanCancel) controller.cancel();
   }
-
-
 </script>
 
 <svelte:window on:keydown={handleKeydown} on:click|capture={onWindowClick} />

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { _ } from 'svelte-i18n';
 
   import { RichText } from '@mathesar/components/rich-text';
@@ -24,6 +25,7 @@
   export let windowPositionerElement: HTMLElement;
 
   let contentHeight = 0;
+  let controllerCanCancel = false;
 
   $: nestedController = new RecordSelectorController({
     nestingLevel: controller.nestingLevel + 1,
@@ -67,6 +69,15 @@
     return false; // Parent element not found in the hierarchy
   }
 
+  // Prevents the RecordSelector Modal from closing for 500ms
+  // after mounting to preserve double click behaviour
+  onMount(() => {
+    setTimeout(() => {
+      controllerCanCancel = true;
+    }, 500);
+  });
+
+
   function onWindowClick(event: MouseEvent) {
     if ($nestedSelectorIsOpen) return;
 
@@ -77,8 +88,10 @@
       currentWindow,
     );
 
-    if (!isElementInside) controller.cancel();
+    if (!isElementInside && controllerCanCancel) controller.cancel();
   }
+
+
 </script>
 
 <svelte:window on:keydown={handleKeydown} on:click|capture={onWindowClick} />


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4037 

<!-- Concisely describe what the pull request does. -->

**Technical details**
I have added a flag called **controllerCanCancel** in the ```mathesar_ui/src/systems/record-selector/RecordSelectorWindow.svelte```  file that doesn't let the modal close until 300ms after it mounts.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
