### PR TITLE
Remove redundant cast to date and time functions

### DIFF
--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1133,55 +1133,15 @@ $$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_timestamp_with_time_zone
 
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_with_time_zone(character varying)
-RETURNS timestamp with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_with_time_zone(timestamp with time zone)
-RETURNS timestamp with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_with_time_zone(character)
-RETURNS timestamp with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_with_time_zone(timestamp without time zone)
-RETURNS timestamp with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS timestamp with time zone AS $$
+  SELECT $1::timestamp with time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_with_time_zone(text)
-RETURNS timestamp with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS timestamp with time zone AS $$
+  SELECT $1::timestamp with time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_timestamp_without_time_zone

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -674,6 +674,11 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_date
 
+CREATE OR REPLACE FUNCTION msar.cast_to_date(date)
+RETURNS date AS $$
+  SELECT $1::timestamp with time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
+
 CREATE OR REPLACE FUNCTION msar.cast_to_date(text)
 RETURNS date AS $$
 DECLARE

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1190,129 +1190,40 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 -- msar.cast_to_date
 
-CREATE OR REPLACE FUNCTION msar.cast_to_date(date)
-RETURNS date
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_date(character varying)
-RETURNS date
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = date_value) THEN
-        RETURN $1::date;
-        END IF;
-
-  RAISE EXCEPTION '% is not a date', $1;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
 CREATE OR REPLACE FUNCTION msar.cast_to_date(text)
-RETURNS date
-AS $$
-
+RETURNS date AS $$
 DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
+  timestamp_value_with_tz NUMERIC;
+  timestamp_value NUMERIC;
+  date_value NUMERIC;
 BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = date_value) THEN
-        RETURN $1::date;
-        END IF;
-
+  SET LOCAL TIME ZONE 'UTC';
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
+  SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
+  IF (timestamp_value_with_tz = date_value) THEN
+    RETURN $1::date;
+  END IF;
   RAISE EXCEPTION '% is not a date', $1;
 END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_date(character)
-RETURNS date
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = date_value) THEN
-        RETURN $1::date;
-        END IF;
-
-  RAISE EXCEPTION '% is not a date', $1;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_date(timestamp without time zone)
-RETURNS date
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = date_value) THEN
-        RETURN $1::date;
-        END IF;
-
-  RAISE EXCEPTION '% is not a date', $1;
-END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_date(timestamp with time zone)
-RETURNS date
-AS $$
-
+RETURNS date AS $$
 DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
+  timestamp_value_with_tz NUMERIC;
+  timestamp_value NUMERIC;
+  date_value NUMERIC;
 BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = date_value) THEN
-        RETURN $1::date;
-        END IF;
-
+  SET LOCAL TIME ZONE 'UTC';
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
+  SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
+  IF (timestamp_value_with_tz = date_value) THEN
+    RETURN $1::date;
+  END IF;
   RAISE EXCEPTION '% is not a date', $1;
 END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1108,44 +1108,14 @@ $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_time_without_time_zone
 
 CREATE OR REPLACE FUNCTION msar.cast_to_time_without_time_zone(text)
-RETURNS time without time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time without time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_time_without_time_zone(character varying)
-RETURNS time without time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time without time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_time_without_time_zone(time without time zone)
-RETURNS time without time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time without time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS time without time zone AS $$
+  SELECT $1::time without time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_time_without_time_zone(time with time zone)
-RETURNS time without time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time without time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS time without time zone AS $$
+  SELECT $1::time without time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_time_with_time_zone

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1121,44 +1121,14 @@ $$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_time_with_time_zone
 
 CREATE OR REPLACE FUNCTION msar.cast_to_time_with_time_zone(text)
-RETURNS time with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_time_with_time_zone(character varying)
-RETURNS time with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_time_with_time_zone(time without time zone)
-RETURNS time with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS time with time zone AS $$
+  SELECT $1::time with time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_time_with_time_zone(time with time zone)
-RETURNS time with time zone
-AS $$
-
-    BEGIN
-      RETURN $1::time with time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS time with time zone AS $$
+  SELECT $1::time with time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 
 -- msar.cast_to_timestamp_with_time_zone

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -1147,128 +1147,44 @@ $$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 -- msar.cast_to_timestamp_without_time_zone
 
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(timestamp without time zone)
-RETURNS timestamp without time zone
-AS $$
-
-    BEGIN
-      RETURN $1::timestamp without time zone;
-    END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(character varying)
-RETURNS timestamp without time zone
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = timestamp_value) THEN
-        RETURN $1::timestamp without time zone;
-        END IF;
-
-  RAISE EXCEPTION '% is not a timestamp without time zone', $1;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+RETURNS timestamp without time zone AS $$
+  SELECT $1::timestamp without time zone;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(text)
-RETURNS timestamp without time zone
-AS $$
-
+RETURNS timestamp without time zone AS $$
 DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
+  timestamp_value_with_tz NUMERIC;
+  timestamp_value NUMERIC;
+  date_value NUMERIC;
 BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = timestamp_value) THEN
-        RETURN $1::timestamp without time zone;
-        END IF;
-
+  SET LOCAL TIME ZONE 'UTC';
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
+  SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
+  IF (timestamp_value_with_tz = timestamp_value) THEN
+    RETURN $1::timestamp without time zone;
+  END IF;
   RAISE EXCEPTION '% is not a timestamp without time zone', $1;
 END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(character)
