### PR TITLE
Remove redundant cast_to_numeric functions 

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -4236,35 +4236,24 @@ AS $$
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(real) RETURNS numeric AS $$
-  BEGIN
-    RETURN $1::numeric;
-  END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+  SELECT $1::numeric;
+$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(bigint) RETURNS numeric AS $$
-  BEGIN
-    RETURN $1::numeric;
-  END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+  SELECT $1::numeric;
+$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(double precision)
-RETURNS numeric AS $$
-  BEGIN
-    RETURN $1::numeric;
-  END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(double precision) RETURNS numeric AS $$
+  SELECT $1::numeric;
+$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(numeric) RETURNS numeric AS $$
-  BEGIN
-    RETURN $1::numeric;
-  END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+  SELECT $1::numeric;
+$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(money) RETURNS numeric AS $$
-  BEGIN
-    RETURN $1::numeric;
-  END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+  SELECT $1::numeric;
+$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text) RETURNS numeric AS $$
 DECLARE

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -4235,78 +4235,38 @@ AS $$
   END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(smallint)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(real) RETURNS numeric AS $$
+  BEGIN
+    RETURN $1::numeric;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(real)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(bigint)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(bigint) RETURNS numeric AS $$
+  BEGIN
+    RETURN $1::numeric;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(double precision)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
+RETURNS numeric AS $$
+  BEGIN
+    RETURN $1::numeric;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(numeric)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(numeric) RETURNS numeric AS $$
+  BEGIN
+    RETURN $1::numeric;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(money)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(money) RETURNS numeric AS $$
+  BEGIN
+    RETURN $1::numeric;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(integer)
-RETURNS numeric
-AS $$
-
-    BEGIN
-      RETURN $1::numeric;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text) RETURNS numeric
-AS $$
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text) RETURNS numeric AS $$
 DECLARE
   decimal_point text;
   is_negative boolean;
@@ -4333,17 +4293,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(boolean)
-RETURNS numeric
-AS $$
-
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(boolean) RETURNS numeric AS $$
 BEGIN
   IF $1 THEN
     RETURN 1::numeric;
   END IF;
   RETURN 0::numeric;
 END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -4210,8 +4210,7 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_numeric
 
-CREATE OR REPLACE FUNCTION msar.get_numeric_array(text) RETURNS text[]
-AS $$
+CREATE OR REPLACE FUNCTION msar.get_numeric_array(text) RETURNS text[] AS $$
   DECLARE
     raw_arr text[];
     actual_number_arr text[];
@@ -4237,23 +4236,23 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(real) RETURNS numeric AS $$
   SELECT $1::numeric;
-$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(bigint) RETURNS numeric AS $$
   SELECT $1::numeric;
-$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(double precision) RETURNS numeric AS $$
   SELECT $1::numeric;
-$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(numeric) RETURNS numeric AS $$
   SELECT $1::numeric;
-$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(money) RETURNS numeric AS $$
   SELECT $1::numeric;
-$$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text) RETURNS numeric AS $$
 DECLARE
@@ -4283,13 +4282,8 @@ END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(boolean) RETURNS numeric AS $$
-BEGIN
-  IF $1 THEN
-    RETURN 1::numeric;
-  END IF;
-  RETURN 0::numeric;
-END;
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+  SELECT CASE WHEN $1 THEN 1::numeric ELSE 0::numeric END;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_jsonb

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -4305,94 +4305,32 @@ AS $$
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(character varying)
-RETURNS numeric
+CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text) RETURNS numeric
 AS $$
-
-DECLARE decimal_point text;
-DECLARE is_negative boolean;
-DECLARE numeric_arr text[];
-DECLARE numeric text;
+DECLARE
+  decimal_point text;
+  is_negative boolean;
+  numeric_arr text[];
+  numeric text;
 BEGIN
-    SELECT msar.get_numeric_array($1::text) INTO numeric_arr;
-    IF numeric_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to numeric', $1;
-    END IF;
-    SELECT numeric_arr[1] INTO numeric;
-    SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-    SELECT $1::text ~ '^-.*$' INTO is_negative;
-    IF numeric_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[2], '', 'gq') INTO numeric;
-    END IF;
-    IF numeric_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[3], decimal_point, 'q') INTO numeric;
-    END IF;
-    IF is_negative THEN
-        RETURN ('-' || numeric)::numeric;
-    END IF;
-    RETURN numeric::numeric;
+  SELECT msar.get_numeric_array($1::text) INTO numeric_arr;
+  IF numeric_arr IS NULL THEN
+    RAISE EXCEPTION '% cannot be cast to numeric', $1;
+  END IF;
+  SELECT numeric_arr[1] INTO numeric;
+  SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
+  SELECT $1::text ~ '^-.*$' INTO is_negative;
+  IF numeric_arr[2] IS NOT NULL THEN
+    SELECT regexp_replace(numeric, numeric_arr[2], '', 'gq') INTO numeric;
+  END IF;
+  IF numeric_arr[3] IS NOT NULL THEN
+    SELECT regexp_replace(numeric, numeric_arr[3], decimal_point, 'q') INTO numeric;
+  END IF;
+  IF is_negative THEN
+    RETURN ('-' || numeric)::numeric;
+  END IF;
+  RETURN numeric::numeric;
 END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(text)
