### PR TITLE
Update command in developer guide to start dev-service

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -29,7 +29,7 @@ Mathesar is built using:
 1. From the repository's root directory, run:
 
     ```
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml up dev-service
+    docker compose -f docker-compose.dev.yml up dev-service
     ```
 
     > **Note:** You may need to run docker `sudo` depending on how you have it installed.
@@ -145,7 +145,7 @@ If you want to use Mathesar with a preexisting Postgres DB, modify the `DATABASE
 Sometimes you may need to rebuild your Docker images after pulling new code changes or switching branches. Do so via:
 
 ```
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up dev-service --force-recreate --build dev-service
+docker compose -f docker-compose.dev.yml up dev-service --force-recreate --build dev-service
 ```
 
 ## Internationalization


### PR DESCRIPTION
This PR updates the command in our developer guide to start the dev-service.

The existing command in the guide references both docker compose files (we used to have dependencies between these files, we no longer do). While this should not cause any issues, it's not necessary to include the prod docker compose file for starting the dev-service.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
