### PR TITLE
Add `is_joined_column` to exploration return

### DIFF
--- a/db/deprecated/queries/base.py
+++ b/db/deprecated/queries/base.py
@@ -345,7 +345,7 @@ class InitialColumn:
         """
         A base column is an initial column on a query's base table.
         """
-        return self.jp_path is None
+        return not self.jp_path
 
     def __eq__(self, other):
         """Instances are equal when attributes are equal."""

--- a/mathesar/utils/explorations.py
+++ b/mathesar/utils/explorations.py
@@ -184,6 +184,7 @@ def _get_exploration_column_metadata(
             "type_options": sa_col.type_options,
             "metadata": ColumnMetaDataRecord.from_model(column_metadata) if column_metadata else None,
             "is_initial_column": True if initial_column else False,
+            "is_joined_column": not initial_column.is_base_column if initial_column else None,
             "input_column_name": input_column_name,
             "input_table_name": input_table_name,
             "input_table_id": initial_column.reloid if initial_column else None,
@@ -191,10 +192,7 @@ def _get_exploration_column_metadata(
         }
     for alias, metadata in exploration_column_metadata.items():
         input_alias = metadata["input_alias"] or alias
-        metadata["is_base_table_column"] = (
-            exploration_column_metadata[input_alias]["input_table_id"]
-            == exploration_def["base_table_oid"]
-        )
+        metadata["is_joined_column"] = exploration_column_metadata[input_alias]["is_joined_column"]
     return exploration_column_metadata
 
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4502 

<!-- Concisely describe what the pull request does. -->

Adds an `is_joined_column` attribute to each `column_metadata` blob in the response to calls to `explorations.run` (or `explorations.run_saved`). This boolean is `false` if:

- The column was added in the "Base Table Column" section of the UI, or
- The column is a grouping or aggregation of such a column

Otherwise, this is false.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

I didn't write tests for this, since testing explorations is a bit sketchy. But, the logic and LOC are obvious and minimal, respectively.

We should make up for this with a scenario test involving explorations until such time as we move the exploration code to a more maintainable/testable state.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
