### PR TITLE
Move hostname = None into socket conditional

### DIFF
--- a/db/deprecated/engine.py
+++ b/db/deprecated/engine.py
@@ -24,7 +24,7 @@ def create_future_engine(
     query = {}
     if hostname.startswith("/"):
         query = {"host": hostname}
-    hostname = None
+        hostname = None
     conn_url = URL.create(
         "postgresql",
         username=username,


### PR DESCRIPTION
This PR updates our socket connection bugfix from #4481, which unfortunately introduced a regression where explorations on DBs _not_ connected via Unix socket were broken.

## Testing instructions

Run Mathesar locally and verify you can work with explorations on non-socket and socket (if you can, I will test this as well) connections.