### PR TITLE
Skip PK column in records.patch from record page

### DIFF
--- a/mathesar_ui/src/pages/record/RecordPageContent.svelte
+++ b/mathesar_ui/src/pages/record/RecordPageContent.svelte
@@ -49,6 +49,28 @@
       })
       .run();
   }
+
+  function shouldPatchIncludeColumn(columnId: string) {
+    const processedColumn = $processedColumns.get(parseInt(columnId, 10));
+    if (!processedColumn) return false;
+
+    // Only patch columns that are not primary keys.
+    //
+    // See https://github.com/mathesar-foundation/mathesar/issues/4318
+    //
+    // It would probably be better to check if the column is editable but we
+    // don't have that information here. It would be good to include that in the
+    // columns API response at some point.
+    return !processedColumn.column.primary_key;
+  }
+
+  function save() {
+    const formValues = Object.entries($form.values);
+    const patch = Object.fromEntries(
+      formValues.filter(([c]) => shouldPatchIncludeColumn(c)),
+    );
+    record.patch(patch);
+  }
 </script>
 
 <div class="record-page-content">
@@ -82,7 +104,7 @@
         catchErrors
         proceedButton={{ label: $_('save'), icon: iconSave }}
         cancelButton={{ label: $_('discard_changes'), icon: iconUndo }}
-        onProceed={() => record.patch($form.values)}
+        onProceed={save}
         getErrorMessages={(e) => {
           const { columnErrors, recordErrors } = getDetailedRecordsErrors(e);
           for (const [columnId, errors] of columnErrors) {


### PR DESCRIPTION
Fixes #4318



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


