### PR TITLE
Fix SSO traceback printing & mount

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -122,7 +122,8 @@ try:
                 )
 except Exception as e:
     # We swallow any exceptions when SSO is misconfigured in sso.yml so that the django server doesn't fail to start.
-    traceback.print_exception(type(e), e, e.__traceback__)  # Print the traceback in case of an exception.
+    if OIDC_CONFIG_DICT not in [None, {}]:
+        traceback.print_exception(type(e), e, e.__traceback__)  # Print the traceback in case of an exception.
 
 
 SOCIALACCOUNT_PROVIDERS = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,8 @@ services:
     volumes:
       - ./msar/static:/code/static
       - ./msar/media:/code/media
-      - ./sso.yml:/code/sso.yml
+      # Uncomment the following to mount sso.yml and enable Single Sign-On(SSO).
+      # - ./sso.yml:/code/sso.yml
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
This PR makes sure that we only print exception tracebacks when `OIDC_CONFIG_DICT` is misconfigured. 

This PR also fixes the issue described https://github.com/mathesar-foundation/mathesar/pull/4634#discussion_r2211163047 , The user would have to uncomment the mount from the docker compose file once they have created `sso.yml` at the appropriate location so that a directory named as `sso.yml/` isn't created unintentionally.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
