### PR TITLE
Improve responsive behavior of shared form fill-out page

### DIFF
--- a/mathesar_ui/src/pages/shared-data-form/SharedDataFormFillPage.svelte
+++ b/mathesar_ui/src/pages/shared-data-form/SharedDataFormFillPage.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import type { RawDataForm, RawDataFormSource } from '@mathesar/api/rpc/forms';
   import Errors from '@mathesar/components/errors/Errors.svelte';
-  import LayoutWithHeader from '@mathesar/layouts/LayoutWithHeader.svelte';
   import type { RpcError } from '@mathesar/packages/json-rpc-client-builder';
   import { makeSimplePageTitle } from '@mathesar/pages/pageTitleUtils';
   import type { AsyncStoreValue } from '@mathesar/stores/AsyncStore';
   import {
-    DataFormCanvas,
     DataFormStructure,
     FormSource,
     ReadonlyDataFormManager,
   } from '@mathesar/systems/data-forms/form-maker';
+  import DataFormBranding from '@mathesar/systems/data-forms/form-maker/DataFormBranding.svelte';
+  import DataFormFieldsContainer from '@mathesar/systems/data-forms/form-maker/elements/DataFormFieldsContainer.svelte';
+  import DataFormFooter from '@mathesar/systems/data-forms/form-maker/elements/DataFormFooter.svelte';
+  import DataFormHeader from '@mathesar/systems/data-forms/form-maker/elements/DataFormHeader.svelte';
 
   export let rawDataForm: RawDataForm;
   export let formSourceInfo: AsyncStoreValue<RawDataFormSource, RpcError>;
@@ -30,19 +32,40 @@
   <title>{makeSimplePageTitle(pageTitle)}</title>
 </svelte:head>
 
-<LayoutWithHeader fitViewport>
-  {#if dataFormManager}
-    <div class="data-form-filler">
-      <DataFormCanvas {dataFormManager} />
+{#if dataFormManager}
+  {@const { fields } = dataFormManager.dataFormStructure}
+  <div class="data-form-filler">
+    <div class="form">
+      <DataFormHeader {dataFormManager} />
+      <DataFormFieldsContainer {fields} {dataFormManager} />
+      <DataFormFooter {dataFormManager} />
+      <div class="branding">
+        <DataFormBranding />
+      </div>
     </div>
-  {:else if formSourceInfo.error}
-    <Errors errors={[formSourceInfo.error]} />
-  {/if}
-</LayoutWithHeader>
+  </div>
+{:else if formSourceInfo.error}
+  <Errors errors={[formSourceInfo.error]} />
+{/if}
 
 <style lang="scss">
   .data-form-filler {
+    overflow: auto;
+    position: relative;
     height: 100%;
-    overflow: hidden;
+    background: var(--elevated-background);
+    --data_forms__label-input-gap: var(--sm5);
+    --data_forms__selectable-element-padding: var(--sm5) 0 var(--sm5) 1rem;
+
+    .form {
+      margin: 0 auto;
+      max-width: 40rem;
+      padding-right: 1rem;
+
+      .branding {
+        border-top: 1px solid var(--border-color);
+        margin-top: var(--lg2);
+      }
+    }
   }
 </style>


### PR DESCRIPTION

Before this PR, the anonymous form fill-out UI was truncated for narrow viewports, making it difficult to fill out the form on a phone.

## Notes

- I changed the page layout design slightly, removing the inset page area. It's simpler now. Just one background color. I think a simple design is good here, but that's somewhat subjective. If we still want the inset page design, we could add it back in at a certain breakpoint.

- I also collapsed some vertical space, making it easier to see more of the form on smaller screens. Again, this is a subjective design choice. This change only affects the anonymous shared form fill-out page. It does not affect the form builder, where the additional vertical space is useful to account for the additional form-building UI that appears when a field is selected.

## Before vs After

<img alt="Image" src="https://github.com/user-attachments/assets/7db8b74f-7435-4f35-9d8a-2b911a4faa8b" />

<img  lt="Image" src="https://github.com/user-attachments/assets/75369896-63a2-4af5-acc9-46d39088abbc" />

<img alt="Image" src="https://github.com/user-attachments/assets/4e220426-2ff7-4c5f-a491-ca552691d63f" />


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

