### PR TITLE
Remove redundant cast_to_mathesar_money functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1618,194 +1618,80 @@ AS $$
   END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(mathesar_types.mathesar_money)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(smallint)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(real)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.mathesar_money AS $$
+  SELECT $1::numeric::mathesar_types.mathesar_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(bigint)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.mathesar_money AS $$
+  SELECT $1::numeric::mathesar_types.mathesar_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(double precision)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.mathesar_money AS $$
+  SELECT $1::numeric::mathesar_types.mathesar_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(numeric)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(integer)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    BEGIN
-      RETURN $1::numeric::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(character varying)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    DECLARE decimal_point text;
-    DECLARE is_negative boolean;
-    DECLARE money_arr text[];
-    DECLARE money_num text;
-    BEGIN
-      SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
-      IF money_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
-      END IF;
-      SELECT money_arr[1] INTO money_num;
-      SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-      SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
-      IF money_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
-      END IF;
-      IF money_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
-      END IF;
-      IF is_negative THEN
-        RETURN ('-' || money_num)::mathesar_types.mathesar_money;
-      END IF;
-      RETURN money_num::mathesar_types.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.mathesar_money AS $$
+  SELECT $1::numeric::mathesar_types.mathesar_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(text)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    DECLARE decimal_point text;
-    DECLARE is_negative boolean;
-    DECLARE money_arr text[];
-    DECLARE money_num text;
-    BEGIN
-      SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
-      IF money_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
-      END IF;
-      SELECT money_arr[1] INTO money_num;
-      SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-      SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
-      IF money_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
-      END IF;
-      IF money_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
-      END IF;
-      IF is_negative THEN
-        RETURN ('-' || money_num)::mathesar_types.mathesar_money;
-      END IF;
-      RETURN money_num::mathesar_types.mathesar_money;
-    END;
-
+RETURNS mathesar_types.mathesar_money AS $$
+  DECLARE
+    decimal_point text;
+    is_negative boolean;
+    money_arr text[];
+    money_num text;
+  BEGIN
+    SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
+    IF money_arr IS NULL THEN
+      RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
+    END IF;
+    SELECT money_arr[1] INTO money_num;
+    SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
+    SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
+    IF money_arr[2] IS NOT NULL THEN
+      SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
+    END IF;
+    IF money_arr[3] IS NOT NULL THEN
+      SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
+    END IF;
+    IF is_negative THEN
+      RETURN ('-' || money_num)::mathesar_types.mathesar_money;
+    END IF;
+    RETURN money_num::mathesar_types.mathesar_money;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(money)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    DECLARE decimal_point text;
-    DECLARE is_negative boolean;
-    DECLARE money_arr text[];
-    DECLARE money_num text;
-    BEGIN
-      SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
-      IF money_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
-      END IF;
-      SELECT money_arr[1] INTO money_num;
-      SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-      SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
-      IF money_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
-      END IF;
-      IF money_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
-      END IF;
-      IF is_negative THEN
-        RETURN ('-' || money_num)::msar.mathesar_money;
-      END IF;
-      RETURN money_num::msar.mathesar_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_mathesar_money(character)
-RETURNS mathesar_types.mathesar_money
-AS $$
-
-    DECLARE decimal_point text;
-    DECLARE is_negative boolean;
-    DECLARE money_arr text[];
-    DECLARE money_num text;
-    BEGIN
-      SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
-      IF money_arr IS NULL THEN
-        RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
-      END IF;
-      SELECT money_arr[1] INTO money_num;
-      SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
-      SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
-      IF money_arr[2] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
-      END IF;
-      IF money_arr[3] IS NOT NULL THEN
-        SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
-      END IF;
-      IF is_negative THEN
-        RETURN ('-' || money_num)::mathesar_types.mathesar_money;
-      END IF;
-      RETURN money_num::mathesar_types.mathesar_money;
-    END;
-
+RETURNS mathesar_types.mathesar_money AS $$
+  DECLARE
+    decimal_point text;
+    is_negative boolean;
+    money_arr text[];
+    money_num text;
+  BEGIN
+    SELECT msar.get_mathesar_money_array($1::text) INTO money_arr;
+    IF money_arr IS NULL THEN
+      RAISE EXCEPTION '% cannot be cast to mathesar_types.mathesar_money', $1;
+    END IF;
+    SELECT money_arr[1] INTO money_num;
+    SELECT ltrim(to_char(1, 'D'), ' ') INTO decimal_point;
+    SELECT $1::text ~ '^.*(-|\(.+\)).*$' INTO is_negative;
+    IF money_arr[2] IS NOT NULL THEN
+      SELECT regexp_replace(money_num, money_arr[2], '', 'gq') INTO money_num;
+    END IF;
+    IF money_arr[3] IS NOT NULL THEN
+      SELECT regexp_replace(money_num, money_arr[3], decimal_point, 'q') INTO money_num;
+    END IF;
+    IF is_negative THEN
+      RETURN ('-' || money_num)::msar.mathesar_money;
+    END IF;
+    RETURN money_num::msar.mathesar_money;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333
<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
List of functions that removed:
```diff
mathesar=# \df msar.cast_to_mathesar_money
                                           List of functions
 Schema |          Name          |       Result data type        |      Argument data types      | Type 
 -------+------------------------+-------------------------------+-------------------------------+------
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | bigint                        | func
- msar  | cast_to_mathesar_money | mathesar_types.mathesar_money | character                     | func
- msar  | cast_to_mathesar_money | mathesar_types.mathesar_money | character varying             | func
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | double precision              | func
- msar  | cast_to_mathesar_money | mathesar_types.mathesar_money | integer                       | func
- msar  | cast_to_mathesar_money | mathesar_types.mathesar_money | mathesar_types.mathesar_money | func
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | money                         | func
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | numeric                       | func
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | real                          | func
- msar  | cast_to_mathesar_money | mathesar_types.mathesar_money | smallint                      | func
 msar   | cast_to_mathesar_money | mathesar_types.mathesar_money | text                          | func
```

Since our `mathesar_types.mathesar_money` is `numeric` under the hood, it _does_ seem to get implicitly casted to `numeric`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
