### PR TITLE
Add default for OIDC_CONFIG_DICT

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE-config.settings.development}
       - ALLOWED_HOSTS=${ALLOWED_HOSTS-*}
       - SECRET_KEY=${SECRET_KEY}
-      - OIDC_CONFIG_DICT=${OIDC_CONFIG_DICT}
+      - OIDC_CONFIG_DICT=${OIDC_CONFIG_DICT-{}}
       - MATHESAR_ANALYTICS_URL=${MATHESAR_ANALYTICS_URL-https://example.com/collector}
       - MATHESAR_INIT_REPORT_URL=${MATHESAR_INIT_REPORT_URL-https://example.com/hello}
       - MATHESAR_FEEDBACK_URL=${MATHESAR_FEEDBACK_URL-https://example.com/feedback}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ x-config: &config
   # sso.yml configuration file.
   # See https://docs.mathesar.org/administration/single-sign-on/ for additional
   # details on how to configure this variable.
-  OIDC_CONFIG_DICT: ${OIDC_CONFIG_DICT:-}
+  OIDC_CONFIG_DICT: ${OIDC_CONFIG_DICT:-{}}
 
 #-------------------------------------------------------------------------------
 # ADDITIONAL INFO ABOUT CONFIG VARIABLES


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

## THIS BRANCH IS TARGETED AT `master`.

During the review of #4643 I missed that `OIDC_CONFIG_DICT: ${OIDC_CONFIG_DICT:-}` or `OIDC_CONFIG_DICT=${OIDC_CONFIG_DICT}` is not read as `None` instead it prints the following on the console:

```
Traceback (most recent call last):
mathesar_service_dev  |   File "/code/config/settings/common_settings.py", line 66, in <module>
mathesar_service_dev  |     OIDC_CONFIG_DICT = json.loads(os.getenv('OIDC_CONFIG_DICT', "{}"))
mathesar_service_dev  |   File "/usr/local/lib/python3.13/json/__init__.py", line 346, in loads
mathesar_service_dev  |     return _default_decoder.decode(s)
mathesar_service_dev  |            ~~~~~~~~~~~~~~~~~~~~~~~^^^
mathesar_service_dev  |   File "/usr/local/lib/python3.13/json/decoder.py", line 345, in decode
mathesar_service_dev  |     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
mathesar_service_dev  |                ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
mathesar_service_dev  |   File "/usr/local/lib/python3.13/json/decoder.py", line 363, in raw_decode
mathesar_service_dev  |     raise JSONDecodeError("Expecting value", s, err.value) from None
mathesar_service_dev  | json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
mathesar_service_dev  | 
``` 
This doesn't affect any functionality for using SSO or mathesar in general and as long as `sso.yml` is correctly configured SSO will work as expected.

This PR aims to suppress this error message by adding a default for OIDC_CONFIG_DICT.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
