### PR TITLE
Fix 500 on /auth/login route after password change

### DIFF
--- a/api_tests/test_happy_db_setups.py
+++ b/api_tests/test_happy_db_setups.py
@@ -47,7 +47,7 @@ def intern_session():
         "new_password1": "myinternpass1234",
         "new_password2": "myinternpass1234"
     }
-    s.post(f'{SERVICE_HOST}/auth/password_reset_confirm', data=reset_payload)
+    s.post(f'{SERVICE_HOST}/auth/password_reset_confirm/', data=reset_payload)
     s.headers['X-CSRFToken'] = s.cookies['csrftoken']
     new_login_payload = {"username": "intern", "password": "myinternpass1234"}
     s.post(f'{SERVICE_HOST}/auth/login/', data=new_login_payload)

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -53,6 +53,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      gap: var(--size-xx-large);
     }
     .tutorial, .login-card,
     .login-card form, .login-card .footer {

--- a/mathesar/templates/users/password_reset_confirmation.html
+++ b/mathesar/templates/users/password_reset_confirmation.html
@@ -66,7 +66,7 @@
         <button class="btn btn-primary submit-button" type="submit">
           {% translate "Update Password" %}
         </button>
-        <div class="warning-message">
+        <div class="message-box warning-message">
           <div class="icon">&#9432;</div>
           <div>{% translate "After updating your password, you'll need to log in again." %}</div>
         </div>

--- a/mathesar/templates/users/password_reset_confirmation.html
+++ b/mathesar/templates/users/password_reset_confirmation.html
@@ -63,13 +63,13 @@
         </label>
       </div>
       <div class="footer">
-        <button class="btn btn-primary submit-button" type="submit">
-          {% translate "Update Password" %}
-        </button>
         <div class="message-box warning-message">
           <div class="icon">&#9432;</div>
           <div>{% translate "After updating your password, you'll need to log in again." %}</div>
         </div>
+        <button class="btn btn-primary submit-button" type="submit">
+          {% translate "Update Password" %}
+        </button>
       </div>
     </form>
   {% else %}

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     path('api/db/v0/', include(db_router.urls)),
     path('api/export/v0/tables/', views.export.export_table, name="export_table"),
     path('complete_installation/', installation_incomplete(CompleteInstallationFormView.as_view()), name='complete_installation'),
-    path('auth/password_reset_confirm', MathesarPasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path('auth/password_reset_confirm/', MathesarPasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('auth/login/', installation_complete(LoginView.as_view(redirect_authenticated_user=True)), name='login'),
     path('auth/', include('django.contrib.auth.urls')),
     path('', views.home, name='home'),

--- a/mathesar/views/installation/complete_installation.py
+++ b/mathesar/views/installation/complete_installation.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model, login
 from django.contrib.auth.forms import UserCreationForm
 from django.views.generic import CreateView
+from django.urls import reverse_lazy
 from django import forms
 from mathesar.analytics import upload_initial_report, initialize_analytics
 import logging
@@ -47,7 +48,7 @@ class CompleteInstallationForm(UserCreationForm):
 class CompleteInstallationFormView(CreateView):
     template_name = "installation/complete_installation.html"
     form_class = CompleteInstallationForm
-    success_url = "/auth/login"
+    success_url = reverse_lazy('login')
 
     def form_valid(self, form):
         success = super().form_valid(form)

--- a/mathesar/views/users/password_reset.py
+++ b/mathesar/views/users/password_reset.py
@@ -4,6 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.translation import gettext_lazy as _
+from django.urls import reverse_lazy
 
 
 class MathesarSetPasswordForm(SetPasswordForm):
@@ -22,7 +23,7 @@ class MathesarPasswordResetConfirmView(PasswordResetConfirmView):
     form_class = MathesarSetPasswordForm
     template_name = 'users/password_reset_confirmation.html'
     title = _('Change Default Password')
-    success_url = "/auth/login"
+    success_url = reverse_lazy('login')
 
     @method_decorator(sensitive_post_parameters())
     @method_decorator(never_cache)


### PR DESCRIPTION
Fixes #4162

Note:
- This PR doesn't make any changes to how Django handles trailing slashes
- It only fixes the scenarios where redirections happen between routes. I've identified only two places which needed fixes.
- Additionally, I made a small UI fix. The warning box wasn't styled previously when user resets password. 
  |Previously|Now|
  |---|---|
  | ![Screenshot 2025-01-23 at 10 00 15 PM](https://github.com/user-attachments/assets/40e3befc-8f5e-4d17-a2d2-b1432ae576b4)  | ![Screenshot 2025-01-23 at 10 04 02 PM](https://github.com/user-attachments/assets/69ba9c53-2319-47ad-8321-c41a60169d1a)  |


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
