### PR TITLE
Upgrade docker compose  to PG 17

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,9 +9,9 @@ services:
       context: .
       dockerfile: Dockerfile.devdb
       args:
-        PG_VERSION: ${PG_VERSION-13}
+        PG_VERSION: ${PG_VERSION-17}
     environment:
-      - PG_VERSION=${PG_VERSION-13}
+      - PG_VERSION=${PG_VERSION-17}
       - POSTGRES_DB=mathesar_django
       - POSTGRES_USER=mathesar
       - POSTGRES_PASSWORD=mathesar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,7 +190,7 @@ services:
   # services, allowing the Mathesar web sevice to connect to it.
   #
   db:
-    image: postgres:13
+    image: pgautoupgrade/pgautoupgrade:17-bookworm
     container_name: mathesar_db
     # This service needs the config variables defined above.
     environment: *config
@@ -200,12 +200,6 @@ services:
       - "5432"
     volumes:
       - ./msar/pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      interval: 5s
-      timeout: 1s
-      retries: 30
-      start_period: 5s
 
   #-----------------------------------------------------------------------------
   # Caddy

--- a/docs/docs/administration/version-support.md
+++ b/docs/docs/administration/version-support.md
@@ -11,11 +11,11 @@ The general strategy of Mathesar is to support whichever versions of Python and 
 - Python 3.9 is supported upstream until October 2025
 - PostgreSQL 13 is supported upstream until November 2025
 
-## Default Python and PostgreSQL versions for Mathesar 0.2.0
+## Default Python and PostgreSQL versions for Mathesar 0.2.1
 
 - Mathesar's Docker image uses PostgreSQL 17.
 - Mathesar's Docker image uses Python 3.13.
-- The default PostgreSQL version provided in our example `docker-compose.yml` is 13.
+- The default PostgreSQL version provided in our example `docker-compose.yml` is 17.
 
 ## Regarding Python Support
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3508 

<!-- Concisely describe what the pull request does. -->

Changes the image specified for the prod `db` service to `pgautoupgrade/pgautoupgrade:17-bookworm`. This will result in

- PostgreSQL 17 being used for new installations, and
- upgrading users' postgres cluster to 17 if they use the new `docker-compose.yml` file.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

- We should recommend users use the new docker compose file if they want to upgrade Postgres, and to continue using their old one if they don't want to upgrade.
- We should instruct users to run `cp -r msar msar.backup` before upgrading PostgreSQL in case anything goes wrong.
- This PR also changes the default PostgreSQL version used in the dev setup. Developers should either set the `PG_VERSION` environment variable (e.g., in the `.env` file) to whatever version they used before, or they should knock out their docker volumes and restart the dev setup with a clean state.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