-RETURNS numeric
-AS $$
-
-DECLARE decimal_point text;
-DECLARE is_negative boolean;
-DECLARE numeric_arr text[];
-DECLARE numeric text;
-BEGIN
-    SELECT msar.get_numeric_array($1::text) INTO numeric_arr;
-    IF numeric_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to numeric', $1;
-    END IF;
-    SELECT numeric_arr[1] INTO numeric;
-    SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-    SELECT $1::text ~ '^-.*$' INTO is_negative;
-    IF numeric_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[2], '', 'gq') INTO numeric;
-    END IF;
-    IF numeric_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[3], decimal_point, 'q') INTO numeric;
-    END IF;
-    IF is_negative THEN
-        RETURN ('-' || numeric)::numeric;
-    END IF;
-    RETURN numeric::numeric;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_numeric(character)
-RETURNS numeric
-AS $$
-
-DECLARE decimal_point text;
-DECLARE is_negative boolean;
-DECLARE numeric_arr text[];
-DECLARE numeric text;
-BEGIN
-    SELECT msar.get_numeric_array($1::text) INTO numeric_arr;
-    IF numeric_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to numeric', $1;
-    END IF;
-    SELECT numeric_arr[1] INTO numeric;
-    SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-    SELECT $1::text ~ '^-.*$' INTO is_negative;
-    IF numeric_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[2], '', 'gq') INTO numeric;
-    END IF;
-    IF numeric_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(numeric, numeric_arr[3], decimal_point, 'q') INTO numeric;
-    END IF;
-    IF is_negative THEN
-        RETURN ('-' || numeric)::numeric;
-    END IF;
-    RETURN numeric::numeric;
-END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_numeric(boolean)


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Table for implicit type conversions for function calls, supported by postgres ordered by target_type:
```diff
   source    |   target    |
 ------------+--------------
 timestamptz | timestamptz |
 timestamp   | timestamptz |
 date        | timestamptz |
 timestamp   | timestamp   |
 date        | timestamp   |
 time        | time        |
+ varchar    | text        |
 name        | text        |
 bpchar      | text        |
+ char       | text        |
 int4        | oid         |
 int8        | oid         |
 int2        | oid         |
+ int2       | numeric     |
 numeric     | numeric     |
+ int4       | numeric     |
 int8        | numeric     |
 text        | name        |
 bpchar      | name        |
 varchar     | name        |
 macaddr     | macaddr8    |
 macaddr8    | macaddr     |
 interval    | interval    |
 time        | interval    |
+ int4       | int8        |
+ int2       | int8        |
 int2        | int4        |
 cidr        | inet        |
- int4       | float8      |
- int2       | float8      |
- numeric    | float8      |
- int8       | float8      |
- float4     | float8      |
 numeric     | float4      |
 int4        | float4      |
 int8        | float4      |
 int2        | float4      |
 text        | bpchar      |
 varchar     | bpchar      |
 bpchar      | bpchar      |
 varbit      | bit         |
 bit         | bit         |
```

Even though `float8`(double precision) is a supported implicit conversion for all the number like data types, there is a possibility of data loss during this implicit conversion for data types like `int8`(bigint):
e.g:
```diff
mathesar=# SELECT msar.cast_to_numeric(922337203685477580::bigint);
   cast_to_numeric   
 --------------------
- 922337203685478000 <-- (data loss due to implicit conversion to float8)
+ 922337203685477580 <-- (correct result with no implicit conversion)
```
implicit conversion from `float4` to `float8` is also not ideal:
```diff
mathesar=# SELECT msar.cast_to_numeric(36.91234::real);
  cast_to_numeric  
 ------------------
- 36.9123382568359 <-- (with implicit conversion)
+ 36.91234 <-- (without implicit conversion)
```

So, here is the list of remaining `cast_to_numeric` functions that are required:
```
mathesar=# \df msar.cast_to_numeric 
                            List of functions
 Schema |      Name       | Result data type | Argument data types | Type 
--------+-----------------+------------------+---------------------+------
 msar   | cast_to_numeric | numeric          | bigint              | func
 msar   | cast_to_numeric | numeric          | boolean             | func
 msar   | cast_to_numeric | numeric          | double precision    | func
 msar   | cast_to_numeric | numeric          | money               | func
 msar   | cast_to_numeric | numeric          | numeric             | func
 msar   | cast_to_numeric | numeric          | real                | func
 msar   | cast_to_numeric | numeric          | text                | func
```

Additionally, I've made some of the functions to be `SQL IMMUTABLE` functions instead of plpgsql for performance reasons. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
