### PR TITLE
Fix UUID search

### DIFF
--- a/db/sql/05_msar.sql
+++ b/db/sql/05_msar.sql
@@ -5327,12 +5327,12 @@ $$ LANGUAGE plpgsql STABLE;
 CREATE OR REPLACE FUNCTION
 msar.get_score_expr(tab_id oid, parameters_ jsonb) RETURNS text AS $$
 SELECT string_agg(
-  CASE WHEN pgt.typcategory = 'S' THEN
+  CASE WHEN pgt.typcategory = 'S' OR pgt.typname = 'uuid' THEN
     format(
       $s$(CASE
-        WHEN %1$I ILIKE %2$L THEN 4
-        WHEN %1$I ILIKE %2$L || '%%' THEN 3
-        WHEN %1$I ILIKE '%%' || %2$L || '%%' THEN 2
+        WHEN %1$I::text ILIKE %2$L THEN 4
+        WHEN %1$I::text ILIKE %2$L || '%%' THEN 3
+        WHEN %1$I::text ILIKE '%%' || %2$L || '%%' THEN 2
         ELSE 0
       END)$s$,
       pga.attname,


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2724

<!-- Concisely describe what the pull request does. -->
Fixes search functionality for UUID columns, and enables substring searches within UUIDs.

![Screenshot 2025-03-18 at 8 12 52 PM](https://github.com/user-attachments/assets/efefe097-940f-4d83-9a66-c9719b760ff0)
![Screenshot 2025-03-18 at 8 13 06 PM](https://github.com/user-attachments/assets/fc356acf-a0ec-4a59-9924-fae9ad14976a)
![Screenshot 2025-03-18 at 8 12 31 PM](https://github.com/user-attachments/assets/5d08082f-c961-47e3-9464-97ea1562ab2a)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
