### PR TITLE
Conn leak bug

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -117,6 +117,9 @@ if POSTGRES_DB and POSTGRES_USER and POSTGRES_HOST:
         role=POSTGRES_USER,
         password=POSTGRES_PASSWORD,
     ).to_django_dict()
+    DATABASES['default']['OPTIONS'] = {
+        "application_name": f"Mathesar Django"
+    }
 
 for db_key, db_dict in DATABASES.items():
     # Engine should be '.postgresql' or '.postgresql_psycopg2' for all db(s)

--- a/db/connection.py
+++ b/db/connection.py
@@ -1,3 +1,4 @@
+import psycopg
 from psycopg.rows import dict_row
 from uuid import uuid4
 
@@ -58,3 +59,14 @@ def select_from_msar_func(conn, func_name, *args):
 def load_file_with_conn(conn, file_handle):
     """Run an SQL script from a file, using psycopg."""
     conn.execute(file_handle.read())
+
+
+def mathesar_connection(*args, **kwargs):
+    """
+    All Mathesar psycopg connections should use this function. It adds an
+    application_name to each connection (prepending any previously-set
+    application name). This is visible in the `pg_stat_activity` table,
+    useful for debugging (and perhaps required by some DBAs).
+    """
+    kwargs.update(application_name="Mathesar " + kwargs.get("application_name", ""))
+    return psycopg.connect(*args, **kwargs)

--- a/db/deprecated/engine.py
+++ b/db/deprecated/engine.py
@@ -45,6 +45,10 @@ def create_engine(conn_url, *args, **kwargs):
     across all engines. This is important for testing: without this intervention, fixtures become
     randomly corrupted.
     """
+    kwargs.update(
+        connect_args={"application_name": "db.deprecated.engine.create_future_engine"},
+        pool_size=2,
+    )
     engine = sa_create_engine(conn_url, *args, **kwargs)
     _make_ischema_names_unique(engine)
     return engine

--- a/db/deprecated/utils.py
+++ b/db/deprecated/utils.py
@@ -1,10 +1,11 @@
 import inspect
 import warnings
 
-import psycopg
 from psycopg2 import errors as p_errors
 import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
+
+from db.connection import mathesar_connection
 
 
 class UndefinedFunction(Exception):
@@ -74,10 +75,11 @@ def get_pg_catalog_table(table_name, engine, metadata):
 
 
 def engine_to_psycopg_conn(engine):
-    return psycopg.connect(
+    return mathesar_connection(
         host=engine.url.host or engine.url.query["host"],
         port=engine.url.port,
         dbname=engine.url.database,
         user=engine.url.username,
-        password=engine.url.password
+        password=engine.url.password,
+        application_name='mathesar.db.deprecated.utils.engine_to_psycopg_conn',
     )

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -3,7 +3,6 @@ import os
 from django.conf import settings
 from django.db import models
 from encrypted_fields.fields import EncryptedCharField
-import psycopg
 
 from db.sql.install import uninstall, install
 from db.analytics import get_object_counts

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -7,6 +7,7 @@ import psycopg
 
 from db.sql.install import uninstall, install
 from db.analytics import get_object_counts
+from db.connection import mathesar_connection
 from mathesar import __version__
 from mathesar.models import exceptions
 
@@ -121,12 +122,13 @@ class Database(BaseModel):
 
     def connect_manually(self, role, password):
         """Return a connection to the Database using the role and password."""
-        return psycopg.connect(
+        return mathesar_connection(
             host=self.server.host,
             port=self.server.port,
             dbname=self.name,
             user=role,
             password=password,
+            application_name='mathesar.models.base.Database.connect_manually',
         )
 
     def connect_admin(self):
@@ -196,12 +198,13 @@ class UserDatabaseRoleMap(BaseModel):
 
     @property
     def connection(self):
-        return psycopg.connect(
+        return mathesar_connection(
             host=self.server.host,
             port=self.server.port,
             dbname=self.database.name,
             user=self.configured_role.name,
             password=self.configured_role.password,
+            application_name='mathesar.models.base.UserDatabaseRoleMap.connection',
         )
 
 

--- a/mathesar/utils/permissions.py
+++ b/mathesar/utils/permissions.py
@@ -4,6 +4,7 @@ from psycopg.errors import DuplicateSchema
 
 from config.database_config import get_internal_database_config
 from db.databases import create_database
+from db.connection import mathesar_connection
 from mathesar.examples.bike_shop_dataset import load_bike_shop_dataset
 from mathesar.examples.hardware_store_dataset import load_hardware_store_dataset
 from mathesar.examples.ice_cream_employees_dataset import load_ice_cream_employees_dataset
@@ -42,12 +43,13 @@ def set_up_new_database_for_user_on_internal_server(
         conn_info.password,
         user
     )
-    with psycopg.connect(
+    with mathesar_connection(
             host=conn_info.host,
             port=conn_info.port,
             dbname=conn_info.dbname,
             user=conn_info.role,
             password=conn_info.password,
+            application_name='mathesar.utils.permissions.set_up_new_database_for_user_on_internal_server',
     ) as root_conn:
         create_database(database_name, root_conn)
     user_database_role.database.install_sql(

--- a/mathesar/utils/permissions.py
+++ b/mathesar/utils/permissions.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-import psycopg
 from psycopg.errors import DuplicateSchema
 
 from config.database_config import get_internal_database_config


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4535 

<!-- Concisely describe what the pull request does. -->

This adds an application name to all PostgreSQL connections created by Mathesar. It also limits the connection pool size to 2.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

I don't consider this a complete solution, since the connections still remain live and connected if the user logs off, until the Mathesar service is restarted (if it is).

The application name is _at least_ "Mathesar" for all connections. In some cases, the application name for a connection is "Mathesar " followed by the function that created the connection, e.g.,

```
Mathesar db.deprecated.engine.create_future_engine
```

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
