### PR TITLE
Fix bug in RichText parsing

### DIFF
--- a/mathesar_ui/src/components/rich-text/__tests__/richTextUtils.test.ts
+++ b/mathesar_ui/src/components/rich-text/__tests__/richTextUtils.test.ts
@@ -31,6 +31,19 @@ describe('RichText', () => {
         text('\\(baz_1)foo_2'),
       ],
     ],
+    ['[foo](bar baz)', [slot('foo', 'bar baz')]],
+    [
+      'Read about [link](space travel).',
+      [text('Read about '), slot('link', 'space travel'), text('.')],
+    ],
+    [
+      'foo [button](click here) bar',
+      [text('foo '), slot('button', 'click here'), text(' bar')],
+    ],
+    [
+      'Click [here](this link) to continue.',
+      [text('Click '), slot('here', 'this link'), text(' to continue.')],
+    ],
   ];
   test.each(cases)('parse %# %s', (input, output) => {
     expect(parse(input)).toEqual(output);

--- a/mathesar_ui/src/components/rich-text/richTextUtils.ts
+++ b/mathesar_ui/src/components/rich-text/richTextUtils.ts
@@ -22,7 +22,7 @@ interface ParseState {
 function parseSlot(text: string): ParseState | undefined {
   let token: Token | undefined;
   const remainder = text.replace(
-    /^\[(\w+)\]\((\w+)\)|^\[(\w+)\]/,
+    /^\[(\w+)\]\(([^)]+)\)|^\[(\w+)\]/,
     (
       _,
       nameOfSlotWithArg: string | undefined,


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4185

<!-- Concisely describe what the pull request does. -->
Fixed the issue where RichText component is unable to handle multi-word translated arguments, I changed the Regex pattern in  richTextUtils.ts to allow for spaces as well as created 4 more test cases that checked for multi word arguments.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
[
![Screenshot 2025-01-29 094007](https://github.com/user-attachments/assets/2e7042e4-599d-4950-84b6-0fca8002c81e)
](url)
## This usage of the RichText component above now displays like this on the page
![Screenshot 2025-01-29 094023](https://github.com/user-attachments/assets/6a76c269-4b04-496b-ac2d-e39371c59859)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [X] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
