### PR TITLE
Docs: remove whitespaces in DOMAIN_NAME and new way to export env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 ALLOWED_HOSTS=".localhost, 127.0.0.1, [::1]"
-SECRET_KEY=2gr6ud88x="(p855_5nbj_+7^bw-iz&n7ldqv%94mjaecl+b9=4"
+SECRET_KEY="2gr6ud88x=(p855_5nbj_+7^bw-iz&n7ldqv%94mjaecl+b9=4"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-ALLOWED_HOSTS=.localhost,127.0.0.1,[::1]
-SECRET_KEY=2gr6ud88x=(p855_5nbj_+7^bw-iz&n7ldqv%94mjaecl+b9=4
+ALLOWED_HOSTS=".localhost, 127.0.0.1, [::1]"
+SECRET_KEY=2gr6ud88x="(p855_5nbj_+7^bw-iz&n7ldqv%94mjaecl+b9=4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ x-config: &config
 #           or https(port 443), also automatically creating SSL certificates 
 #           for the same. If you want to host an instance of Mathesar over the
 #           internet or over your local network, add those domains here.
-#     Example: yourdomain.com,*.subdomain.com,127.0.0.1
+#     Example: yourdomain.com, *.subdomain.com, 127.0.0.1
 #
 # POSTGRES_DB:
 #     Default: mathesar_django

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -20,8 +20,8 @@ This page contains all available environment variables supported by Mathesar. Se
 ### `ALLOWED_HOSTS` {: #allowed_hosts}
 
 - **Description**: A set of strings representing the host/domain names that Django is allowed to serve. This is a security measure to prevent HTTP Host header attacks ([see Django docs](https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts)).
-- **Format**: A set of host/domain names separated by a comma
-- **Default value**: `.localhost,127.0.0.1,[::1]`
+- **Format**: A set of host/domain names separated by a comma and a whitespace
+- **Default value**: `.localhost, 127.0.0.1, [::1]`
 
 
 ## Internal Database configuration {: #db}

--- a/docs/docs/administration/install-from-scratch.md
+++ b/docs/docs/administration/install-from-scratch.md
@@ -171,17 +171,21 @@ Then press <kbd>Enter</kbd> to customize this guide with your domain name.
 
         !!! example
             Your `.env` file should look something like this
+
+            ```
+            SECRET_KEY="REPLACE_THIS_WITH_YOUR_50_CHAR_RANDOMLY_GENERATED_STRING"
+            ALLOWED_HOSTS="xDOMAIN_NAMEx"
+            DOMAIN_NAME="xDOMAIN_NAMEx"
+            POSTGRES_DB="mathesar_django"
+            POSTGRES_USER="mathesar"
+            POSTGRES_PASSWORD="REPLACE_THIS_WITH_APPROPRIATE_PASSWORD_FOR_THE_CHOSEN_POSTGRES_USER"
+            POSTGRES_HOST="localhost"
+            POSTGRES_PORT="5432"
+            ```
+
+        !!! info "Note"
+            Each value in the environment file must be enclosed in double quotes(`""`).
             
-            ```
-            SECRET_KEY=REPLACE_THIS_WITH_YOUR_50_CHAR_RANDOMLY_GENERATED_STRING
-            ALLOWED_HOSTS=xDOMAIN_NAMEx
-            DOMAIN_NAME=xDOMAIN_NAMEx
-            POSTGRES_DB=mathesar_django
-            POSTGRES_USER=mathesar
-            POSTGRES_PASSWORD=REPLACE_THIS_WITH_APPROPRIATE_PASSWORD_FOR_THE_CHOSEN_POSTGRES_USER
-            POSTGRES_HOST=localhost
-            POSTGRES_PORT=5432
-            ```
 
         !!! tip
             To generate a [`SECRET_KEY`](./environment-variables.md#secret_key) you can use this [browser-based generator](https://djecrety.ir/) or run this command on MacOS or Linux:
@@ -191,21 +195,21 @@ Then press <kbd>Enter</kbd> to customize this guide with your domain name.
             ```
 
         !!! tip
-            If you want to host Mathesar on multiple domains/subdomains you can do so by adding multiple comma separated domain names to the following env variables without a whitespace: 
+            To host Mathesar on multiple domains/subdomains simply list the domain names separated by a comma and a whitespace to the following env variables: 
 
             ```
-            DOMAIN_NAME=xDOMAIN_NAMEx,xDOMAIN_NAMEx.example.org
-            ALLOWED_HOSTS=xDOMAIN_NAMEx,xDOMAIN_NAMEx.example.org
+            DOMAIN_NAME="xDOMAIN_NAMEx, xDOMAIN_NAMEx.example.org"
+            ALLOWED_HOSTS="xDOMAIN_NAMEx, xDOMAIN_NAMEx.example.org"
             ```
 
     1. Add the environment variables to the shell
-   
+
         You need to `export` the environment variables listed in the `.env` file to your shell. The easiest way would be to run the below command.
-    
+
           ```
-          export $(cat .env)
+          set -a && source .env && set +a
           ```
-       
+
         !!! warning "Important"
             You need to export the environment variables each time you restart the shell as they don't persist across sessions.
 
@@ -312,7 +316,7 @@ Then press <kbd>Enter</kbd> to customize this guide with your domain name.
 2. Add the configuration details to the CaddyFile
 
     ```
-    {$DOMAIN_NAME:xDOMAIN_NAMEx} {
+    {$DOMAIN_NAME} {
         log {
             output stdout
         }

--- a/docs/docs/administration/install-from-scratch.md
+++ b/docs/docs/administration/install-from-scratch.md
@@ -369,6 +369,7 @@ Then press <kbd>Enter</kbd> to customize this guide with your domain name.
     Type=notify
     User=caddy
     Group=caddy
+    EnvironmentFile=xMATHESAR_INSTALLATION_DIRx/.env
     ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile
     ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
     TimeoutStopSec=5s

--- a/docs/docs/administration/install-via-docker-compose.md
+++ b/docs/docs/administration/install-via-docker-compose.md
@@ -100,7 +100,7 @@ Add your domain(s) or sub-domain(s) to the [`DOMAIN_NAME`](../../configuration/e
 
 !!! example
     ```yaml
-    DOMAIN_NAME: ${DOMAIN_NAME:-yourdomain.org,yoursubdomain.example.org}
+    DOMAIN_NAME: ${DOMAIN_NAME:-yourdomain.org, yoursubdomain.example.org}
     ```
 
 Restart the docker containers for the configuration to take effect.


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4219

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Here is the output using (`source .env`) to export env variable:

![Screenshot 2025-02-20 at 11 46 46 PM](https://github.com/user-attachments/assets/a4b10ae5-684c-4c0e-a050-f33efb370a5b)

Docker _does_ correctly infer the values for the environment variables when they are double quoted.

Relevant caddy docs: https://caddyserver.com/docs/running#environment-variables, https://caddyserver.com/docs/caddyfile/concepts#environment-variables 

Currently, an installation using this method is deployed on https://anish-testing.mathesar.dev & https://demo-testing.mathesar.dev, The credentials are stored in 1Password.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
