### PR TITLE
Remove redundant cache-images job

### DIFF
--- a/.github/workflows/test-and-lint-code.yml
+++ b/.github/workflows/test-and-lint-code.yml
@@ -100,51 +100,6 @@ jobs:
       - name: echo
         run: echo "${{ steps.changed_files.outputs.any_changed }}"
 
-  cache-images:
-    runs-on: ubuntu-latest
-    needs: [python_tests_required, all_be_tests_required]
-    if: needs.python_tests_required.outputs.tests_should_run == 'true' ||
-        needs.all_be_tests_required.outputs.tests_should_run == 'true'
-    steps:
-      - uses: actions/checkout@v4
-      - id: docker-cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/docker-images
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile', '**/api_tests/Dockerfile', '**/Dockerfile.caddy', '**/Dockerfile.devdb') }}
-      - name: Verify image SHAs
-        id: verifysha
-        if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: |
-          touch /tmp/live-images-sha.txt
-          for version in 3.9 3.10 3.11 3.12 3.13; do
-            echo "$(skopeo inspect docker://python:$version-bookworm | jq -r '.Digest') python:$version-bookworm" >> /tmp/live-images-sha.txt
-          done
-          for version in 13 14 15 16 17; do
-            echo "$(skopeo inspect docker://postgres:$version | jq -r '.Digest') postgres:$version" >> /tmp/live-images-sha.txt
-          done
-          if diff <(sort -k2 /tmp/live-images-sha.txt) <(sort -k2 /tmp/docker-images/cached-images-sha.txt); then
-            echo "needs-update=false" >> $GITHUB_OUTPUT;
-            echo "exit code $?";
-          else
-            echo "needs-update=true" >> $GITHUB_OUTPUT;
-            echo "exit code $?";
-          fi
-      - name: echo
-        run: echo "${{ steps.verifysha.outputs.needs-update }}"
-      - name: Pull and save python images on cache misses
-        if: steps.docker-cache.outputs.cache-hit != 'true' || steps.verifysha.outputs.needs-update == 'true'
-        run: |
-          mkdir -p /tmp/docker-images && cd /tmp/docker-images
-          for version in 3.9 3.10 3.11 3.12 3.13; do
-            docker pull python:$version-bookworm && docker save python:$version-bookworm -o python-$version-bookworm.tar
-          done
-          for version in 13 14 15 16 17; do
-            docker pull postgres:$version && docker save postgres:$version -o postgres-$version.tar
-          done
-          docker images --digests --format '{{.Digest}} {{.Repository}}:{{.Tag}}' > cached-images-sha.txt
-          cat cached-images-sha.txt
-
 ################################################################################
 ##                         BACK END TEST/LINT RUNNERS                         ##
 ##                                                                            ##


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
I pulled out the `cache-images` job in a new file `.github/workflows/cache-images.yml` in #4471 & #4472, the reason for this change is that it caches against `develop` when a push happens on `develop`, instead of creating caches against each individual PR and merge_group, creating a cache against each individual PR was requiring us to retrigger our CI workflows, making a cache against `develop` fixes that. You can see that this PR passes all the tests in 1 try, no retriggers were made to pass the tests. 
![Screenshot 2025-05-15 at 4 55 05 AM](https://github.com/user-attachments/assets/e4c233a5-4a21-4266-aa1d-b4ed42bcba80)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
