### PR TITLE
Separate out common data for anonymous pages (Split from #4609)

### DIFF
--- a/mathesar_ui/src/App.svelte
+++ b/mathesar_ui/src/App.svelte
@@ -10,7 +10,11 @@
   import RootRoute from './routes/RootRoute.svelte';
 
   const commonData = preloadCommonData();
-  void initI18n(commonData.user.display_language ?? 'en');
+  const userDisplayLanguage =
+    commonData.routing_context !== 'anonymous'
+      ? commonData.user.display_language
+      : null;
+  void initI18n(userDisplayLanguage ?? 'en');
 </script>
 
 <AppContext {commonData}>

--- a/mathesar_ui/src/stores/databases.ts
+++ b/mathesar_ui/src/stores/databases.ts
@@ -151,14 +151,3 @@ export const databasesStore: MakeWritablePropertiesReadable<DatabasesStore> =
       currentDatabase,
     );
   })();
-
-/** ⚠️ This readable store contains a type assertion designed to sacrifice type
- * safety for the benefit of convenience.
- *
- * We need to access `currentDatabase` like EVERYWHERE throughout the app, and
- * we'd like to avoid checking if it's defined every time. So we assert that it
- * is defined, and we'll just have to be careful to **never use the value from
- * this store within a context where no database is set.**
- */
-export const currentDatabase =
-  databasesStore.currentDatabase as Readable<Database>;

