### PR TITLE
Remove redundant cast_to_multicurrency_money functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1940,124 +1940,39 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_multicurrency_money
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(mathesar_types.multicurrency_money)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(smallint)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT $1::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(real)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(mathesar_types.mathesar_money)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(bigint)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(double precision)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(numeric)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(integer)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(character varying)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1::numeric, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(text)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1::numeric, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(money)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1::numeric, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_multicurrency_money(character)
-RETURNS mathesar_types.multicurrency_money
-AS $$
-
-    BEGIN
-      RETURN ROW($1::numeric, 'USD')::mathesar_types.multicurrency_money;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS mathesar_types.multicurrency_money AS $$
+  SELECT ROW($1, 'USD')::mathesar_types.multicurrency_money;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_character_varying


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333
<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```diff
mathesar=# \df msar.cast_to_multicurrency_money
                                                   List of functions
 Schema |            Name             |          Result data type          |        Argument data types         | Type 
 -------+-----------------------------+------------------------------------+------------------------------------+------
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | bigint                             | func
- msar  | cast_to_multicurrency_money | mathesar_types.multicurrency_money | character                          | func
- msar  | cast_to_multicurrency_money | mathesar_types.multicurrency_money | character varying                  | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | double precision                   | func
- msar  | cast_to_multicurrency_money | mathesar_types.multicurrency_money | integer                            | func
- msar  | cast_to_multicurrency_money | mathesar_types.multicurrency_money | mathesar_types.mathesar_money      | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | mathesar_types.multicurrency_money | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | money                              | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | numeric                            | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | real                               | func
- msar  | cast_to_multicurrency_money | mathesar_types.multicurrency_money | smallint                           | func
 msar   | cast_to_multicurrency_money | mathesar_types.multicurrency_money | text                               | func

```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
