### PR TITLE
Fix documentation version chooser

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -267,9 +267,18 @@
   font-size: 0.75rem;
   font-weight: 500;
   background: rgba(255, 255, 255, 0.06);
-  padding: 0.3rem 0.6rem;
+  padding: 0.2rem 0;
   border-radius: 6px;
   transition: all 0.2s ease;
+  height: 1.4rem;
+  align-self: center;
+  line-height: 1;
+  display: inline-flex;
+  margin-left: .5rem;
+}
+
+.md-version__link:is(:focus, :hover) {
+  color: white;
 }
 
 .md-version:hover {


### PR DESCRIPTION
The styling for the Mathesar version chooser in the header was awful. This PR to fix it has already been deployed.

Before:

![image](https://github.com/user-attachments/assets/7b601d37-abd7-42d0-a143-2af653590b06)

After:

![Screenshot From 2025-02-27 13-42-03](https://github.com/user-attachments/assets/1c3c4dad-24c6-48e9-b457-44e575c10baf)


@seancolsen I wasn't sure if this should be based on master and cherry-picked into develop or vise-versa. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
