### PR TITLE
Allow patching records in tables with non-integer primary keys

### DIFF
--- a/db/sql/05_msar.sql
+++ b/db/sql/05_msar.sql
@@ -5717,14 +5717,10 @@ The `rec_def` object's form is defined by the record being updated.  It should h
 corresponding to the attnums of desired columns and values corresponding to values we should set.
 */
 DECLARE
-  rec_modified_id integer;
   rec_modified jsonb;
 BEGIN
   EXECUTE format(
-    $p$
-    WITH update_cte AS (%1$s %2$s RETURNING %3$I)
-    SELECT * FROM update_cte
-    $p$,
+    $p$ %1$s %2$s $p$,
     msar.build_update_expr(tab_id, rec_def),
     msar.build_where_clause(
       tab_id, jsonb_build_object(
@@ -5733,12 +5729,11 @@ BEGIN
           jsonb_build_object('type', 'attnum', 'value', msar.get_pk_column(tab_id))
         )
       )
-    ),
-    msar.get_column_name(tab_id, msar.get_pk_column(tab_id))
-  ) INTO rec_modified_id;
+    )
+  );
   rec_modified := msar.get_record_from_table(
     tab_id,
-    rec_modified_id,
+    rec_id,
     return_record_summaries,
     table_record_summary_templates
   );

--- a/db/sql/test_sql_functions.sql
+++ b/db/sql/test_sql_functions.sql
@@ -4624,6 +4624,23 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION test_patch_record_in_table_with_string_pk() RETURNS SETOF TEXT AS $$
+DECLARE
+  rec_id TEXT := 'Millennium Falcon';
+BEGIN
+  CREATE TABLE spaceships(name TEXT PRIMARY KEY, max_speed real);
+  INSERT INTO spaceships VALUES (rec_id, 9.0);
+
+  PERFORM msar.patch_record_in_table('spaceships'::regclass, rec_id, '{"2": 10.3}');
+
+  RETURN NEXT results_eq(
+    format($q$ SELECT max_speed FROM spaceships WHERE name = %L $q$, rec_id),
+    'VALUES (10.3::real)'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION __setup_add_records_table_only_pk() RETURNS SETOF TEXT AS $$
 BEGIN
   CREATE TABLE atable (

--- a/db/sql/test_sql_functions.sql
+++ b/db/sql/test_sql_functions.sql
@@ -4607,6 +4607,23 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION test_patch_record_in_table_with_uuid_pk() RETURNS SETOF TEXT AS $$
+DECLARE
+  rec_id uuid := 'c4e8eb88-8b34-459c-9c1f-778699c1f25f'::uuid;
+BEGIN
+  CREATE TABLE things(id uuid PRIMARY KEY, name TEXT);
+  INSERT INTO things VALUES (rec_id, 'chair');
+
+  PERFORM msar.patch_record_in_table('things'::regclass, rec_id, '{"2": "recliner"}');
+
+  RETURN NEXT results_eq(
+    format($q$ SELECT name FROM things WHERE id = %L $q$, rec_id),
+    $v$ VALUES ('recliner') $v$
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION __setup_add_records_table_only_pk() RETURNS SETOF TEXT AS $$
 BEGIN
   CREATE TABLE atable (


### PR DESCRIPTION
Fixes #4242

## Notes

The bug was caused by:

```sql
DECLARE
  rec_modified_id integer;
```

We can't assume `integer` here.

I don't see why we need `RETURNING` here. I took it out and everything seems to work. All tests passed for me. So if I'm missing something, then it'd be great to see a test or a code comment explaining the need for this extra code that I took out.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

