### PR TITLE
Allow static props for Rpc requests in AsyncRpcApiStore

### DIFF
--- a/mathesar_ui/src/models/Database.ts
+++ b/mathesar_ui/src/models/Database.ts
@@ -43,6 +43,7 @@ export class Database {
 
   constructConfiguredRolesStore() {
     return new AsyncRpcApiStore(api.roles.configured.list, {
+      staticProps: { server_id: this.server.id },
       postProcess: (rawConfiguredRoles) =>
         new SortedImmutableMap(
           (v) => [...v].sort(([, a], [, b]) => a.name.localeCompare(b.name)),
@@ -56,6 +57,7 @@ export class Database {
 
   constructRolesStore() {
     return new AsyncRpcApiStore(api.roles.list, {
+      staticProps: { database_id: this.id },
       postProcess: (rawRoles) =>
         new SortedImmutableMap(
           (v) => [...v].sort(([, a], [, b]) => a.name.localeCompare(b.name)),
@@ -69,6 +71,7 @@ export class Database {
 
   constructCollaboratorsStore() {
     return new AsyncRpcApiStore(api.collaborators.list, {
+      staticProps: { database_id: this.id },
       postProcess: (rawCollaborators) =>
         new ImmutableMap(
           rawCollaborators.map((rawCollaborator) => [
@@ -81,6 +84,7 @@ export class Database {
 
   constructDatabasePrivilegesStore() {
     return new AsyncRpcApiStore(api.databases.privileges.list_direct, {
+      staticProps: { database_id: this.id },
       postProcess: (rawDbPrivilegesForRoles) =>
         new ImmutableMap(
           rawDbPrivilegesForRoles.map((rawDatabasePrivilegesForRole) => [
@@ -93,6 +97,7 @@ export class Database {
 
   constructUnderlyingDatabaseStore() {
     return new AsyncRpcApiStore(api.databases.get, {
+      staticProps: { database_id: this.id },
       postProcess: (rawUnderlyingDatabase) =>
         new UnderlyingDatabase({
           database: this,
@@ -103,6 +108,7 @@ export class Database {
 
   constructCurrentRoleStore() {
     return new AsyncRpcApiStore(api.roles.get_current_role, {
+      staticProps: { database_id: this.id },
       postProcess: (currentRole) => ({
         currentRoleOid: currentRole.current_role.oid,
         parentRoleOids: new Set(currentRole.parent_roles.map((pr) => pr.oid)),

--- a/mathesar_ui/src/models/Schema.ts
+++ b/mathesar_ui/src/models/Schema.ts
@@ -109,6 +109,7 @@ export class Schema {
 
   constructSchemaPrivilegesStore() {
     return new AsyncRpcApiStore(api.schemas.privileges.list_direct, {
+      staticProps: { database_id: this.database.id, schema_oid: this.oid },
       postProcess: (rawSchemaPrivilegesForRoles) =>
         new ImmutableMap(
           rawSchemaPrivilegesForRoles.map((rawSchemaPrivilegesForRole) => [

--- a/mathesar_ui/src/pages/database/DatabasePageWrapper.svelte
+++ b/mathesar_ui/src/pages/database/DatabasePageWrapper.svelte
@@ -40,7 +40,7 @@
 
   const databaseRouteContext = DatabaseRouteContext.get();
   $: ({ database, underlyingDatabase } = $databaseRouteContext);
-  $: void underlyingDatabase.runConservatively({ database_id: database.id });
+  $: void underlyingDatabase.runConservatively();
 
   // // TODO Allow dropping databases
   // const commonData = preloadCommonData();

--- a/mathesar_ui/src/pages/database/permissions/DatabasePermissionsModal.svelte
+++ b/mathesar_ui/src/pages/database/permissions/DatabasePermissionsModal.svelte
@@ -70,10 +70,10 @@
 
   function getAsyncStoresForPermissions() {
     void AsyncRpcApiStore.runBatchConservatively([
-      databasePrivileges.batchRunner({ database_id: database.id }),
-      roles.batchRunner({ database_id: database.id }),
-      underlyingDatabase.batchRunner({ database_id: database.id }),
-      currentRole.batchRunner({ database_id: database.id }),
+      databasePrivileges.batchRunner(),
+      roles.batchRunner(),
+      underlyingDatabase.batchRunner(),
+      currentRole.batchRunner(),
     ]);
     return {
       roles,

--- a/mathesar_ui/src/pages/database/schemas/SchemasSection.svelte
+++ b/mathesar_ui/src/pages/database/schemas/SchemasSection.svelte
@@ -35,7 +35,7 @@
   let highlightingEnabled = true;
 
   $: ({ database, underlyingDatabase } = $databaseRouteContext);
-  $: void underlyingDatabase.runConservatively({ database_id: database.id });
+  $: void underlyingDatabase.runConservatively();
   $: schemasMap = $schemasStore.data;
   $: schemasRequestStatus = $schemasStore.requestStatus;
   $: isLoading =

--- a/mathesar_ui/src/pages/database/settings/collaborators/Collaborators.svelte
+++ b/mathesar_ui/src/pages/database/settings/collaborators/Collaborators.svelte
@@ -44,8 +44,8 @@
   } = $routeContext);
 
   $: void AsyncRpcApiStore.runBatchConservatively([
-    collaborators.batchRunner({ database_id: database.id }),
-    configuredRoles.batchRunner({ server_id: database.server.id }),
+    collaborators.batchRunner(),
+    configuredRoles.batchRunner(),
   ]);
   $: void users.runConservatively();
   $: isLoading =
@@ -68,10 +68,8 @@
   function checkAndHandleSideEffects(collaborator: Collaborator) {
     if (collaborator.userId === $userProfileStore.id) {
       void AsyncRpcApiStore.runBatch([
-        databaseRouteContext.underlyingDatabase.batchRunner({
-          database_id: database.id,
-        }),
-        databaseRouteContext.roles.batchRunner({ database_id: database.id }),
+        databaseRouteContext.underlyingDatabase.batchRunner(),
+        databaseRouteContext.roles.batchRunner(),
       ]);
       void fetchSchemasForCurrentDatabase();
     }

--- a/mathesar_ui/src/pages/database/settings/role-configuration/RoleConfiguration.svelte
+++ b/mathesar_ui/src/pages/database/settings/role-configuration/RoleConfiguration.svelte
@@ -36,12 +36,12 @@
   const userProfileStore = getUserProfileStoreFromContext();
   $: ({ isMathesarAdmin } = $userProfileStore);
 
-  $: ({ database, databaseRouteContext, configuredRoles, combinedLoginRoles } =
+  $: ({ databaseRouteContext, configuredRoles, combinedLoginRoles } =
     $routeContext);
   $: ({ roles } = databaseRouteContext);
   $: void AsyncRpcApiStore.runBatchConservatively([
-    configuredRoles.batchRunner({ server_id: database.server.id }),
-    roles.batchRunner({ database_id: database.id }),
+    configuredRoles.batchRunner(),
+    roles.batchRunner(),
   ]);
   $: isLoading = $configuredRoles.isLoading || $roles.isLoading;
   $: errors = [$configuredRoles.error, $roles.error].filter(

--- a/mathesar_ui/src/pages/database/settings/roles/Roles.svelte
+++ b/mathesar_ui/src/pages/database/settings/roles/Roles.svelte
@@ -26,10 +26,9 @@
   const modifyRoleMembersModalController = modal.spawnModalController();
 
   $: ({ databaseRouteContext, configuredRoles, collaborators } = $routeContext);
-  $: ({ database, roles, underlyingDatabase, currentRole } =
-    databaseRouteContext);
+  $: ({ roles, underlyingDatabase, currentRole } = databaseRouteContext);
 
-  $: void roles.runConservatively({ database_id: database.id });
+  $: void roles.runConservatively();
   $: roleList = [...($roles.resolvedValue?.values() ?? [])];
 
   let targetRole: Role | undefined = undefined;
@@ -51,8 +50,8 @@
 
     if (currentRoleInheritsOrIsEditedRole) {
       void AsyncRpcApiStore.runBatch([
-        currentRole.batchRunner({ database_id: database.id }),
-        underlyingDatabase.batchRunner({ database_id: database.id }),
+        currentRole.batchRunner(),
+        underlyingDatabase.batchRunner(),
       ]);
       void fetchSchemasForCurrentDatabase();
     }

--- a/mathesar_ui/src/pages/schema/SchemaPermissionsModal.svelte
+++ b/mathesar_ui/src/pages/schema/SchemaPermissionsModal.svelte
@@ -73,12 +73,9 @@
 
   function getAsyncStoresForPermissions() {
     void AsyncRpcApiStore.runBatchConservatively([
-      schemaPrivileges.batchRunner({
-        database_id: schema.database.id,
-        schema_oid: schema.oid,
-      }),
-      roles.batchRunner({ database_id: schema.database.id }),
-      currentRole.batchRunner({ database_id: schema.database.id }),
+      schemaPrivileges.batchRunner(),
+      roles.batchRunner(),
+      currentRole.batchRunner(),
     ]);
     return {
       roles,

--- a/mathesar_ui/src/systems/table-view/table-inspector/table/TablePermissionsModal.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/table/TablePermissionsModal.svelte
@@ -94,8 +94,8 @@
         database_id: table.schema.database.id,
         table_oid: table.oid,
       }),
-      roles.batchRunner({ database_id: table.schema.database.id }),
-      currentRole.batchRunner({ database_id: table.schema.database.id }),
+      roles.batchRunner(),
+      currentRole.batchRunner(),
     ]);
     return {
       roles,


### PR DESCRIPTION
This is a minor improvement/refactor on the frontend. This was affecting my work on the forms prototype and I decided to raise a PR for it.

We have an `AsyncRpcApiStore` class that makes it easier to construct an `AsyncStore` for RPC requests.

We also have models that construct these stores for their children and process the response to ensure that the stored values are models and not raw responses.

However, when we run the RPC method from the store, we have to include information which is already present in the models that construct these stores. This PR adds a `staticProps` option to AsyncRpcApiStore to avoid having to do that.

Example:
- The `Database` model constructs a store for the collaborators when the method `constructCollaboratorsStore` is called.
   - It fetches raw collaborators.list response, processes, and stores them as an immutable map of `Collaborator` models.
   - Each `Collaborator` model contains a reference to the `Database` model.
- However, while invoking `run` or `batchRunner` from that store, we'd have to do:
   - `collaborators.batchRunner({ database_id: database.id })`
- After this PR:
   - `database_id` is passed as a static prop while creating the AsyncRpcApiStore store.
   - We only have to invoke `collaborators.batchRunner()` or `collaborators.run()`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
