### PR TITLE
Fix QA issues - 0.5.0

### DIFF
--- a/mathesar/rpc/forms.py
+++ b/mathesar/rpc/forms.py
@@ -414,5 +414,4 @@ def submit(*, form_token: str, values: dict, **kwargs) -> None:
         form_token: The unique token of the form.
         values: A dict describing the values to insert.
     """
-    user = kwargs.get(REQUEST_KEY).user
-    return submit_form(form_token, values, user)
+    return submit_form(form_token, values)

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path('administration/settings/', views.admin_home, name='admin_settings'),
     path('i18n/', include('django.conf.urls.i18n')),
     path('info/analytics_sample_report/', views.analytics_sample_report, name='analytics_sample_report'),
-    path('shares/forms/<str:form_token>/', views.anonymous_route_home, name='shared_form'),
+    re_path(r'^shares/forms/(?P<form_token>[0-9a-zA-Z\-]+)/?', views.anonymous_route_home, name='shared_form'),
     re_path(
         r'^db/(?P<database_id>\d+)/schemas/(?P<schema_id>\d+)/',
         views.schema_route,

--- a/mathesar/utils/forms.py
+++ b/mathesar/utils/forms.py
@@ -204,9 +204,9 @@ def iterate_form_fields(fields, parent_field=None, depth=0, fields_to_pick=[]):
         )
 
 
-def submit_form(form_token, values, user):
+def submit_form(form_token, values):
     form_model = Form.objects.get(token=form_token)
-    assert has_permission_for_form(user, form_model), 'Insufficient permission to submit the form'
+    assert form_model.publish_public, 'This form does not accept submissions'
     fields_to_pick = [i for i in values.keys() if isinstance(values[i], dict) and values[i].get('type') == 'pick']
     field_info_list = [
         {

--- a/mathesar_ui/src/i18n/languages/en/dict.json
+++ b/mathesar_ui/src/i18n/languages/en/dict.json
@@ -768,6 +768,7 @@
   "theme_light": "Light",
   "theme_system": "System",
   "this_behavior_is_not_configurable": "This behavior is not configurable.",
+  "this_form_is_not_publicly_shared": "This form is not publicly shared.",
   "this_will_remove_following_columns": "This will remove the following column(s):",
   "this_will_remove_following_transformations": "This will remove the following transformation(s):",
   "time_to_create_exploration": "It's time to use your tables. Create your first exploration.",

--- a/mathesar_ui/src/routes/SharedFormRoute.svelte
+++ b/mathesar_ui/src/routes/SharedFormRoute.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { _ } from 'svelte-i18n';
+
   import { api } from '@mathesar/api/rpc';
   import { isDefinedNonNullable } from '@mathesar/component-library';
   import Errors from '@mathesar/components/errors/Errors.svelte';
@@ -27,10 +29,17 @@
 {#if isLoading}
   <LoadingPage />
 {:else if $rawFormStore.resolvedValue && $formSourceInfo.resolvedValue}
-  <SharedDataFormFillPage
-    rawDataForm={$rawFormStore.resolvedValue}
-    formSource={$formSourceInfo.resolvedValue}
-  />
+  {#if $rawFormStore.resolvedValue.publish_public}
+    <SharedDataFormFillPage
+      rawDataForm={$rawFormStore.resolvedValue}
+      formSource={$formSourceInfo.resolvedValue}
+    />
+  {:else}
+    <!-- For authenticated users accessing the un-shared form -->
+    <ErrorPage showGoToRoot={false}>
+      {$_('this_form_is_not_publicly_shared')}
+    </ErrorPage>
+  {/if}
 {:else}
   <ErrorPage showGoToRoot={false}>
     <Errors {errors} showFallbackError />

--- a/mathesar_ui/src/routes/urls.ts
+++ b/mathesar_ui/src/routes/urls.ts
@@ -135,7 +135,7 @@ export function getDataFormPageUrl(
 }
 
 export function getFormShareUrl(formToken: string) {
-  return `/shares/forms/${formToken}`;
+  return `/shares/forms/${formToken}/`;
 }
 
 export const USER_PROFILE_URL = '/profile/';


### PR DESCRIPTION
Fixes the following issues from [this mail thread](https://groups.google.com/a/mathesar.org/g/mathesar-developers/c/fArihRw_v58/m/Eh3rZqPLDQAJ).
- Critical issue: The public share URLs for some forms will return a 500 error
- Disabled share links continue to display and work (data can be submitted) in the current logged-in session.

**Technical details**
- Backend:
  - https://github.com/mathesar-foundation/mathesar/commit/bcc624c7ec1fb4090878ddaf0c822e5db5354c95 accepts urls with and without backslash for shared forms.
    - This is because these urls can be copied, saved, and shared by the user, and we want it to be as flexible as possible.
  - https://github.com/mathesar-foundation/mathesar/commit/328f033c634f504c090b341cf97ebea3bb441cff only accepts submit requests when form is publicly shared.
    - The retrieval methods are common for both authenticated and anonymous RPC methods, so they aren't changed.
    - The submit method should only be accessible for a publicly shared form.
    - We removed the ability to submit forms for authenticated users on the UI following discussions from internal QA, and scheduled the feature for a later release.
- Frontend:
    - https://github.com/mathesar-foundation/mathesar/commit/25cf709e0c90cae70e344001d2ff2dc6f978de5e adds a trailing backslash to the shared form url for users to copy.
      - Though we allow urls with & without trailing slashes, this commit makes it consistent to the rest of the codebase where we always append a trailing backslash.
   - https://github.com/mathesar-foundation/mathesar/commit/2f0115170468f05540c66001518dc757d0dad442 commit hides the form and shows an error when an authenticated user accesses the public url of a form which is no longer shared.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
