### PR TITLE
4187 invalid uri empty page

### DIFF
--- a/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCellContent.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCellContent.svelte
@@ -2,7 +2,8 @@
   export let isActive = false;
   export let value: string | null | undefined;
   $: isExternalUri =
-    value?.startsWith('http://') || value?.startsWith('https://');
+    value?.toLowerCase().startsWith('http://') ||
+    value?.toLowerCase().startsWith('https://');
   $: htmlPropsForHref =
     isActive && value ? { href: value, target: '_blank' } : {};
   $: htmlPropsForNonLink = value ? { href: null, target: '_blank' } : {};

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCellContent.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCellContent.svelte
@@ -1,22 +1,25 @@
 <script lang="ts">
   export let isActive = false;
   export let value: string | null | undefined;
-
+  $: isExternalUri =
+    value?.startsWith('http://') || value?.startsWith('https://');
   $: htmlPropsForHref =
     isActive && value ? { href: value, target: '_blank' } : {};
+  $: htmlPropsForNonLink = value ? { href: null, target: '_blank' } : {};
 </script>
 
 <!-- svelte-ignore a11y-missing-attribute -->
 <a
-  {...htmlPropsForHref}
-  class:link={isActive}
+  {...isExternalUri ? htmlPropsForHref : htmlPropsForNonLink}
+  class:link={isActive && isExternalUri}
+  class:external-uri={isExternalUri}
   style:pointer-events={isActive ? 'auto' : 'none'}
 >
   <slot />
 </a>
 
 <style>
-  a {
+  .external-uri {
     text-decoration: underline;
   }
   .link {


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4187

<!-- Concisely describe what the pull request does. -->
Invalid URIs could be clicked if the DB datatype for that column was `URI`. The user would then be taken to an empty records page. This PR only allows the clicking and rendering of hyperlinks if the are external URIs. 

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Checks if the link begins with `http://` or `https://`, and only renders those as valid hyperlinks. This _isn't_ full on link validation, but from my understanding solves this particular issue. The errors already handle hyperlink-like data, as shown in the screenshots. If the hyperlink still should be displayed as one, but not clickable, I will make that fix 😄. If you want more robust link validation, I can also fix that. 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
The specific bug URI cannot be clicked anymore, and is not rendered as a hyperlink, since it isn't one.
<img width="728" alt="Screenshot 2025-03-20 at 7 38 20 PM" src="https://github.com/user-attachments/assets/d8c25202-3d27-4311-8e8c-cbe4c4e2e0cc" />

This valid hyperlink can be clicked
<img width="694" alt="Screenshot 2025-03-20 at 7 39 49 PM" src="https://github.com/user-attachments/assets/100dfbb7-8a85-4705-8e55-d8f256d5fecd" />

This error is already handled
<img width="743" alt="Screenshot 2025-03-20 at 7 42 49 PM" src="https://github.com/user-attachments/assets/f110ac08-612b-44d6-8ca6-70297f9ee712" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