--- a/mathesar_ui/src/stores/databases.ts
+++ b/mathesar_ui/src/stores/databases.ts
@@ -138,10 +138,19 @@ class DatabasesStore {
 export type DatabaseDisconnectFn = typeof databasesStore.disconnectDatabase;
 
 export const databasesStore: MakeWritablePropertiesReadable<DatabasesStore> =
-  new DatabasesStore(
-    generateDatabaseEntries(commonData.servers, commonData.databases),
-    commonData.current_database,
-  );
+  (() => {
+    const isInAuthenticatedContext = commonData.routing_context !== 'anonymous';
+    const servers = isInAuthenticatedContext ? commonData.servers : [];
+    const databases = isInAuthenticatedContext ? commonData.databases : [];
+    const currentDatabase = isInAuthenticatedContext
+      ? commonData.current_database
+      : null;
+
+    return new DatabasesStore(
+      generateDatabaseEntries(servers, databases),
+      currentDatabase,
+    );
+  })();
 
 /** ⚠️ This readable store contains a type assertion designed to sacrifice type
  * safety for the benefit of convenience.

--- a/mathesar_ui/src/stores/queries.ts
+++ b/mathesar_ui/src/stores/queries.ts
@@ -50,6 +50,7 @@ import { type CancellablePromise, collapse } from '@mathesar-component-library';
 import { currentSchema } from './schemas';
 
 const commonData = preloadCommonData();
+const isInAuthenticatedContext = commonData.routing_context !== 'anonymous';
 
 export interface QueriesStoreSubstance {
   databaseId?: Database['id'];
@@ -249,6 +250,7 @@ export const queries = collapse(
     ) {
       if (
         preload &&
+        isInAuthenticatedContext &&
         commonData.current_schema === $currentSchema?.oid &&
         commonData.current_database === $currentSchema?.database.id
       ) {

--- a/mathesar_ui/src/stores/schemas.ts
+++ b/mathesar_ui/src/stores/schemas.ts
@@ -22,9 +22,13 @@ import {
 import { databasesStore } from './databases';
 
 const commonData = preloadCommonData();
+const isInAuthenticatedContext = commonData.routing_context !== 'anonymous';
+const currentSchemaFromCommonData = isInAuthenticatedContext
+  ? commonData.current_schema
+  : null;
 
 export const currentSchemaId: Writable<Schema['oid'] | undefined> = writable(
-  commonData.current_schema ?? undefined,
+  currentSchemaFromCommonData ?? undefined,
 );
 
 export interface SchemaStoreData {
@@ -161,7 +165,11 @@ export const schemas = collapse(
   derived(databasesStore.currentDatabase, ($currentDatabase) => {
     const $schemasStore = get(schemasStore);
     if ($schemasStore.databaseId !== $currentDatabase?.id) {
-      if (preload && commonData.current_database === $currentDatabase?.id) {
+      if (
+        preload &&
+        isInAuthenticatedContext &&
+        commonData.current_database === $currentDatabase?.id
+      ) {
         if (commonData.schemas.state === 'success') {
           setSchemasInStore($currentDatabase, commonData.schemas.data);
         } else {

--- a/mathesar_ui/src/stores/tables.ts
+++ b/mathesar_ui/src/stores/tables.ts
@@ -41,6 +41,7 @@ import {
 import { currentSchema } from './schemas';
 
 const commonData = preloadCommonData();
+const isInAuthenticatedContext = commonData.routing_context !== 'anonymous';
 
 type TablesMap = Map<Table['oid'], Table>;
 
@@ -417,6 +418,7 @@ export const currentTablesData = collapse(
     ) {
       if (
         preload &&
+        isInAuthenticatedContext &&
         commonData.current_schema === $currentSchema?.oid &&
         commonData.current_database === $currentSchema?.database.id
       ) {

--- a/mathesar_ui/src/systems/data-explorer/QueryManager.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryManager.ts
@@ -9,7 +9,7 @@ import {
   explorationIsAddable,
   explorationIsSaved,
 } from '@mathesar/api/rpc/explorations';
-import { currentDatabase } from '@mathesar/stores/databases';
+import { databasesStore } from '@mathesar/stores/databases';
 import { addExploration, replaceExploration } from '@mathesar/stores/queries';
 import CacheManager from '@mathesar/utils/CacheManager';
 import type { CancellablePromise } from '@mathesar-component-library';
@@ -108,7 +108,10 @@ export default class QueryManager extends QueryRunner {
     }
 
     try {
-      const database = get(currentDatabase);
+      const database = get(databasesStore.currentDatabase);
+      if (!database) {
+        throw new Error('Current database not set');
+      }
       this.state.update((state) => ({
         ...state,
         inputColumnsFetchState: { state: 'processing' },

--- a/mathesar_ui/src/systems/table-view/constraints/ForeignKeyConstraintDetails.svelte
+++ b/mathesar_ui/src/systems/table-view/constraints/ForeignKeyConstraintDetails.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { get } from 'svelte/store';
   import { _ } from 'svelte-i18n';
 
   import { api } from '@mathesar/api/rpc';
@@ -6,7 +7,7 @@
   import { Icon, Spinner, iconError } from '@mathesar/component-library';
   import ColumnName from '@mathesar/components/column/ColumnName.svelte';
   import TableName from '@mathesar/components/TableName.svelte';
-  import { currentDatabase } from '@mathesar/stores/databases';
+  import { databasesStore } from '@mathesar/stores/databases';
   import { currentTablesData } from '@mathesar/stores/tables';
 
   export let constraint: RawConstraint;
@@ -20,9 +21,13 @@
     if (_constraint.type !== 'foreignkey') {
       return [];
     }
+    const database = get(databasesStore.currentDatabase);
+    if (!database) {
+      throw new Error('Current database not set');
+    }
     const referentTableColumns = await api.columns
       .list({
-        database_id: $currentDatabase.id,
+        database_id: database.id,
         table_oid: _constraint.referent_table_oid,
       })
       .run();

--- a/mathesar_ui/src/utils/preloadData.ts
+++ b/mathesar_ui/src/utils/preloadData.ts
@@ -18,7 +18,13 @@ type WithStatus<D> =
       };
     };
 
-export interface CommonData {
+export interface BaseCommonData {
+  current_release_tag_name: string;
+  supported_languages: Record<string, string>;
+  is_authenticated: boolean;
+}
+
+export interface AuthenticatedCommonData extends BaseCommonData {
   databases: RawDatabase[];
   servers: RawServer[];
   schemas: WithStatus<RawSchema[]>;
@@ -33,11 +39,14 @@ export interface CommonData {
   };
   current_schema: number | null;
   user: User;
-  current_release_tag_name: string;
-  supported_languages: Record<string, string>;
-  is_authenticated: boolean;
-  routing_context: 'normal' | 'anonymous';
+  routing_context: 'normal';
 }
+
+export interface AnonymousCommonData extends BaseCommonData {
+  routing_context: 'anonymous';
+}
+
+export type CommonData = AuthenticatedCommonData | AnonymousCommonData;
 
 function getData<T>(selector: string): T | undefined {
   const preloadedData = document.querySelector<Element>(selector);


### PR DESCRIPTION
This PR is split from https://github.com/mathesar-foundation/mathesar/pull/4609

- Splits CommonData for authenticated and anonymous views
- Removes the type unsafe `currentDatabase` store (it was previously used in several places in the app, now its only used in a couple locations) 

This PR targets the `develop` branch as it is self-contained and not specific to forms.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
