### PR TITLE
Improve keyboard navigation for the form builder

### DIFF
--- a/mathesar_ui/src/systems/data-forms/form-maker/elements/SelectableElement.svelte
+++ b/mathesar_ui/src/systems/data-forms/form-maker/elements/SelectableElement.svelte
@@ -51,7 +51,7 @@
   $: ({ isSelected, isImmediateChildSelected, isAnyChildSelected } =
     selectionOpts);
 
-  function onClick(e: Event) {
+  function activate(e: Event) {
     if (editableDataFormManager) {
       e.stopPropagation();
       editableDataFormManager.selectElement(element);
@@ -60,13 +60,14 @@
 </script>
 
 <div
-  tabindex={editableDataFormManager ? 0 : undefined}
   data-form-selectable
   class:can-select={!!editableDataFormManager}
   class:selected={isSelected}
   class:immediate-child-selected={isImmediateChildSelected}
   class:some-child-selected={isAnyChildSelected}
-  on:click={onClick}
+  on:click={activate}
+  on:focus={activate}
+  on:focusin={activate}
   use:sortableItem
 >
   {#if isSelected && $$slots.header}


### PR DESCRIPTION
<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This small PR improves the keyboard navigability of the form maker:

- Removes the tabindex from SelectableElements, so instead of focusing the parent container, the first focusable child is focused
- Adding focus and focus in events to select the current form element.

The improvement is best conveyed with quick videos:

> Before

https://github.com/user-attachments/assets/7081f51e-27bd-4f66-bb8d-10fda725809b

> After

https://github.com/user-attachments/assets/1456d07f-4c6d-41a2-bdff-8ff3752758d2


**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
