### PR TITLE
Use relative URLs for screenshots

### DIFF
--- a/docs/docs/releases/0.2.0.md
+++ b/docs/docs/releases/0.2.0.md
@@ -55,13 +55,13 @@ _This page provides a comprehensive list of all changes since version 0.1.7._
 
 We've completely redesigned Mathesar's [access controls](../user-guide/access-control.md) to leverage PostgreSQL's powerful system of roles and privileges. Each Mathesar user will now be assigned to a specific PostgreSQL role so that all their operations on the underlying database will be performed using that role.
 
-![A screenshot of Mathesar's UI showing the "Add Collaborator" modal for a database.](/assets/releases/0.2.0/add-collaborator.png)
+![A screenshot of Mathesar's UI showing the "Add Collaborator" modal for a database.](../assets/releases/0.2.0/add-collaborator.png)
 
 The new system gives Mathesar several new capabilities. You can use Mathesar to configure roles and privileges in PostgreSQL and to set granular access control at the individual schema and table level. Plus Mathesar will respect all these configurations when performed directly in PostgreSQL by database administrators outside of Mathesar. Mathesar also no longer needs a database superuser for day-to-day operations.
 
-![A screenshot of Mathesar's UI depicting the "Roles" database settings page, where roles and their dependent child roles can be managed.](/assets/releases/0.2.0/showcase-roles.png)
+![A screenshot of Mathesar's UI depicting the "Roles" database settings page, where roles and their dependent child roles can be managed.](../assets/releases/0.2.0/showcase-roles.png)
 
-![A screenshot of Mathesar's UI showing the "Permissions" modal for a table, where privleges can be granted to the different database roles.](/assets/releases/0.2.0/showcase-table-permissions.png)
+![A screenshot of Mathesar's UI showing the "Permissions" modal for a table, where privleges can be granted to the different database roles.](../assets/releases/0.2.0/showcase-table-permissions.png)
 
 [#3626](https://github.com/mathesar-foundation/mathesar/pull/3626 "Initial permissions remodel")
 [#3663](https://github.com/mathesar-foundation/mathesar/pull/3663 "Implement RPC endpoint for listing roles in server")
@@ -255,7 +255,7 @@ Some pages in the library management schema that would demo perf improvements we
 
 You can now use Mathesar to [export a table](../user-guide/exporting-data.md) to a CSV file. Any filters and sorting that you've applied to the table will be reflected in the exported data. And all relevant records will be included in the export, even if they are not shown on the current page within Mathesar.
 
-![A screenshot of Mathesar's UI showing the "Export" button on a table page.](/assets/releases/0.2.0/export-button-table-view-arrow.png)
+![A screenshot of Mathesar's UI showing the "Export" button on a table page.](../assets/releases/0.2.0/export-button-table-view-arrow.png)
 
 [#4090](https://github.com/mathesar-foundation/mathesar/pull/4090 "Add ability to export tables")
 
@@ -263,7 +263,7 @@ You can now use Mathesar to [export a table](../user-guide/exporting-data.md) to
 
 When disconnecting a database from Mathesar, you can now choose to remove the Mathesar schemas from the database.
 
-![A screenshot of Mathesar's UI showing the "Disconnect Database" modal, with all options selected except "Specify a role".](/assets/releases/0.2.0/disconnect-db.png)
+![A screenshot of Mathesar's UI showing the "Disconnect Database" modal, with all options selected except "Specify a role".](../assets/releases/0.2.0/disconnect-db.png)
 
 [#4122](https://github.com/mathesar-foundation/mathesar/pull/4122 "Function to remove Mathesar schemas and disconnect DB")
 [#4136](https://github.com/mathesar-foundation/mathesar/pull/4136 "Allow disconnecting server via `databases.configured.disconnect`")
@@ -298,7 +298,7 @@ To help us better understand the ways in which people are using Mathesar, we've 
 
 This usage data will help us make Mathesar better! And it will help us demonstrate Mathesar's traction and impact to potential donors — so we encourage you to enable it.
 
-![A screenshot of Mathesar's UI showing the "Privacy" page with a checkbox to opt out of data collection.](/assets/releases/0.2.0/usage-stats.png)
+![A screenshot of Mathesar's UI showing the "Privacy" page with a checkbox to opt out of data collection.](../assets/releases/0.2.0/usage-stats.png)
 
 We do not collect any personal or sensitive data!
 


### PR DESCRIPTION
## Notes

This PR fixes a problem with the published release notes — due to the multi-versioned docs, the screenshots need to have relative URLs instead of absolute. They looked fine with previewing locally because our local docs preview doesn't have the additional path segment for the version.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


