### PR TITLE
Fix CSS issue with inline layout of LabeledInput component

### DIFF
--- a/mathesar_ui/src/component-library/labeled-input/LabeledInput.scss
+++ b/mathesar_ui/src/component-library/labeled-input/LabeledInput.scss
@@ -42,6 +42,15 @@
     }
   }
 
+  &.layout-inline,
+  &.layout-inline-input-first {
+    // This is to avoid having the `<label>` element take up the full width of
+    // its parent. If that happens it can become an annoyingly large click
+    // target. The problem is especially evident when a `Select` component is
+    // used as the input element.
+    max-width: max-content;
+  }
+
   &.layout-inline .label-content {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Fixes #4373

## Notes

Hopefully this isn't too reckless, but I've made this PR against 0.2.2 even though it makes a  far-reaching change to a low-level component.

I think it's safe though.

The new CSS just says:

> Don't make a `LabeledInput` component wider than it needs to be.

This affects a lot of UI, but in a very small way. It means the click targets are more contained. Clicking on empty space no longer targets a `<label>` element that contains an `<input>` element. The problem was especially evident on the UI I added in #4313, but it was all over the app. Ironically enough it's also present here:

![Image](https://github.com/user-attachments/assets/70feb040-4e05-4223-95fc-1bf2e737cb4a)

That overly-large click target is on the same page as the problem mentioned in the linked issue, and it's been there a _long_ time. But it's just less annoying because the associated input is just text, so it doesn't open a dropdown.

I did a pretty thorough audit of our usage of `LabeledInput` and a lot of spot-checking. In addition to fixing the linked issue directly, here are some other areas of Mathesar that now have narrower `<label>` elements so as to avoid turning negative space into unnecessarily large click targets:

<img src="https://github.com/user-attachments/assets/6444554b-b69f-4cb7-947f-a445d99dd499" width="600px" /> 

<img src="https://github.com/user-attachments/assets/5378ac02-23d6-4435-97b6-e3e7f40e231d" width="400px" /> 

<img src="https://github.com/user-attachments/assets/01b92c66-2bf7-4010-900a-0571d110cda7" width="400px" /> 

<img src="https://github.com/user-attachments/assets/abaddcbb-1941-4382-b4d8-f1a74572ebd9" width="400px" /> 

<img src="https://github.com/user-attachments/assets/df97edc3-bee5-4cc6-bc58-116418ebc1cd" width="400px" /> 

There are more as well, but I think this should demonstrate the change well enough.

---

And here's an example of one that is effectively unchanged to the user because its content is so wide:

![Image](https://github.com/user-attachments/assets/fed2ec19-0dac-4e95-b849-c591d9ef20d5)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

