### PR TITLE
Sort schemas in Database page and Breadcrumb selector

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -1106,7 +1106,8 @@ LEFT JOIN pg_catalog.pg_class c ON c.relnamespace = s.oid AND c.relkind = 'r'
 GROUP BY
   s.oid,
   s.nspname,
-  s.nspowner;
+  s.nspowner
+ORDER BY s.nspname;
 -- Filter on relkind so that we only count tables. This must be done in the ON clause so that
 -- we still get a row for schemas with no tables.
 $$ LANGUAGE SQL STABLE;

--- a/mathesar_ui/src/components/breadcrumb/SchemaSelector.svelte
+++ b/mathesar_ui/src/components/breadcrumb/SchemaSelector.svelte
@@ -8,7 +8,7 @@
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
   import {
     currentSchemaId,
-    schemas as schemasStore,
+    sortedSchemas as schemasStore,
   } from '@mathesar/stores/schemas';
 
   import BreadcrumbSelector from './BreadcrumbSelector.svelte';

--- a/mathesar_ui/src/pages/database/schemas/SchemasSection.svelte
+++ b/mathesar_ui/src/pages/database/schemas/SchemasSection.svelte
@@ -13,7 +13,7 @@
   import {
     type SchemaStoreData,
     deleteSchema as deleteSchemaAPI,
-    schemas as schemasStore,
+    sortedSchemas as schemasStore,
   } from '@mathesar/stores/schemas';
   import AddEditSchemaModal from '@mathesar/systems/schemas/AddEditSchemaModal.svelte';
   import {

--- a/mathesar_ui/src/stores/schemas.ts
+++ b/mathesar_ui/src/stores/schemas.ts
@@ -13,7 +13,11 @@ import type { Database } from '@mathesar/models/Database';
 import { Schema } from '@mathesar/models/Schema';
 import { getErrorMessage } from '@mathesar/utils/errors';
 import { preloadCommonData } from '@mathesar/utils/preloadData';
-import { type CancellablePromise, collapse } from '@mathesar-component-library';
+import {
+  type CancellablePromise,
+  collapse,
+  unite,
+} from '@mathesar-component-library';
 
 import { databasesStore } from './databases';
 
@@ -174,6 +178,26 @@ export const schemas = collapse(
     return schemasStore;
   }),
 );
+
+function sortSchemas(_schemas: Iterable<Schema>): Schema[] {
+  return [..._schemas].sort((a, b) => get(a.name).localeCompare(get(b.name)));
+}
+
+export const schemaNames = collapse(
+  derived(schemas, ($schemas) =>
+    unite([...$schemas.data.values()].map((s) => s.name)),
+  ),
+);
+
+export const sortedSchemas = derived([schemas, schemaNames], ([$schemas]) => {
+  const schemasMap = new Map(
+    sortSchemas($schemas.data.values()).map((s) => [s.oid, s]),
+  );
+  return {
+    ...$schemas,
+    data: schemasMap,
+  };
+});
 
 export const currentSchema: Readable<Schema | undefined> = derived(
   [currentSchemaId, schemas],


### PR DESCRIPTION
Fixes #1897 

**Technical details**
* This PR sorts list of schemas in the API response (as mentioned in the issue) and also the frontend (since we do not make requests when renaming schemas).
* I do think that the UX behaviour of re-sorting schemas when any schema is renamed needs to rethought, however I've  implemented it since we already use that pattern in other places (eg., tables).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
