### PR TITLE
Remove redundant cast_to integer and interval functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -996,122 +996,85 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_integer
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(bigint)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS integer AS $$
+  SELECT $1::integer;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(text)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS integer AS $$
+  SELECT $1::integer;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(real)
-RETURNS integer
-AS $$
-
-    DECLARE integer_res integer;
-    BEGIN
-      SELECT $1::integer INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
-    END;
-
+RETURNS integer AS $$
+  DECLARE integer_res integer;
+  BEGIN
+    SELECT $1::integer INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(double precision)
-RETURNS integer
-AS $$
-
-    DECLARE integer_res integer;
-    BEGIN
-      SELECT $1::integer INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
-    END;
-
+RETURNS integer AS $$
+  DECLARE integer_res integer;
+  BEGIN
+    SELECT $1::integer INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(numeric)
-RETURNS integer
-AS $$
-
-    DECLARE integer_res integer;
-    BEGIN
-      SELECT $1::integer INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
-    END;
-
+RETURNS integer AS $$
+  DECLARE integer_res integer;
+  BEGIN
+    SELECT $1::integer INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(money)
-RETURNS integer
-AS $$
-
-    DECLARE integer_res integer;
-    BEGIN
-      SELECT $1::integer INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
-    END;
-
+RETURNS integer AS $$
+  DECLARE integer_res integer;
+  BEGIN
+    SELECT $1::integer INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(boolean)
-RETURNS integer
-AS $$
-
-BEGIN
-  IF $1 THEN
-    RETURN 1::integer;
-  END IF;
-  RETURN 0::integer;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS integer AS $$
+  SELECT CASE WHEN $1 THEN 1::integer ELSE 0::integer END;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_interval
 
 CREATE OR REPLACE FUNCTION msar.cast_to_interval(interval)
-RETURNS interval
-AS $$
-
-    BEGIN
-      RETURN $1;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS interval AS $$
+  SELECT $1;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_interval(text)
-RETURNS interval
-AS $$
- BEGIN
-      PERFORM $1::numeric;
-      RAISE EXCEPTION '% is a numeric', $1;
-      EXCEPTION
-        WHEN sqlstate '22P02' THEN
-          RETURN $1::interval;
-    END;
-
+RETURNS interval AS $$
+BEGIN
+  PERFORM $1::numeric;
+  RAISE EXCEPTION '% is a numeric', $1;
+  EXCEPTION
+    WHEN sqlstate '22P02' THEN
+      RETURN $1::interval;
+END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -995,37 +995,7 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_integer
 
-CREATE OR REPLACE FUNCTION msar.cast_to_integer(smallint)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_integer(character varying)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(bigint)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_integer(character)
 RETURNS integer
 AS $$
 
@@ -1045,32 +1015,7 @@ AS $$
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_integer(integer)
-RETURNS integer
-AS $$
-
-    BEGIN
-      RETURN $1::integer;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_integer(real)
-RETURNS integer
-AS $$
-
-    DECLARE integer_res integer;
-    BEGIN
-      SELECT $1::integer INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to integer without loss', $1;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_integer(mathesar_types.mathesar_money)
 RETURNS integer
 AS $$
 
@@ -1156,33 +1101,7 @@ AS $$
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_interval(character varying)
-RETURNS interval
-AS $$
- BEGIN
-      PERFORM $1::numeric;
-      RAISE EXCEPTION '% is a numeric', $1;
-      EXCEPTION
-        WHEN sqlstate '22P02' THEN
-          RETURN $1::interval;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_interval(text)
-RETURNS interval
-AS $$
- BEGIN
-      PERFORM $1::numeric;
-      RAISE EXCEPTION '% is a numeric', $1;
-      EXCEPTION
-        WHEN sqlstate '22P02' THEN
-          RETURN $1::interval;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_interval(character)
 RETURNS interval
 AS $$
  BEGIN


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```diff
mathesar=# \df msar.cast_to_integer
                                 List of functions
 Schema |      Name       | Result data type |      Argument data types      | Type 
 -------+-----------------+------------------+-------------------------------+------
 msar   | cast_to_integer | integer          | bigint                        | func
 msar   | cast_to_integer | integer          | boolean                       | func
- msar  | cast_to_integer | integer          | character                     | func
- msar  | cast_to_integer | integer          | character varying             | func
 msar   | cast_to_integer | integer          | double precision              | func
- msar  | cast_to_integer | integer          | integer                       | func
- msar  | cast_to_integer | integer          | mathesar_types.mathesar_money | func
 msar   | cast_to_integer | integer          | money                         | func
 msar   | cast_to_integer | integer          | numeric                       | func
 msar   | cast_to_integer | integer          | real                          | func
- msar  | cast_to_integer | integer          | smallint                      | func
 msar   | cast_to_integer | integer          | text                          | func

```

```diff
mathesar=# \df msar.cast_to_interval
                             List of functions
 Schema |       Name       | Result data type | Argument data types | Type 
 -------+------------------+------------------+---------------------+------
- msar  | cast_to_interval | interval         | character           | func
- msar  | cast_to_interval | interval         | character varying   | func
 msar   | cast_to_interval | interval         | interval            | func
 msar   | cast_to_interval | interval         | text                | func
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
