### PR TITLE
Implement context menu to duplicate records

### DIFF
--- a/mathesar_ui/src/icons/index.ts
+++ b/mathesar_ui/src/icons/index.ts
@@ -169,6 +169,10 @@ export const iconGrip = { data: faGrip };
 export const iconReinstall = { data: faRotateBack };
 export const iconAddPrimaryKeyColumn = iconAddNew;
 export const iconPickPrimaryKeyColumn = { data: faHandPointer };
+export const iconDuplicateRecord: IconProps = {
+  data: faClone,
+  flip: 'vertical',
+};
 
 // THINGS
 //

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -651,6 +651,25 @@ export class RecordsData {
     return result;
   }
 
+  async duplicateRecord(sourceRow: RecordRow): Promise<void> {
+    const pkColumn = get(this.columnsDataStore.pkColumn);
+
+    const fields = { ...sourceRow.record };
+    if (pkColumn) {
+      delete fields[pkColumn.id];
+    }
+
+    const newRow = new DraftRecordRow({
+      record: {
+        ...this.getEmptyApiRecord(),
+        ...fields,
+      },
+    });
+
+    this.newRecords.update((existing) => existing.concat(newRow));
+    await this.createRecord(newRow);
+  }
+
   async addEmptyRecord(): Promise<void> {
     const row = new DraftRecordRow({
       record: this.getEmptyApiRecord(),

--- a/mathesar_ui/src/systems/table-view/row/Row.svelte
+++ b/mathesar_ui/src/systems/table-view/row/Row.svelte
@@ -35,6 +35,7 @@
     selection,
     canUpdateRecords,
     canDeleteRecords,
+    canInsertRecords,
   } = $tabularData);
   $: ({
     rowStatus,
@@ -99,6 +100,7 @@
             {recordPk}
             {recordsData}
             {row}
+            canInsertRecords={$canInsertRecords}
             canDeleteRecords={$canDeleteRecords}
           />
         </ContextMenu>
@@ -126,6 +128,7 @@
           {processedColumn}
           {recordsData}
           {recordPk}
+          canInsertRecords={$canInsertRecords}
           canUpdateRecords={$canUpdateRecords}
           canDeleteRecords={$canDeleteRecords}
         />

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -57,6 +57,7 @@
   export let processedColumn: ProcessedColumn;
   export let clientSideErrorMap: WritableMap<CellKey, ClientSideCellError[]>;
   export let value: unknown = undefined;
+  export let canInsertRecords: boolean;
   export let canUpdateRecords: boolean;
   export let canDeleteRecords: boolean;
 
@@ -183,7 +184,13 @@
     <!-- Row -->
     <MenuDivider />
     <MenuHeading>{$_('row')}</MenuHeading>
-    <RowContextOptions {recordPk} {recordsData} {row} {canDeleteRecords} />
+    <RowContextOptions
+      {recordPk}
+      {recordsData}
+      {row}
+      {canDeleteRecords}
+      {canInsertRecords}
+    />
   </ContextMenu>
   {#if errors.length}
     <CellErrors {serverErrors} {clientErrors} forceShowErrors={isActive} />

--- a/mathesar_ui/src/systems/table-view/row/RowContextOptions.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowContextOptions.svelte
@@ -2,7 +2,7 @@
   import { _ } from 'svelte-i18n';
 
   import type { ResultValue } from '@mathesar/api/rpc/records';
-  import { iconDeleteMajor } from '@mathesar/icons';
+  import { iconDeleteMajor, iconDuplicateRecord } from '@mathesar/icons';
   import { confirmDelete } from '@mathesar/stores/confirmation';
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import {
@@ -22,10 +22,13 @@
   export let recordPk: ResultValue | undefined = undefined;
   export let recordsData: RecordsData;
   export let canDeleteRecords: boolean;
+  export let canInsertRecords: boolean;
 
   // To be used in case of publicly shared links where user should not be able
   // to view linked tables & explorations
   const canViewLinkedEntities = true;
+
+  $: hasPk = recordPk !== undefined;
 
   async function handleDeleteRecords() {
     if (isRecordRow(row)) {
@@ -44,9 +47,13 @@
       });
     }
   }
+
+  function handleDuplicate() {
+    void recordsData.duplicateRecord(row);
+  }
 </script>
 
-{#if recordPk && canViewLinkedEntities}
+{#if hasPk && canViewLinkedEntities}
   <LinkMenuItem
     href={$storeToGetRecordPageUrl({ recordId: recordPk }) || ''}
     icon={iconExternalLink}
@@ -54,6 +61,14 @@
     {$_('go_to_record_page')}
   </LinkMenuItem>
 {/if}
+
+<ButtonMenuItem
+  on:click={handleDuplicate}
+  icon={iconDuplicateRecord}
+  disabled={!hasPk || !canInsertRecords}
+>
+  {$_('duplicate_record')}
+</ButtonMenuItem>
 
 <ButtonMenuItem
   on:click={handleDeleteRecords}


### PR DESCRIPTION
In #4341 we fixed a bug that a user encountered. But as [noted](https://matrix.to/#/!AcZNKHctLphVoqyJTQ:matrix.mathesar.org/$0FUHLWlhbAyNNeQmGj-is3znGyYJiInypkauumEI4Ug?via=matrix.mathesar.org&via=matrix.org&via=glup.sk) by the user in Matrix, what they really wanted was to be able to _duplicate_ a row. 

> does mathesar support either copy and pasting rows or duplicating a row?

This PR adds that feature. It's fewer clicks than using the copy-paste workflow.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


