### PR TITLE
Update Flake8 to 7.2.0, fix error in deprecated code

### DIFF
--- a/db/deprecated/queries/base.py
+++ b/db/deprecated/queries/base.py
@@ -223,9 +223,6 @@ class DBQuery:
             and returns the SA column that the initial column represents.
             """
             nonlocal from_clause
-            nonlocal base_table
-            nonlocal map_of_jp_subpath_to_alias
-            nonlocal created_joins
             jp_path = initial_col.jp_path
             right = base_table
             for i, jp in enumerate(jp_path):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-flake8==7.1.1
+flake8==7.2.0
 ipython==8.10.0
 pytest==8.3.3
 pytest-django==4.9.0


### PR DESCRIPTION
On Saturday version 7.2.0 of Flake8 was released. Our Flake8 CI step uses the latest version. This new version identified some errors in some of our deprecated code:

```shell
db/deprecated/queries/base.py:226:13: F824 `nonlocal base_table` is unused: name is never assigned in scope
db/deprecated/queries/base.py:227:13: F824 `nonlocal map_of_jp_subpath_to_alias` is unused: name is never assigned in scope
db/deprecated/queries/base.py:228:13: F824 `nonlocal created_joins` is unused: name is never assigned in scope
```

This PR updates our Flake8 dev dependency to 7.2.0 and fixes `db/deprecated/queries/base.py` to remove unnecessary `nonlocal` statements.

This is necessary to fix our ["Test and Lint Code" action](https://github.com/mathesar-foundation/mathesar/actions/workflows/test-and-lint-code.yml) which is currently failing.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
