### PR TITLE
Update collaborators.md

### DIFF
--- a/docs/docs/user-guide/collaborators.md
+++ b/docs/docs/user-guide/collaborators.md
@@ -13,9 +13,10 @@ Note that with collaborators, a user's role is set _per-database_. This means th
 !!! info "Prerequisites"
     Before you can add a new collaborator:
 
-    - Your [database](./databases.md) must be connected already.
-    - The [user](./users.md) must already exist in Mathesar.
-    - The [role](./roles.md) must already exist in PostgreSQL. (If needed, uou can use Mathesar to [add new role](./roles.md#managing) before creating a collaborator.)
+    - Your [database](./databases.md) must be connected already
+    - The [user](./users.md) must already exist in Mathesar
+    - The [role](./roles.md) must already exist in PostgreSQL (you can [use Mathesar](./roles.md#managing))
+    - A password must be [stored](./stored-role-passwords.md) for the role
     - TODO
 
 1. Navigate to the page for your connected database.


### PR DESCRIPTION
Add prerequisite "Password must be stored" for adding a collaborator

Related to #4215

Add one line in the list of prerequisites before adding a collaborator on a database.

**Technical details**
I actually found this through trial and error. I don't know if the behavior is what's wanted. Further improvements are possible.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