-RETURNS timestamp without time zone
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = timestamp_value) THEN
-        RETURN $1::timestamp without time zone;
-        END IF;
-
-  RAISE EXCEPTION '% is not a timestamp without time zone', $1;
-END;
-
-$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
-
-CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(date)
-RETURNS timestamp without time zone
-AS $$
-
-DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
-BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = timestamp_value) THEN
-        RETURN $1::timestamp without time zone;
-        END IF;
-
-  RAISE EXCEPTION '% is not a timestamp without time zone', $1;
-END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(timestamp with time zone)
-RETURNS timestamp without time zone
-AS $$
-
+RETURNS timestamp without time zone AS $$
 DECLARE
-timestamp_value_with_tz NUMERIC;
-timestamp_value NUMERIC;
-date_value NUMERIC;
+  timestamp_value_with_tz NUMERIC;
+  timestamp_value NUMERIC;
+  date_value NUMERIC;
 BEGIN
-    SET LOCAL TIME ZONE 'UTC';
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
-    SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
-    SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
-
-        IF (timestamp_value_with_tz = timestamp_value) THEN
-        RETURN $1::timestamp without time zone;
-        END IF;
-
+  SET LOCAL TIME ZONE 'UTC';
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
+  SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
+  IF (timestamp_value_with_tz = timestamp_value) THEN
+    RETURN $1::timestamp without time zone;
+  END IF;
   RAISE EXCEPTION '% is not a timestamp without time zone', $1;
 END;
-
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
 

--- a/db/sql/45_msar_type_casting.sql
+++ b/db/sql/45_msar_type_casting.sql
@@ -653,6 +653,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
 
+CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(date)
+RETURNS timestamp without time zone AS $$
+DECLARE
+  timestamp_value_with_tz NUMERIC;
+  timestamp_value NUMERIC;
+  date_value NUMERIC;
+BEGIN
+  SET LOCAL TIME ZONE 'UTC';
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITH TIME ZONE ) INTO timestamp_value_with_tz;
+  SELECT EXTRACT(EPOCH FROM $1::TIMESTAMP WITHOUT TIME ZONE) INTO timestamp_value;
+  SELECT EXTRACT(EPOCH FROM $1::DATE ) INTO date_value;
+  IF (timestamp_value_with_tz = timestamp_value) THEN
+    RETURN $1::timestamp without time zone;
+  END IF;
+  RAISE EXCEPTION '% is not a timestamp without time zone', $1;
+END;
+$$ LANGUAGE plpgsql RETURNS NULL ON NULL INPUT;
+
 CREATE OR REPLACE FUNCTION msar.cast_to_timestamp_without_time_zone(timestamp with time zone)
 RETURNS timestamp without time zone AS $$
 DECLARE


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4333
<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
```diff
mathesar=# \df msar.cast_to_time_without_time_zone 
                                        List of functions
 Schema |              Name              |    Result data type    |  Argument data types   | Type 
 -------+--------------------------------+------------------------+------------------------+------
- msar  | cast_to_time_without_time_zone | time without time zone | character varying      | func
 msar   | cast_to_time_without_time_zone | time without time zone | text                   | func
- msar  | cast_to_time_without_time_zone | time without time zone | time without time zone | func
 msar   | cast_to_time_without_time_zone | time without time zone | time with time zone    | func
```

```diff
mathesar=# \df msar.cast_to_time_with_time_zone 
                                     List of functions
 Schema |            Name             |  Result data type   |  Argument data types   | Type 
 -------+-----------------------------+---------------------+------------------------+------
- msar  | cast_to_time_with_time_zone | time with time zone | character varying      | func
 msar   | cast_to_time_with_time_zone | time with time zone | text                   | func
- msar  | cast_to_time_with_time_zone | time with time zone | time without time zone | func
 msar   | cast_to_time_with_time_zone | time with time zone | time with time zone    | func
```

```diff
mathesar=# \df msar.cast_to_timestamp_with_time_zone
                                             List of functions
 Schema |               Name               |     Result data type     |     Argument data types     | Type 
 -------+----------------------------------+--------------------------+-----------------------------+------
- msar  | cast_to_timestamp_with_time_zone | timestamp with time zone | character                   | func
- msar  | cast_to_timestamp_with_time_zone | timestamp with time zone | character varying           | func
 msar   | cast_to_timestamp_with_time_zone | timestamp with time zone | text                        | func
- msar  | cast_to_timestamp_with_time_zone | timestamp with time zone | timestamp without time zone | func
 msar   | cast_to_timestamp_with_time_zone | timestamp with time zone | timestamp with time zone    | func
```

```diff
mathesar=# \df msar.cast_to_timestamp_without_time_zone
                                                List of functions
 Schema |                Name                 |      Result data type       |     Argument data types     | Type 
 -------+-------------------------------------+-----------------------------+-----------------------------+------
- msar  | cast_to_timestamp_without_time_zone | timestamp without time zone | character                   | func
- msar  | cast_to_timestamp_without_time_zone | timestamp without time zone | character varying           | func
 msar   | cast_to_timestamp_without_time_zone | timestamp without time zone | date                        | func
 msar   | cast_to_timestamp_without_time_zone | timestamp without time zone | text                        | func
 msar   | cast_to_timestamp_without_time_zone | timestamp without time zone | timestamp without time zone | func
 msar   | cast_to_timestamp_without_time_zone | timestamp without time zone | timestamp with time zone    | func
```

```diff
mathesar=# \df msar.cast_to_date
                               List of functions
 Schema |     Name     | Result data type |     Argument data types     | Type 
 -------+--------------+------------------+-----------------------------+------
- msar  | cast_to_date | date             | character                   | func
- msar  | cast_to_date | date             | character varying           | func
 msar   | cast_to_date | date             | date                        | func
 msar   | cast_to_date | date             | text                        | func
- msar  | cast_to_date | date             | timestamp without time zone | func
 msar   | cast_to_date | date             | timestamp with time zone    | func
```
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
