### PR TITLE
Add spell-checking to MkDocs build process

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -891,7 +891,7 @@ $$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 CREATE OR REPLACE FUNCTION msar.get_fkey_map_table(tab_id oid)
   RETURNS TABLE (target_oid oid, conkey smallint, confkey smallint)
 AS $$/*
-Generate a table mapping foreign key values from refererrer to referant tables.
+Generate a table mapping foreign key values from refererrer to referent tables.
 
 Given an input table (identified by OID), we return a table with each row representing a foreign key
 constraint on that table. We return only single-column foreign keys, and only one per foreign key

--- a/db/sql/10_msar_joinable_tables.sql
+++ b/db/sql/10_msar_joinable_tables.sql
@@ -25,7 +25,7 @@ A Foreign Key path gives the same information in a different form:
 ]
 
 In this form, `constraint_idN` is a foreign key constraint, and `reversed` is a boolean giving
-whether to travel from referrer to referant (when False) or from referant to referrer (when True).
+whether to travel from referrer to referent (when False) or from referent to referrer (when True).
 */
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,23 @@ We have some custom code in `overrides/404.html` which is pretty weird!
 - We have some customizations to the version switcher which are applied within the `extra.css` file.
 - If you modify this, you'll need to port those modifications to all published versions so that the user experience is consistent when switching between versions.
 
