### PR TITLE
Fixed docs nav capitalization inconsistencies

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,11 +9,11 @@ nav:
   - Administrator Guide:
       - Install using Docker Compose: administration/install-via-docker-compose.md
       - Install from scratch: administration/install-from-scratch.md
-      - Environment Variables: administration/environment-variables.md
+      - Environment variables: administration/environment-variables.md
       - Upgrade Mathesar: administration/upgrade.md
       - Uninstall Mathesar: administration/uninstall.md
       - Debugging Mathesar: administration/debug.md
-      - Postgres & Python Versions: administration/version-support.md
+      - Postgres & Python versions: administration/version-support.md
       
   - User Guide:
       - Introduction: user-guide/index.md
@@ -23,11 +23,11 @@ nav:
           - Tables: user-guide/tables.md
           - Data types: user-guide/data-types.md
           - Relationships: user-guide/relationships.md
-      - Access Control:
+      - Access control:
           - Overview: user-guide/access-control.md
-          - Mathesar Users: user-guide/users.md
-          - PostgreSQL Roles: user-guide/roles.md
-          - Stored Role Passwords: user-guide/stored-role-passwords.md
+          - Mathesar users: user-guide/users.md
+          - PostgreSQL roles: user-guide/roles.md
+          - Stored role passwords: user-guide/stored-role-passwords.md
           - Collaborators: user-guide/collaborators.md
       - Mathesar constructs:
           - Metadata: user-guide/metadata.md
@@ -36,13 +36,13 @@ nav:
           - Importing data: user-guide/importing-data.md
           - Exporting data: user-guide/exporting-data.md
       - Settings:
-          - Usage Data Collection: user-guide/usage-data-collection.md
+          - Usage data collection: user-guide/usage-data-collection.md
   - API:
       - Overview: api/index.md
       - Methods: api/methods.md
   - Releases:
       - '0.2.0': releases/0.2.0.md
-      - Previous Releases:
+      - Previous releases:
           - '0.1.7': releases/0.1.7.md
           - '0.1.6': releases/0.1.6.md
           - '0.1.5': releases/0.1.5.md


### PR DESCRIPTION
It was bugging me. Targeting develop since this seems non-urgent.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
