### PR TITLE
Fix UX issue with case-sensitive filtering

### DIFF
--- a/mathesar_ui/src/stores/abstract-types/operations/filtering.ts
+++ b/mathesar_ui/src/stores/abstract-types/operations/filtering.ts
@@ -79,7 +79,6 @@ const equalityFiltersResponse: AbstractTypeFilterDefinitionResponse[] = [
 // This is the API response expected from the server
 // Might be better if we can have this with the types endpoint
 const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
-  ...equalityFiltersResponse,
   {
     id: 'contains_case_insensitive',
     name: 'contains',
@@ -100,6 +99,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     },
     hasParams: true,
   },
+  ...equalityFiltersResponse,
   {
     id: 'uri_scheme_equals',
     name: 'URI scheme is',

--- a/mathesar_ui/src/systems/table-view/actions-pane/record-operations/filter/Filter.svelte
+++ b/mathesar_ui/src/systems/table-view/actions-pane/record-operations/filter/Filter.svelte
@@ -5,6 +5,7 @@
   import { _ } from 'svelte-i18n';
 
   import type { LinkedRecordInputElement } from '@mathesar/components/cell-fabric/data-types/components/linked-record/LinkedRecordUtils';
+  import ProcessedColumnName from '@mathesar/components/column/ProcessedColumnName.svelte';
   import { validateFilterEntry } from '@mathesar/components/filter-entry';
   import { FILTER_INPUT_CLASS } from '@mathesar/components/filter-entry/utils';
   import { iconAddNew } from '@mathesar/icons';
@@ -15,7 +16,7 @@
   } from '@mathesar/stores/table-data';
   import type { FilterCombination } from '@mathesar/stores/table-data/filtering';
   import type RecordSummaryStore from '@mathesar/stores/table-data/record-summaries/RecordSummaryStore';
-  import { Button, Icon } from '@mathesar-component-library';
+  import { ButtonMenuItem, DropdownMenu } from '@mathesar-component-library';
 
   import { deepCloneFiltering } from '../utils';
 
@@ -57,11 +58,8 @@
     filtering.set(newFiltering);
   }
 
