### PR TITLE
Add language selector to complete installation template

### DIFF
--- a/mathesar/templates/installation/complete_installation.html
+++ b/mathesar/templates/installation/complete_installation.html
@@ -114,6 +114,24 @@
     color: var(--sky-600);
   }
 
+  
+  .language-selector-form {
+    position: fixed;
+    bottom: 2%;
+    right: 2%;
+  }
+
+  .language-selector {
+    display: block;
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius-m);
+    color: var(--text-color-primary);
+    padding: var(--sm3);
+    cursor: pointer;
+  }
+
+
   @media (max-width: 54rem) {
     .container {
       grid-template-columns: none;
@@ -321,6 +339,19 @@
         {% translate "Complete Installation" %}
       </button>
     </div>
+  </form>
+  <form class="language-selector-form" action="{% url 'set_language' %}" method="post">{% csrf_token %}
+    <input name="next" type="hidden" value="{{ redirect_to }}">
+    <select name="language" onchange="form.submit()" class="language-selector align-center" aria-label="Display Language">
+        {% get_current_language as LANGUAGE_CODE %}
+        {% get_available_languages as LANGUAGES %}
+        {% get_language_info_list for LANGUAGES as languages %}
+        {% for language in languages %}
+            <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
+                {{ language.name_local }} ({{ language.code }})
+            </option>
+        {% endfor %}
+    </select>
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
This update introduces a language selector form in the complete_installation.html template, allowing users to choose their preferred display language. The form is styled for fixed positioning and includes a dropdown populated with available languages.

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4174

<!-- Concisely describe what the pull request does. -->
This PR add's a **"switch language dropdown"** on the installation page(`/complete_installation`)

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I copied the code from the `login_base.html` file 
```
<form action="{% url 'set_language' %}" method="post">{% csrf_token %}
      <input name="next" type="hidden" value="{{ redirect_to }}">
      <select name="language" onchange="form.submit()" class="language-selector align-center" aria-label="Display Language">
          {% get_current_language as LANGUAGE_CODE %}
          {% get_available_languages as LANGUAGES %}
          {% get_language_info_list for LANGUAGES as languages %}
          {% for language in languages %}
              <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
                  {{ language.name_local }} ({{ language.code }})
              </option>
          {% endfor %}
      </select>
</form>
```
to the `complete_installation.html` file after adding some styles for the dropdow to be fixed at the bottom right corner of the page.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

Problem:
![image](https://github.com/user-attachments/assets/e65a3fbe-a9e1-42c6-a983-1fd957fb5f30)

Solution:
![Screenshot 2025-05-07 at 1 10 38 PM](https://github.com/user-attachments/assets/7f39310b-5130-446d-92fa-2259f615debf)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
