### PR TITLE
Initial file cell appearance for non-images

### DIFF
--- a/mathesar_ui/src/component-library/common/icons.ts
+++ b/mathesar_ui/src/component-library/common/icons.ts
@@ -22,6 +22,7 @@ import {
   faSpinner,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
+
 import type { IconProps } from '@mathesar-component-library-dir/icon/IconTypes';
 
 /**

--- a/mathesar_ui/src/component-library/common/icons.ts
+++ b/mathesar_ui/src/component-library/common/icons.ts
@@ -12,6 +12,8 @@ import {
   faEllipsisH,
   faExclamationTriangle,
   faFile,
+  faFileAlt,
+  faFilePdf,
   faFileUpload,
   faGears,
   faLightbulb,
@@ -20,7 +22,6 @@ import {
   faSpinner,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
-
 import type { IconProps } from '@mathesar-component-library-dir/icon/IconTypes';
 
 /**
@@ -54,6 +55,8 @@ export const iconUploadFile: IconProps = { data: faFileUpload };
 // (These names should all be nouns)
 
 export const iconFile: IconProps = { data: faFile };
+export const iconFileAlt: IconProps = { data: faFileAlt };
+export const iconPDF: IconProps = { data: faFilePdf };
 export const iconSettings: IconProps = { data: faGears };
 export const iconExternalLink: IconProps = { data: faArrowUpRightFromSquare };
 

--- a/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
+++ b/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
@@ -3,17 +3,17 @@
 
   import type { FileManifest } from '@mathesar/api/rpc/records';
   import {
-    assertExhaustive,
     Icon,
+    assertExhaustive,
     iconFileAlt,
     iconPDF,
   } from '@mathesar/component-library';
+  import Button from '@mathesar/component-library/button/Button.svelte';
   import Spinner from '@mathesar/component-library/spinner/Spinner.svelte';
+  import Tooltip from '@mathesar/component-library/tooltip/Tooltip.svelte';
   import { toast } from '@mathesar/stores/toast';
 
   import { fetchImage, getFileName, getFileViewerType } from '../fileUtils';
-  import Button from '@mathesar/component-library/button/Button.svelte';
-  import Tooltip from '@mathesar/component-library/tooltip/Tooltip.svelte';
 
   export let manifest: FileManifest;
   export let canOpenViewer: boolean;

--- a/mathesar_ui/src/components/file-attachments/fileUtils.ts
+++ b/mathesar_ui/src/components/file-attachments/fileUtils.ts
@@ -39,3 +39,7 @@ export function parseFileReference(value: unknown): FileReference | undefined {
   if (!hasStringProperty(obj, 'uri')) return undefined;
   return obj;
 }
+
+export function getFileName(manifest: FileManifest): string | undefined {
+  return manifest.uri.split('/').at(-1);
+}


### PR DESCRIPTION
Fixes item **11** on our [Files UI checklist](https://internal.mathesar.org/db/36/schemas/112012/tables/112014/7).

⚠️ Don't merge until base branch becomes `file_attachment_feature` ⚠️

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This PR adds a simple icon button display for non-image files in the table cell. There one icon for PDFs and one generic file icon for all other file types.

The file _name_ is now displayed in a tooltip for both images _and_ non-images. I did this, rather than display the file name directly in the cell, to provide visual balance in cases where mixed image and non-image attachments (a use case demonstrated by one of our users) appear in the same column. I am however very open to displaying the filename in the cell. 

I also added some rounding and a very small increase of padding to the image thumbnails to make them more visually cohesive with the buttons for non-images. Feel free to remove, @seancolsen. I appreciate your efforts to maximize the thumbnail size in the cell.  

Side note: I really dislike the new colors of our tooltips.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

<img width="508" height="447" alt="image" src="https://github.com/user-attachments/assets/47feb594-317c-48b7-8c9d-18cf6d192564" />

<img width="508" height="447" alt="image" src="https://github.com/user-attachments/assets/52f76529-a169-406d-9756-7f2a174eabf2" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