-  function addFilter(columnId?: number) {
-    const column =
-      columnId === undefined
-        ? [...processedColumns.values()][0]
-        : processedColumns.get(columnId);
+  function addFilter(columnId: number) {
+    const column = processedColumns.get(columnId);
     if (!column) {
       return;
     }
@@ -135,17 +133,24 @@
   </div>
   {#if processedColumns.size}
     <div class="footer">
-      <Button
-        appearance="secondary"
-        on:click={async () => {
-          addFilter();
-          await tick();
-          activateLastFilterInput();
-        }}
+      <DropdownMenu
+        icon={iconAddNew}
+        label={$_('add_new_filter')}
+        disabled={processedColumns.size === 0}
+        triggerAppearance="secondary"
       >
-        <Icon {...iconAddNew} />
-        <span>{$_('add_new_filter')}</span>
-      </Button>
+        {#each [...processedColumns.values()] as column (column.id)}
+          <ButtonMenuItem
+            on:click={async () => {
+              addFilter(column.id);
+              await tick();
+              activateLastFilterInput();
+            }}
+          >
+            <ProcessedColumnName processedColumn={column} />
+          </ButtonMenuItem>
+        {/each}
+      </DropdownMenu>
     </div>
   {/if}
 </div>

--- a/mathesar_ui/src/systems/table-view/actions-pane/record-operations/group/Group.svelte
+++ b/mathesar_ui/src/systems/table-view/actions-pane/record-operations/group/Group.svelte
@@ -2,8 +2,9 @@
   import type { Writable } from 'svelte/store';
   import { _ } from 'svelte-i18n';
 
-  import ColumnName from '@mathesar/components/column/ColumnName.svelte';
+  import ProcessedColumnName from '@mathesar/components/column/ProcessedColumnName.svelte';
   import GroupEntryComponent from '@mathesar/components/group-entry/GroupEntry.svelte';
+  import { iconAddNew } from '@mathesar/icons';
   import {
     type Grouping,
     type ProcessedColumn,
@@ -70,24 +71,14 @@
   </div>
   <footer>
     <DropdownMenu
+      icon={iconAddNew}
       label={$_('add_new_grouping')}
       disabled={availableColumns.length === 0}
       triggerAppearance="secondary"
     >
       {#each availableColumns as column (column.id)}
         <ButtonMenuItem on:click={() => addGroupColumn(column)}>
-          <ColumnName
-            column={{
-              name: $processedColumns.get(column.id)?.column.name ?? '',
-              type: $processedColumns.get(column.id)?.column.type ?? '',
-              type_options:
-                $processedColumns.get(column.id)?.column.type_options ?? null,
-              constraintsType: getColumnConstraintTypeByColumnId(
-                column.id,
-                $processedColumns,
-              ),
-            }}
-          />
+          <ProcessedColumnName processedColumn={column} />
         </ButtonMenuItem>
       {/each}
     </DropdownMenu>

--- a/mathesar_ui/src/systems/table-view/actions-pane/record-operations/sort/Sort.svelte
+++ b/mathesar_ui/src/systems/table-view/actions-pane/record-operations/sort/Sort.svelte
@@ -2,6 +2,7 @@
   import type { Writable } from 'svelte/store';
   import { _ } from 'svelte-i18n';
 
+  import ProcessedColumnName from '@mathesar/components/column/ProcessedColumnName.svelte';
   import SortEntry from '@mathesar/components/sort-entry/SortEntry.svelte';
   import type { SortDirection } from '@mathesar/components/sort-entry/utils';
   import {
@@ -15,7 +16,11 @@
     getTabularDataStoreFromContext,
   } from '@mathesar/stores/table-data';
   import { getColumnConstraintTypeByColumnId } from '@mathesar/utils/columnUtils';
-  import { Button, Icon } from '@mathesar-component-library';
+  import {
+    ButtonMenuItem,
+    DropdownMenu,
+    Icon,
+  } from '@mathesar-component-library';
 
   const tabularData = getTabularDataStoreFromContext();
 
@@ -23,13 +28,13 @@
   $: ({ processedColumns } = $tabularData);
 
   /** Columns which are not already used as a sorting entry */
-  $: availableColumnIds = [...$processedColumns.values()]
-    .filter((column) => !$sorting.has(column.id))
-    .map((entry) => entry.id);
+  $: availableColumns = [...$processedColumns.values()].filter(
+    (c) => !$sorting.has(c.id),
+  );
+  $: availableColumnIds = availableColumns.map((c) => c.id);
 
-  function addSortColumn() {
-    const [newSortColumnId] = availableColumnIds;
-    sorting.update((s) => s.with(newSortColumnId, 'ASCENDING'));
+  function addSortColumn(columnId: number) {
+    sorting.update((s) => s.with(columnId, 'ASCENDING'));
   }
 
   function removeSortColumn(columnId: number) {
@@ -97,10 +102,18 @@
   </div>
   {#if availableColumnIds.length > 0}
     <div class="footer">
-      <Button appearance="secondary" on:click={addSortColumn}>
-        <Icon {...iconAddNew} />
-        <span>{$_('add_new_sort_condition')}</span>
-      </Button>
+      <DropdownMenu
+        icon={iconAddNew}
+        label={$_('add_new_sort_condition')}
+        disabled={availableColumns.length === 0}
+        triggerAppearance="secondary"
+      >
+        {#each availableColumns as column (column.id)}
+          <ButtonMenuItem on:click={() => addSortColumn(column.id)}>
+            <ProcessedColumnName processedColumn={column} />
+          </ButtonMenuItem>
+        {/each}
+      </DropdownMenu>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
Fixes #4094

## Notes

- Much to my chagrin, the linked issue doesn't do an adequate job describing the original _problem_. Even the issue it supersedes — #4051 — doesn't explain the original problem from the user's perspective. Sorry! 😬

    To understand what's going on here, I think it would be worth spending seven minutes watching this [call](https://tldv.io/app/meetings/677e92c83b23c40013f0146c) (from 37:49 and 45:09). In the call, I explain the problem to @ghislaineguerin and get her approval for the direction I took with the fix here.

- Originally, I had wanted to change the comparison labels to be clearer about whether they are case sensitive. However, in implementing this I eventually decided that I'd rather keep the labels as-is for now.

    I still think it would be nice to communicate the case sensitivity of string comparisons to the user. But there ended up being a number of points stacked against changing the labels once I get into the code and looked at the result of changing it.
    
    Because the label change was my idea originally, I'm hoping it's okay to rescind it without thoroughly explaining all the nuance around my rationale, just for the sake of time. This PR achieves my original goal — the default user flow for filtering a text column is performed in a case-insensitive manner. And so I don't think it's important to address the labeling right now.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


