### PR TITLE
Allow DB name/host/port to be updated

### DIFF
--- a/docs/docs/api/methods.md
+++ b/docs/docs/api/methods.md
@@ -209,7 +209,9 @@
     options:
       members:
       - list_
+      - patch
       - ConfiguredServerInfo
+      - ConfiguredServerPatch
 
 ## Tables
 

--- a/mathesar/rpc/databases/configured.py
+++ b/mathesar/rpc/databases/configured.py
@@ -44,8 +44,10 @@ class ConfiguredDatabasePatch(TypedDict):
     Information to be changed about a configured database
 
     Attributes:
+        name: The name of the database on the server.
         nickname: A optional user-configurable name for the database.
     """
+    name: Optional[str]
     nickname: Optional[str]
 
 
@@ -91,6 +93,8 @@ def patch(*, database_id: int, patch: ConfiguredDatabasePatch, **kwargs) -> Conf
         An object describing the database.
     """
     database = Database.objects.get(id=database_id)
+    if "name" in patch:
+        database.name = patch.get("name")
     if "nickname" in patch:
         database.nickname = patch.get("nickname")
     database.save()

--- a/mathesar/rpc/servers/configured.py
+++ b/mathesar/rpc/servers/configured.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, Optional
 
 from mathesar.models.base import Server
 from mathesar.rpc.decorators import mathesar_rpc_method
@@ -26,6 +26,18 @@ class ConfiguredServerInfo(TypedDict):
         )
 
 
+class ConfiguredServerPatch(TypedDict):
+    """
+    Information to be changed about a server
+
+    Attributes:
+        host: The host of the database server.
+        port: the port of the database server.
+    """
+    host: Optional[str]
+    port: Optional[int]
+
+
 @mathesar_rpc_method(name="servers.configured.list", auth="login")
 def list_() -> list[ConfiguredServerInfo]:
     """
@@ -37,3 +49,24 @@ def list_() -> list[ConfiguredServerInfo]:
     server_qs = Server.objects.all()
 
     return [ConfiguredServerInfo.from_model(db_model) for db_model in server_qs]
+
+
+@mathesar_rpc_method(name="servers.configured.patch")
+def patch(*, server_id: int, patch: ConfiguredServerPatch, **kwargs) -> ConfiguredServerInfo:
+    """
+    Patch a server, given its id.
+
+    Args:
+        server: The Django id of the server
+        patch: An object containing the fields to update.
+
+    Returns:
+        An object describing the server.
+    """
+    server = Server.objects.get(id=server_id)
+    if "host" in patch:
+        server.host = patch.get("host")
+    if "port" in patch:
+        server.port = patch.get("port")
+    server.save()
+    return ConfiguredServerInfo.from_model(server)

--- a/mathesar/tests/rpc/test_endpoints.py
+++ b/mathesar/tests/rpc/test_endpoints.py
@@ -368,6 +368,11 @@ METHODS = [
         "servers.configured.list",
         [user_is_authenticated]
     ),
+    (
+        servers.configured.patch,
+        "servers.configured.patch",
+        [user_is_superuser]
+    ),
 
     (
         tables.add,


### PR DESCRIPTION
## Notes

In our [2024-01-11 meeting](https://tldv.io/app/meetings/67ab7af52cfb840013955ed6) (between 11:59 - 18:15) we decided to allow the user to edit the database name and the server host/port.

This PR makes the necessary backend changes to allow the user to make those edits.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

