### PR TITLE
Remove redundant cast_to smallint and bigint functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -694,238 +694,133 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_smallint
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(bigint)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS smallint AS $$
+  SELECT $1::smallint;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(text)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS smallint AS $$
+  SELECT $1::smallint;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(real)
-RETURNS smallint
-AS $$
-
-    DECLARE integer_res smallint;
-    BEGIN
-      SELECT $1::smallint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
-    END;
-
+RETURNS smallint AS $$
+  DECLARE integer_res smallint;
+  BEGIN
+    SELECT $1::smallint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(double precision)
-RETURNS smallint
-AS $$
-
-    DECLARE integer_res smallint;
-    BEGIN
-      SELECT $1::smallint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
-    END;
-
+RETURNS smallint AS $$
+  DECLARE integer_res smallint;
+  BEGIN
+    SELECT $1::smallint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(numeric)
-RETURNS smallint
-AS $$
-
-    DECLARE integer_res smallint;
-    BEGIN
-      SELECT $1::smallint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
-    END;
-
+RETURNS smallint AS $$
+  DECLARE integer_res smallint;
+  BEGIN
+    SELECT $1::smallint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(money)
-RETURNS smallint
-AS $$
-
-    DECLARE integer_res smallint;
-    BEGIN
-      SELECT $1::smallint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
-    END;
-
+RETURNS smallint AS $$
+  DECLARE integer_res smallint;
+  BEGIN
+    SELECT $1::smallint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(boolean)
-RETURNS smallint
-AS $$
-
-BEGIN
-  IF $1 THEN
-    RETURN 1::smallint;
-  END IF;
-  RETURN 0::smallint;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS smallint AS $$
+  SELECT CASE WHEN $1 THEN 1::smallint ELSE 0::smallint END;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_bigint
 
-CREATE OR REPLACE FUNCTION msar.cast_to_bigint(character varying)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(bigint)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_bigint(character)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS bigint AS $$
+  SELECT $1::bigint;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(text)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_bigint(integer)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS bigint AS $$
+  SELECT $1::bigint;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(real)
-RETURNS bigint
-AS $$
-
-    DECLARE integer_res bigint;
-    BEGIN
-      SELECT $1::bigint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_bigint(mathesar_types.mathesar_money)
-RETURNS bigint
-AS $$
-
-    DECLARE integer_res bigint;
-    BEGIN
-      SELECT $1::bigint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
-    END;
-
+RETURNS bigint AS $$
+  DECLARE integer_res bigint;
+  BEGIN
+    SELECT $1::bigint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(double precision)
-RETURNS bigint
-AS $$
-
-    DECLARE integer_res bigint;
-    BEGIN
-      SELECT $1::bigint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
-    END;
-
+RETURNS bigint AS $$
+  DECLARE integer_res bigint;
+  BEGIN
+    SELECT $1::bigint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(numeric)
-RETURNS bigint
-AS $$
-
-    DECLARE integer_res bigint;
-    BEGIN
-      SELECT $1::bigint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
-    END;
-
+RETURNS bigint AS $$
+  DECLARE integer_res bigint;
+  BEGIN
+    SELECT $1::bigint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(money)
-RETURNS bigint
-AS $$
-
-    DECLARE integer_res bigint;
-    BEGIN
-      SELECT $1::bigint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
-    END;
-
+RETURNS bigint AS $$
+  DECLARE integer_res bigint;
+  BEGIN
+    SELECT $1::bigint INTO integer_res;
+    IF integer_res = $1 THEN
+      RETURN integer_res;
+    END IF;
+    RAISE EXCEPTION '% cannot be cast to bigint without loss', $1;
+  END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_bigint(boolean)
-RETURNS bigint
-AS $$
-
-BEGIN
-  IF $1 THEN
-    RETURN 1::bigint;
-  END IF;
-  RETURN 0::bigint;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS bigint AS $$
+  SELECT CASE WHEN $1 THEN 1::bigint ELSE 0::bigint END;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_integer

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -693,37 +693,7 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_smallint
 
-CREATE OR REPLACE FUNCTION msar.cast_to_smallint(smallint)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_smallint(character varying)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(bigint)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_smallint(character)
 RETURNS smallint
 AS $$
 
@@ -743,32 +713,7 @@ AS $$
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_smallint(integer)
-RETURNS smallint
-AS $$
-
-    BEGIN
-      RETURN $1::smallint;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_smallint(real)
-RETURNS smallint
-AS $$
-
-    DECLARE integer_res smallint;
-    BEGIN
-      SELECT $1::smallint INTO integer_res;
-      IF integer_res = $1 THEN
-        RETURN integer_res;
-      END IF;
-      RAISE EXCEPTION '% cannot be cast to smallint without loss', $1;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_smallint(mathesar_types.mathesar_money)
 RETURNS smallint
 AS $$
 
@@ -838,16 +783,6 @@ BEGIN
   END IF;
   RETURN 0::smallint;
 END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_bigint(smallint)
-RETURNS bigint
-AS $$
-
-    BEGIN
-      RETURN $1::bigint;
-    END;
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```diff
mathesar=# \df msar.cast_to_smallint
                                  List of functions
 Schema |       Name       | Result data type |      Argument data types      | Type 
 -------+------------------+------------------+-------------------------------+------
 msar   | cast_to_smallint | smallint         | bigint                        | func
 msar   | cast_to_smallint | smallint         | boolean                       | func
- msar  | cast_to_smallint | smallint         | character                     | func
- msar  | cast_to_smallint | smallint         | character varying             | func
 msar   | cast_to_smallint | smallint         | double precision              | func
- msar  | cast_to_smallint | smallint         | integer                       | func
- msar  | cast_to_smallint | smallint         | mathesar_types.mathesar_money | func
 msar   | cast_to_smallint | smallint         | money                         | func
 msar   | cast_to_smallint | smallint         | numeric                       | func
 msar   | cast_to_smallint | smallint         | real                          | func
- msar  | cast_to_smallint | smallint         | smallint                      | func
 msar   | cast_to_smallint | smallint         | text                          | func
```

```diff
mathesar=# \df msar.cast_to_bigint
                                 List of functions
 Schema |      Name      | Result data type |      Argument data types      | Type 
 -------+----------------+------------------+-------------------------------+------
 msar   | cast_to_bigint | bigint           | bigint                        | func
 msar   | cast_to_bigint | bigint           | boolean                       | func
- msar  | cast_to_bigint | bigint           | character                     | func
- msar  | cast_to_bigint | bigint           | character varying             | func
 msar   | cast_to_bigint | bigint           | double precision              | func
- msar  | cast_to_bigint | bigint           | integer                       | func
- msar  | cast_to_bigint | bigint           | mathesar_types.mathesar_money | func
 msar   | cast_to_bigint | bigint           | money                         | func
 msar   | cast_to_bigint | bigint           | numeric                       | func
 msar   | cast_to_bigint | bigint           | real                          | func
- msar  | cast_to_bigint | bigint           | smallint                      | func
 msar   | cast_to_bigint | bigint           | text                          | func
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
