### PR TITLE
Remove redundant cast_to double precision and email functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -524,16 +524,6 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_double_precision
 
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(smallint)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(bigint)
 RETURNS double precision
 AS $$
@@ -554,47 +544,7 @@ AS $$
 
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(character)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(integer)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(real)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(character varying)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(mathesar_types.mathesar_money)
 RETURNS double precision
 AS $$
 

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -525,77 +525,39 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_double_precision
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(bigint)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(double precision)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(real)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(numeric)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(text)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(money)
-RETURNS double precision
-AS $$
-
-    BEGIN
-      RETURN $1::double precision;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT $1::double precision;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(boolean)
-RETURNS double precision
-AS $$
-
-BEGIN
-  IF $1 THEN
-    RETURN 1::double precision;
-  END IF;
-  RETURN 0::double precision;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS double precision AS $$
+  SELECT CASE WHEN $1 THEN 1::double precision ELSE 0::double precision END;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_email

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -562,45 +562,9 @@ $$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_email
 
-CREATE OR REPLACE FUNCTION msar.cast_to_email(mathesar_types.email)
-RETURNS mathesar_types.email
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.email;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_email(character varying)
-RETURNS mathesar_types.email
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.email;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_email(text)
-RETURNS mathesar_types.email
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.email;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_email(character)
-RETURNS mathesar_types.email
-AS $$
-
-    BEGIN
-      RETURN $1::mathesar_types.email;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+CREATE OR REPLACE FUNCTION msar.cast_to_email(text) RETURNS mathesar_types.email AS $$
+  SELECT $1::mathesar_types.email;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_smallint

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -458,11 +458,6 @@ RETURNS double precision AS $$
   SELECT $1::double precision;
 $$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(money)
-RETURNS double precision AS $$
-  SELECT $1::double precision;
-$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_double_precision(boolean)
 RETURNS double precision AS $$
   SELECT CASE WHEN $1 THEN 1::double precision ELSE 0::double precision END;


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```diff
                                      List of functions
 Schema |           Name           | Result data type |      Argument data types      | Type 
 -------+--------------------------+------------------+-------------------------------+------
 msar   | cast_to_double_precision | double precision | bigint                        | func
 msar   | cast_to_double_precision | double precision | boolean                       | func
- msar  | cast_to_double_precision | double precision | character                     | func
- msar  | cast_to_double_precision | double precision | character varying             | func
 msar   | cast_to_double_precision | double precision | double precision              | func
- msar  | cast_to_double_precision | double precision | integer                       | func
- msar  | cast_to_double_precision | double precision | mathesar_types.mathesar_money | func
- msar  | cast_to_double_precision | double precision | money                         | func
 msar   | cast_to_double_precision | double precision | numeric                       | func
 msar   | cast_to_double_precision | double precision | real                          | func
- msar  | cast_to_double_precision | double precision | smallint                      | func
 msar   | cast_to_double_precision | double precision | text                          | func
```

```diff
mathesar=# \df msar.cast_to_email
                              List of functions
 Schema |     Name      |   Result data type   | Argument data types  | Type 
 -------+---------------+----------------------+----------------------+------
- msar  | cast_to_email | mathesar_types.email | character            | func
- msar  | cast_to_email | mathesar_types.email | character varying    | func
- msar  | cast_to_email | mathesar_types.email | mathesar_types.email | func
 msar   | cast_to_email | mathesar_types.email | text                 | func
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
