### PR TITLE
Fix UI hang issues

### DIFF
--- a/mathesar_ui/src/stores/table-data/display.ts
+++ b/mathesar_ui/src/stores/table-data/display.ts
@@ -108,9 +108,12 @@ function combineRecordRowsWithGroupHeaders({
       group.resultIndices.forEach((resultIndex) => {
         const recordRow = recordRows[resultIndex];
         if (!recordRow) {
-          throw new Error(
-            'Record from group result index is not found. This should never happen',
-          );
+          // ⚠️ This is a weird case. It _does_ actually occur. Returning is a
+          // bit of a hack. Fixing this properly will require some refactoring
+          // of stores. See comments in:
+          // https://github.com/mathesar-foundation/mathesar/issues/4594 and/or
+          // the related PR
+          return;
         }
         combinedRows.push({
           row: recordRow,


### PR DESCRIPTION

Fixes #4648
Fixes #4594

## Analysis

In `combineRecordRowsWithGroupHeaders` we were throwing an error within a logic branch that _seemed_ impossible — but it wasn't!

Within that function, the `recordRows` and `grouping` parameters are tightly coupled. These values come from the same `records.list` API response. The `grouping` value is a data structure which references indices within `recordRows`. So it would seem that each of these index values should always point to a valid record row.

But the problem is that sometimes this function gets called with `recordRows` and `grouping` values _from different API responses_!

Here's how it happens:

1. The table page has loaded and all is well.

1. The user changes _something_ that causes the records to reload, e.g. filter, group, pagination, etc.

1. In `RecordsData.fetch` we get the records and grouping from the API.

1. Then (among other things) we call:

    1. `this.fetchedRecordRows.set`
    1. `this.grouping.set`

    These are _two separate calls_ to update _two separate stores_.

1. The `Display` class maintains a `displayRowDescriptors` store derived from (among other things) `recordsData.fetchedRecordRows` and `recordsData.grouping`.

    The derivation function calls `combineRecordRowsWithGroupHeaders`.

1. So we have a diamond problem:

    ```mermaid
    graph TD
      A[API response] --> B[records]
      A --> C[grouping]
      B --> D[displayRowDescriptors]
      C --> D
    ```

    This would be okay if Svelte were smart enough to batch the computation of derived stores. But it's not. 

1. So inside `RecordsData.fetch` when we call `this.fetchedRecordRows.set`, then `displayRowDescriptors` is immediately recomputed. And in doing so it uses the _latest_ value for `recordRows` but the _old_ value for `grouping`. Boom there's our problem. The interdependence between these two values is not enforced in our stores structure.

Under many circumstances, the `displayRowDescriptors` actually gets recomputed _four_ times!

To me the proper fix would seem to be a refactor that makes the granular stores more coarse by lumping them into an immutable data structure which enforces that interdependence, preventing the values from being decoupled with one another. We could potentially lump other similar stores into the same data structure too, but this will require some thought. In general, I think we ought to make an effort to avoid these diamond store structures, and this is an example of why.

For the time being though, I changed the error to a return. It's a crude way to fix the problem for now.



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

