### PR TITLE
Execute default expr when not dynamic.

### DIFF
--- a/db/sql/00_msar.sql
+++ b/db/sql/00_msar.sql
@@ -934,6 +934,46 @@ WHERE has_privilege;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
 
 
+CREATE OR REPLACE FUNCTION
+msar.describe_column_default(tab_id regclass, col_id smallint) RETURNS jsonb AS $$/*
+Return a JSONB object describing the default (if any) of the given column in the given table.
+
+The returned JSON will have the form:
+  {
+    "value": <any>,
+    "is_dynamic": <bool>,
+  }
+
+If the default is possibly dynamic, i.e., if "is_dynamic" is true, then "value" will be a text SQL
+expression that generates the default value if evaluated. If it is not dynamic, then "value" is the
+actual default value.
+*/
+DECLARE
+  def_expr text;
+  def_json jsonb;
+BEGIN
+def_expr = CASE
+  WHEN attidentity='' THEN pg_catalog.pg_get_expr(adbin, tab_id)
+  ELSE 'identity'
+END
+FROM pg_catalog.pg_attribute LEFT JOIN pg_catalog.pg_attrdef ON attrelid=adrelid AND attnum=adnum
+WHERE attrelid=tab_id AND attnum=col_id;
+IF def_expr IS NULL THEN
+  RETURN NULL;
+ELSIF msar.is_default_possibly_dynamic(tab_id, col_id) THEN
+  EXECUTE format(
+    'SELECT jsonb_build_object(''value'', %L, ''is_dynamic'', true)', def_expr
+  ) INTO def_json;
+ELSE
+  EXECUTE format(
+    'SELECT jsonb_build_object(''value'', msar.format_data(%s), ''is_dynamic'', false)', def_expr
+  ) INTO def_json;
+END IF;
+RETURN def_json;
+END;
+$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
+
 CREATE OR REPLACE FUNCTION msar.get_column_info(tab_id regclass) RETURNS jsonb AS $$/*
 Given a table identifier, return an array of objects describing the columns of the table.
 
@@ -965,20 +1005,7 @@ SELECT jsonb_agg(
     'type_options', msar.get_type_options(atttypid, atttypmod, attndims),
     'nullable', NOT attnotnull,
     'primary_key', COALESCE(pgi.indisprimary, false),
-    'default',
-    nullif(
-      jsonb_strip_nulls(
-        jsonb_build_object(
-          'value',
-          CASE
-            WHEN attidentity='' THEN pg_get_expr(adbin, tab_id)
-            ELSE 'identity'
-          END,
-          'is_dynamic', msar.is_default_possibly_dynamic(tab_id, attnum)
-        )
-      ),
-      jsonb_build_object()
-    ),
+    'default', msar.describe_column_default(tab_id, attnum),
     'has_dependents', msar.has_dependents(tab_id, attnum),
     'description', msar.col_description(tab_id, attnum),
     'current_role_priv', msar.list_column_privileges_for_current_role(tab_id, attnum),

--- a/db/sql/test_00_msar.sql
+++ b/db/sql/test_00_msar.sql
@@ -2662,7 +2662,7 @@ BEGIN
         "name": "txt",
         "type": "text",
         "default": {
-          "value": "'abc'::text",
+          "value": "abc",
           "is_dynamic": false
         },
         "nullable": true,


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3716 

<!-- Concisely describe what the pull request does. -->

This adds logic that executes the stored default expression for a column and then formats it properly for the given type whenever it's not dynamic.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This should bring the current logic up to parity with the older behavior, or better. Since we now apply the format function to the default before putting it in the JSON for return, we (for example) return Date-type defaults in the same ISO format as the column values. The front end seems to happily consume this.

I modified a test to make sure the new behavior is working.

Note that when the default _is_ dynamic (e.g., `now()` or `GENERATED ALWAYS AS IDENTITY`), we don't attempt to execute it. This is for a number of reasons, but the most important is that we don't want to burn sequence values when listing the columns of a table.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

### Before
![image](https://github.com/user-attachments/assets/46eb98bd-db58-4685-b6bb-f86b1d8920f3)

### After
![image](https://github.com/user-attachments/assets/470d62ad-7646-41e3-8945-76ef33aa5724)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
