### PR TITLE
Identify i18n translate function calls made with variables instead of strings

### DIFF
--- a/mathesar_ui/scripts/i18n/check_invalid_calls.py
+++ b/mathesar_ui/scripts/i18n/check_invalid_calls.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+from pathlib import Path
+
+MATHESAR_UI_DIR = Path(__file__).resolve().parent.parent.parent
+
+EN_DICT_FILE = os.path.join(MATHESAR_UI_DIR, 'src/i18n/languages/en/dict.json')
+
+
+# Returns True during these cases:
+#   - Direct: `$_(variable)`
+#   - Considers spaces: `$_(  variable, { values: { date: dateString } })`
+#   - Considers multiple lines. Eg.,
+#       ```
+#       $_(
+#            variable,
+#       )
+#       ```
+def has_invalid_calls():
+    try:
+        pattern = r"\$\_\(\s*[^'\''[:space:]]|get\(_\)\(\s*[^'\''[:space:]]"
+        subprocess.run(
+            [
+                'grep',
+                '-lrEz',
+                pattern,
+                '--include=**.svelte',
+                '--include=**.ts',
+                r'--exclude=\*i18n\*',
+                os.path.join(MATHESAR_UI_DIR, 'src')
+            ],
+            check=True
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+    except Exception:
+        raise
+
+
+def main():
+    if has_invalid_calls():
+        print("i18n strings should not be passed as variables")
+        exit(1)
+    else:
+        print("All OK")
+        exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/mathesar_ui/scripts/i18n/check_unused_strings.py
+++ b/mathesar_ui/scripts/i18n/check_unused_strings.py
@@ -5,6 +5,13 @@ import os
 import subprocess
 from pathlib import Path
 import json
+from check_invalid_calls import has_invalid_calls
+
+
+if has_invalid_calls():
+    print("There are invalid i18n invocations. Please fix them before checking for unused strings")
+    exit(1)
+
 
 MATHESAR_UI_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -51,6 +58,6 @@ with open(EN_DICT_FILE, 'r') as en_dict_file:
     not_found_count = 0
     for key in en_dict_json:
         if not grep_i18n_string(key):
-            print("NOT FOUND: " + key)
+            print("UNUSED: " + key)
             not_found_count += 1
-    print("Number of strings not found: " + str(not_found_count))
+    print("Number of unused strings: " + str(not_found_count))

--- a/mathesar_ui/src/components/rich-text/RichText.svelte
+++ b/mathesar_ui/src/components/rich-text/RichText.svelte
@@ -32,7 +32,7 @@
   example:
 
   ```svelte
-  <RichText text={$_(sometext)} let:slotName let:translatedArg>
+  <RichText text={$_('sometext')} let:slotName let:translatedArg>
     {#if slotName === 'tableName'}
       <TableName {table} />
     {:else if slotName === 'schemaName'}


### PR DESCRIPTION
This PR adds a script to test for any i18n translation call made with variables instead of strings.
Eg., Identifies usage such as `$_(some_variable)` and `get(_)(some_variable)`.

This is an added layer of protection since our check_unused_strings script only checks for strings used directly and does not account for variables. As a pattern, we would also like to avoid any translation call with variables.

This PR is targeted at 0.2.0, but doesn't necessarily have to be merged for the release. It does not affect any code that's shipped.

The change in RichText.svelte is a comment that the script picked up.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
