### PR TITLE
[WIP] DigitalOcean App Platform one-click installation docs

### DIFF
--- a/docs/docs/administration/install-one-click-digital-ocean.md
+++ b/docs/docs/administration/install-one-click-digital-ocean.md
@@ -1,0 +1,27 @@
+# One-click Install Mathesar on DigitalOcean App Platform
+
+Install Mathesar to DigitalOcean in just minutes using the convenient one-click deployment button below:
+
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/mathesar-foundation/mathesar-digital-ocean/tree/main)
+
+Clicking the button will create a new, running Mathesar instance costing ~$12/month.
+
+## Why Choose DigitalOcean App Platform?
+
+[DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform) simplifies deploying, scaling, and managing Mathesar without worrying about underlying infrastructure management. It's ideal for:
+
+- Beginners who need an easy, quick setup without delving into infrastructure specifics.
+- Small to medium-sized teams looking for reliable hosting with minimal overhead.
+- Developers who prefer easy scaling, clear pricing, and stability without needing to SSH into servers or manually manage configuration.
+
+## After succesfully installing Mathesar
+
+### Secure your installation with a `SECRET_KEY` (Strongly Recommended)
+
+### Connect your production database(s)
+
+### Add a custom domain name (optional)
+
+By default, Digital Ocean will give your Mathesar installation its own secured domain name, like `https://mathesar-*.ondigitalocean.app/`.
+
+You can easily add a custom domain name by following Digital Ocean's guide on [Adding a custom domain using their control panel](https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/#custom-domain).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -16,7 +16,7 @@ This is a quick way to play with Mathesar locally, but is not appropriate for sa
 
     ??? tip "Tips when trying Mathesar locally"
         - To open a [psql](https://www.postgresql.org/docs/current/app-psql.html) shell within the container, run:
-        
+
             ```
             docker exec -it mathesar sudo -u postgres psql
             ```
@@ -33,12 +33,16 @@ This is a quick way to play with Mathesar locally, but is not appropriate for sa
 
 You can self-host Mathesar by following one of the guides below:
 
+### Fully self-hosted
+
 - [Install using Docker compose](./administration/install-via-docker-compose.md) — a production setup with separate reverse-proxy and database containers.
 - [Install directly on Linux, macOS, or WSL](./administration/install-from-scratch.md) — an advanced setup that doesn't rely on Docker.
 
+### One-click, managed solutions
+
+- [One-click install to Digital Ocean App Platform](./administration/install-one-click-digital-ocean.md) — Quick and simple management of Mathesar costing as little as $12/month.
 
 ## Help out
 
-- [Make a donation](https://mathesar.org/donate) - We're a non-profit organization and your donations help sustain our core team. 
+- [Make a donation](https://mathesar.org/donate) - We're a non-profit organization and your donations help sustain our core team.
 - [Help build Mathesar](https://github.com/mathesar-foundation/mathesar/blob/develop/CONTRIBUTING.md) - As an open source project, we actively encourage contribution!
-

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,15 +6,17 @@ edit_uri: edit/develop/docs/docs/
 
 nav:
   - Introduction: index.md
+  - Install Mathesar:
+      - Using Docker Compose: administration/install-via-docker-compose.md
+      - On Linux · macOS · WSL: administration/install-from-scratch.md
+      - One-click installations:
+          - Digital Ocean App Platform: administration/install-one-click-digital-ocean.md
   - Administrator Guide:
-      - Install using Docker Compose: administration/install-via-docker-compose.md
-      - Install on Linux · macOS · WSL: administration/install-from-scratch.md
       - Environment variables: administration/environment-variables.md
       - Upgrade Mathesar: administration/upgrade.md
       - Uninstall Mathesar: administration/uninstall.md
       - Debugging Mathesar: administration/debug.md
       - Postgres & Python versions: administration/version-support.md
-
   - User Guide:
       - Introduction: user-guide/index.md
       - Your data in PostgreSQL:


### PR DESCRIPTION
## TODO

- [ ] Finish, clean up, and restructure the Digital Ocean docs
  - Figure out balance between a how-to guide vs. "marketing"-style copy
- [ ] Apps in the DO app platform do not have persistent storage or volumes, which means Mathesar's internal DB _has to_ be in a paid, hosted database. This is fine (and good, from a backup and data integrity perspective!) but it needs to be clearly articulated to users to either:
  - Use and pay for a Digital Ocean managed Postgres DB cluster (default) for their Mathesar internal _and_ Data databases
  - If they have an existing Data database cluster, consider adding a new DB there for the Mathesar internal DB instead.
- [ ] Add information on how to scale up the Mathesar app instance 