### PR TITLE
Fix small problem with schema name in page titles

### DIFF
--- a/mathesar_ui/src/pages/pageTitleUtils.ts
+++ b/mathesar_ui/src/pages/pageTitleUtils.ts
@@ -1,17 +1,10 @@
 import { get } from 'svelte/store';
 import { _ } from 'svelte-i18n';
 
-import { currentSchema } from '@mathesar/stores/schemas';
-
 const SEPARATOR = ' | ';
 
 function makePageTitle(parts: string[]): string {
-  const schema = get(currentSchema);
   const allParts = [...parts];
-  if (schema) {
-    // TODO_BETA: Make this reactive
-    allParts.push(get(schema.name));
-  }
   allParts.push(get(_)('mathesar'));
   return allParts.join(SEPARATOR);
 }


### PR DESCRIPTION
This PR rips out some weird low-level code that was inserting the schema name into HTML page `<title>` elements whenever possible. This code came to my attention because of the `TODO_BETA` comment, but upon closer inspection, I noticed that it was causing this subtle (and low impact) bug where the schema name is included twice in the schema page:

![image](https://github.com/user-attachments/assets/ca24ab0a-c4df-4738-a682-ed46db9b7d13)

Much to my chagrin, apparently I [wrote](https://github.com/mathesar-foundation/mathesar/commit/0e4576563844e1e3dfc3c25187c65033d008c4d9#diff-2d8640a6c116682253c0c2bbfafa694fe15c37b73e190ce2a4f6a623ede8ff1fR7-R11) this logic back on 2022-09-20. But yuck, I do _not_ like that! If we want the schema name to be in page titles, we ought to be setting that at a higher level, like [here](https://github.com/mathesar-foundation/mathesar/blob/026921a5a86982d7323de7a433c5dcd301ff8edf/mathesar_ui/src/pages/table/TablePage.svelte#L72), where on some pages we know we have a schema and on other pages we know we do _not_ have a schema. All in all, I don't think we actually need to worry about include the shcema name in page titles.

This PR simplifies things, removes the `TODO_BETA` comment, and fixes the bug. It does mean that table pages and record pages will no longer include the shcema name, but I don't think that's a problem.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>