+## Spell-checking
+
+We use the [`mkdocs-spellcheck`](https://github.com/pawamoy/mkdocs-spellcheck) plugin to spell-check our documentation.
+
+- CI will fail if there are any spelling errors.
+
+- To check for spelling errors locally, run:
+
+    ```
+    mkdocs build --strict
+    ```
+
+    Spelling errors will be reported as warnings when building in strict mode.
+
+- To configure ignored words, see the `spellcheck` section in `mkdocs.yml` and refer to the [plugin docs](https://github.com/pawamoy/mkdocs-spellcheck) as needed.
+
+- If you happen to be writing documentation content using VS Code, we recommend the Code Spell Checker extension (id: `streetsidesoftware.code-spell-checker`). It will highlight spelling errors in real-time as you type.
 
 ## Page redirects
 

--- a/docs/docs/releases/0.1.3.md
+++ b/docs/docs/releases/0.1.3.md
@@ -54,7 +54,7 @@ This release:
 - Properly detect identity columns _([#3125](https://github.com/centerofci/mathesar/pull/3125))_
 - Wiring sql functions for links and tables _([#3130](https://github.com/centerofci/mathesar/pull/3130))_
 - Tests for alter table _([#3139](https://github.com/centerofci/mathesar/pull/3139))_
-- Add constraint copying to column extration logic _([#3168](https://github.com/centerofci/mathesar/pull/3168))_
+- Add constraint copying to column extraction logic _([#3168](https://github.com/centerofci/mathesar/pull/3168))_
 
 ### Summarization improvements
 

--- a/docs/docs/releases/0.1.4.md
+++ b/docs/docs/releases/0.1.4.md
@@ -40,7 +40,7 @@ _[#3186](https://github.com/mathesar-foundation/mathesar/pull/3186) [#3219](http
 
 ### Text-only imports
 
-When importing CSV data, Mathesar now gives you the option to use `TEXT` as the database type for all columns. This choice speeds up the import for larger data sets by skipping the process of guessing colum types.
+When importing CSV data, Mathesar now gives you the option to use `TEXT` as the database type for all columns. This choice speeds up the import for larger data sets by skipping the process of guessing column types.
 
 ![image](https://github.com/mathesar-foundation/mathesar/assets/42411/6e0b5b1c-2e10-4e1f-8ad3-f4d99d28d8a9)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,6 +68,17 @@ plugins:
             show_root_members_full_path: true
             show_source: false
             group_by_category: false
+  - spellcheck:
+      backends:
+      - codespell:
+          dictionaries: [clear]
+      known_words:
+      - Mathesar
+      ignore_code: yes
+      min_length: 2
+      max_capital: 1
+      allow_unicode: yes
+      strict_only: yes
 
 theme:
   name: material

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ mkdocs-material==8.5.11
 mkdocs-redirects==1.2.0
 mkdocs-macros-plugin==0.7.0
 mkdocs-placeholder-plugin==0.3.1
+mkdocs-spellcheck[codespell]==1.1.0
 mkdocstrings==0.25.2
 mkdocstrings-python==1.10.8

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -77,7 +77,7 @@ class UniqueConstraint(TypedDict):
 
 CreatableConstraintInfo = list[Union[ForeignKeyConstraint, PrimaryKeyConstraint, UniqueConstraint]]
 """
-Type alias for a list of createable constraints which can be unique, primary key, or foreign key constraints.
+Type alias for a list of creatable constraints which can be unique, primary key, or foreign key constraints.
 """
 
 

--- a/mathesar/rpc/databases/privileges.py
+++ b/mathesar/rpc/databases/privileges.py
@@ -18,7 +18,7 @@ class DBPrivileges(TypedDict):
 
     Attributes:
         role_oid: The `oid` of the role on the database server.
-        direct: A list of database privileges for the afforementioned role_oid.
+        direct: A list of database privileges for the aforementioned role_oid.
     """
     role_oid: int
     direct: list[Literal['CONNECT', 'CREATE', 'TEMPORARY']]

--- a/mathesar/rpc/records.py
+++ b/mathesar/rpc/records.py
@@ -89,7 +89,7 @@ class Grouping(TypedDict):
 
     Attributes:
         columns: The columns to be grouped by.
-        preproc: The preprocessing funtions to apply (if any).
+        preproc: The preprocessing functions to apply (if any).
     """
     columns: list[int]
     preproc: list[str]
@@ -123,7 +123,7 @@ class GroupingResponse(TypedDict):
 
     Attributes:
         columns: The columns to be grouped by.
-        preproc: The preprocessing funtions to apply (if any).
+        preproc: The preprocessing functions to apply (if any).
         groups: The groups applicable to the records being returned.
     """
     columns: list[int]

--- a/mathesar/rpc/roles/base.py
+++ b/mathesar/rpc/roles/base.py
@@ -43,7 +43,7 @@ class RoleInfo(TypedDict):
         description: A description of the role
         members: The member roles that directly inherit the role.
 
-    Refer PostgreSQL documenation on:
+    Refer PostgreSQL documentation on:
         - [pg_roles table](https://www.postgresql.org/docs/current/view-pg-roles.html).
         - [Role attributes](https://www.postgresql.org/docs/current/role-attributes.html)
         - [Role membership](https://www.postgresql.org/docs/current/role-membership.html)

--- a/mathesar/rpc/schemas/privileges.py
+++ b/mathesar/rpc/schemas/privileges.py
@@ -18,7 +18,7 @@ class SchemaPrivileges(TypedDict):
 
     Attributes:
         role_oid: The `oid` of the role.
-        direct: A list of schema privileges for the afforementioned role_oid.
+        direct: A list of schema privileges for the aforementioned role_oid.
     """
     role_oid: int
     direct: list[Literal['USAGE', 'CREATE']]

--- a/mathesar/rpc/tables/base.py
+++ b/mathesar/rpc/tables/base.py
@@ -111,7 +111,7 @@ class JoinableTableRecord(TypedDict):
             ]
 
             In this form, `constraint_idN` is a foreign key constraint, and `reversed` is a boolean giving
-            whether to travel from referrer to referant (when False) or from referant to referrer (when True).
+            whether to travel from referrer to referent (when False) or from referent to referrer (when True).
         depth: Specifies how far to search for joinable tables.
         multiple_results: Specifies whether the path included is reversed.
     """

--- a/mathesar/rpc/tables/privileges.py
+++ b/mathesar/rpc/tables/privileges.py
@@ -17,7 +17,7 @@ class TablePrivileges(TypedDict):
     Information about table privileges for a role.
     Attributes:
         role_oid: The `oid` of the role.
-        direct: A list of table privileges for the afforementioned role_oid.
+        direct: A list of table privileges for the aforementioned role_oid.
     """
     role_oid: int
     direct: list[Literal['INSERT', 'SELECT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']]

--- a/mathesar_ui/src/components/rich-text/RichText.svelte
+++ b/mathesar_ui/src/components/rich-text/RichText.svelte
@@ -21,7 +21,7 @@
   For example:
 
   ```
-  The documenation can be found [anchorComponent](here).
+  The documentation can be found [anchorComponent](here).
   ```
 
   The argument 'here' would be translated, and passed to the 'anchorComponent' slot.

--- a/mathesar_ui/src/i18n/languages/en/dict.json
+++ b/mathesar_ui/src/i18n/languages/en/dict.json
@@ -149,7 +149,7 @@
   "data_explorer": "Data Explorer",
   "data_loss_warning_alert": "Data loss can result from changing the data type of a column. This action cannot be undone.",
   "data_source": "Data Source",
-  "data_tabular_format_help": "The data must be in tabular format (CSV, TSV etc) or JSON. See relevant [documentationLink](documenation).",
+  "data_tabular_format_help": "The data must be in tabular format (CSV, TSV etc) or JSON. See relevant [documentationLink](documentation).",
   "data_type": "Data Type",
   "data_type_linked_column_restricted": "The data type of this column must match the referenced column and cannot be changed.",
   "data_type_pk_column_restricted": "The data type of the primary key column is restricted and cannot be changed.",


### PR DESCRIPTION

This PR adds a plugin to our MkDocs site in order to sepll-check the documentation content. It also fixes spelling errors caught by the plugin. Since the plugin runs as part of the MkDocs build step, spelling errors will trigger CI failures via our [test-docs.yml](https://github.com/mathesar-foundation/mathesar/blob/bd1fe16d4ffddddc4c94352b287bfe2929f0f9cd/.github/workflows/test-docs.yml) action which builds the docs in strict mode to ensure there are no build errors or warnings.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.
```

</details>

