### PR TITLE
Fixes appearance of File cell in several places

### DIFF
--- a/mathesar_ui/src/App.svelte
+++ b/mathesar_ui/src/App.svelte
@@ -8,6 +8,9 @@
   import AppContext from './AppContext.svelte';
   import { initI18n } from './i18n';
   import RootRoute from './routes/RootRoute.svelte';
+  import { initUiTheme } from './utils/uiThemePreference';
+
+  initUiTheme();
 
   const commonData = preloadCommonData();
   const userDisplayLanguage =
@@ -17,17 +20,17 @@
   void initI18n(userDisplayLanguage ?? 'en');
 </script>
 
-<AppContext {commonData}>
-  {#if $isTranslationLoading}
-    <div class="app-loader">
-      <Spinner size="2rem" />
-    </div>
-  {:else}
+{#if $isTranslationLoading}
+  <div class="app-loader">
+    <Spinner size="2rem" />
+  </div>
+{:else}
+  <AppContext {commonData}>
     {#key $locale}
       <RootRoute {commonData} />
     {/key}
-  {/if}
-</AppContext>
+  </AppContext>
+{/if}
 
 <!--
   Supporting aliases in scss within the preprocessor is a bit of work.

--- a/mathesar_ui/src/AppContext.svelte
+++ b/mathesar_ui/src/AppContext.svelte
@@ -30,11 +30,9 @@
     LightboxController,
     lightboxContext,
   } from './components/file-attachments/lightbox/LightboxController';
-  import { initUiTheme } from './utils/uiThemePreference';
 
   export let commonData: CommonData;
 
-  initUiTheme();
   setBreadcrumbItemsInContext([]);
 
   function setUserProfileAndReleaseStores() {

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/file/FileCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/file/FileCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { _ } from 'svelte-i18n';
 
   import type { FileManifest } from '@mathesar/api/rpc/records';
   import FileCellContent from '@mathesar/components/file-attachments/cell-content/FileCellContent.svelte';
@@ -115,7 +116,12 @@
   on:mousedown={handleMouseDown}
   hasPadding={false}
 >
-  <div class="file-cell" class:disabled style={`height: ${ROW_HEIGHT_PX}px;`}>
+  <div
+    class="file-cell"
+    class:disabled
+    class:independent={isIndependentOfSheet}
+    style={isIndependentOfSheet ? '' : `height: ${ROW_HEIGHT_PX}px;`}
+  >
     <FileCellContent
       {value}
       manifest={fileManifest}
@@ -125,13 +131,35 @@
       {openImageFileViewer}
       {upload}
     />
+    {#if isIndependentOfSheet && fileManifest}
+      <table>
+        <tr><th>{$_('storage_uri')}</th><td>{fileManifest.uri}</td></tr>
+        <tr><th>{$_('mime_type')}</th><td>{fileManifest.mimetype}</td></tr>
+      </table>
+    {/if}
   </div>
 </CellWrapper>
 
-<style>
+<style lang="scss">
   .file-cell {
     display: grid;
     overflow: hidden;
     padding: 1px;
+  }
+
+  table {
+    padding: var(--sm4);
+    max-width: max-content;
+
+    th {
+      text-align: left;
+      min-width: max-content;
+      white-space: nowrap;
+      vertical-align: top;
+    }
+    td {
+      line-height: 1.2;
+      padding: 0.2em 0.8em;
+    }
   }
 </style>

--- a/mathesar_ui/src/components/file-attachments/file-uploader/ModalFileAttachmentUploader.svelte
+++ b/mathesar_ui/src/components/file-attachments/file-uploader/ModalFileAttachmentUploader.svelte
@@ -40,21 +40,7 @@
     return { [firstFileUpload.fileId]: completion };
   })();
 
-  $: title = 'Upload File';
-  // I'm getting a weird JS console error when I try to use the translated title
-  // below.
-  //
-  // ```
-  // $: title = $_('upload_file');
-  // ```
-  //
-  // The error is:
-  //
-  // > "Cannot format a message without first setting the initial locale."
-  //
-  // I'm using a non-translated title for now.
-  //
-  // TODO_FILES_UI: troubleshoot and fix this error
+  $: title = $_('upload_file');
 
   function init() {
     controller.cancel();

--- a/mathesar_ui/src/components/inspector/cell/CellInspector.svelte
+++ b/mathesar_ui/src/components/inspector/cell/CellInspector.svelte
@@ -24,7 +24,7 @@
 
 <div class="cell-inspector">
   {#if activeCellData}
-    {@const { column, value, recordSummary } = activeCellData}
+    {@const { column, value, recordSummary, fileManifest } = activeCellData}
     <section class="active-cell">
       <header class="header">{$_('content')}</header>
       <div class="content">
@@ -35,6 +35,7 @@
             columnFabric={column}
             {value}
             {recordSummary}
+            {fileManifest}
           />
         {/if}
       </div>

--- a/mathesar_ui/src/components/sheet/selection/selectionUtils.ts
+++ b/mathesar_ui/src/components/sheet/selection/selectionUtils.ts
@@ -1,6 +1,6 @@
 import type { Writable } from 'svelte/store';
 
-import type { ResultValue } from '@mathesar/api/rpc/records';
+import type { FileManifest, ResultValue } from '@mathesar/api/rpc/records';
 import type { CellColumnFabric } from '@mathesar/components/cell-fabric/types';
 import { type ImmutableSet, defined } from '@mathesar-component-library';
 
@@ -135,6 +135,7 @@ export interface SelectedCellData {
     column: CellColumnFabric;
     value: ResultValue | undefined;
     recordSummary?: string;
+    fileManifest?: FileManifest;
   };
   selectionData: {
     cellCount: number;

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorDataCell.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorDataCell.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import type { Writable } from 'svelte/store';
 
+  import type { FileManifest } from '@mathesar/api/rpc/records';
   import CellFabric from '@mathesar/components/cell-fabric/CellFabric.svelte';
+  import { parseFileReference } from '@mathesar/components/file-attachments/fileUtils';
   import type AssociatedCellData from '@mathesar/stores/AssociatedCellData';
   import {
     type ProcessedColumn,
@@ -15,6 +17,7 @@
   export let row: RecordRow;
   export let processedColumn: ProcessedColumn;
   export let linkedRecordSummaries: AssociatedCellData<string>;
+  export let fileManifests: AssociatedCellData<FileManifest>;
   export let searchFuzzy: Writable<SearchFuzzy>;
   export let isLoading = false;
 
@@ -24,6 +27,12 @@
   $: recordSummary = $linkedRecordSummaries
     .get(String(column.id))
     ?.get(String(value));
+  $: fileManifest = (() => {
+    if (!column.metadata?.file_backend) return undefined;
+    const fileReference = parseFileReference(value);
+    if (!fileReference) return undefined;
+    return $fileManifests.get(String(column.id))?.get(fileReference.mash);
+  })();
 </script>
 
 <Cell rowType="dataRow" columnType="dataColumn">
@@ -31,6 +40,7 @@
     columnFabric={processedColumn}
     {value}
     {recordSummary}
+    {fileManifest}
     disabled
     showAsSkeleton={!isPersistedRecordRow(row) || isLoading}
     {searchValue}

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorTable.svelte
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorTable.svelte
@@ -56,6 +56,7 @@
     recordSummaries,
     linkedRecordSummaries,
     state: recordsDataState,
+    fileManifests,
   } = recordsData);
   $: recordsDataIsLoading = $recordsDataState === States.Loading;
   $: ({ constraints } = $constraintsDataStore);
@@ -288,6 +289,7 @@
                 {row}
                 {processedColumn}
                 {linkedRecordSummaries}
+                {fileManifests}
                 {searchFuzzy}
                 isLoading={recordsDataIsLoading}
               />

--- a/mathesar_ui/src/systems/table-view/row/GroupHeader.svelte
+++ b/mathesar_ui/src/systems/table-view/row/GroupHeader.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import type { FileManifest } from '@mathesar/api/rpc/records';
   import { SheetPositionableCell } from '@mathesar/components/sheet';
+  import type { AssociatedCellValuesForSheet } from '@mathesar/stores/AssociatedCellData';
   import type {
     GroupHeaderRow,
     ProcessedColumn,
@@ -16,6 +18,7 @@
   export let grouping: RecordGrouping;
   export let group: RecordGroup;
   export let recordSummariesForSheet: RecordSummariesForSheet;
+  export let fileManifestsForSheet: AssociatedCellValuesForSheet<FileManifest>;
 
   $: ({ columnIds, preprocIds } = grouping);
   $: preProcFunctionsForColumn = columnIds.map(
@@ -40,6 +43,8 @@
           {recordSummariesForSheet}
           {columnId}
           preprocName={preprocNames[index]}
+          {fileManifestsForSheet}
+          totalColumns={columnIds.length}
         />
       {/each}
       <div class="count-container">
@@ -58,11 +63,13 @@
     height: 100%;
     border-bottom: 1px solid var(--color-border-grid);
     border-right: 1px solid var(--color-border-grid);
+    overflow: hidden;
 
     .groups-data {
       align-items: start;
       display: flex;
       gap: 1rem;
+      overflow: hidden;
     }
 
     .count-container {

--- a/mathesar_ui/src/systems/table-view/row/GroupHeaderCellValue.svelte
+++ b/mathesar_ui/src/systems/table-view/row/GroupHeaderCellValue.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-  import type { ResultValue } from '@mathesar/api/rpc/records';
+  import type { FileManifest, ResultValue } from '@mathesar/api/rpc/records';
+  import { Truncate } from '@mathesar/component-library';
   import CellValue from '@mathesar/components/CellValue.svelte';
+  import { parseFileReference } from '@mathesar/components/file-attachments/fileUtils';
   import LinkedRecord from '@mathesar/components/LinkedRecord.svelte';
+  import type { AssociatedCellValuesForSheet } from '@mathesar/stores/AssociatedCellData';
   import type { ProcessedColumn } from '@mathesar/stores/table-data';
   import type { RecordSummariesForSheet } from '@mathesar/stores/table-data/record-summaries/recordSummaryUtils';
 
@@ -10,18 +13,27 @@
   export let columnId: number;
   export let preprocName: string | undefined = undefined;
   export let cellValue: ResultValue | undefined = undefined;
+  export let fileManifestsForSheet: AssociatedCellValuesForSheet<FileManifest>;
+  export let totalColumns: number;
 
+  $: processedColumn = processedColumnsMap.get(columnId);
   $: recordId = String(cellValue);
   $: recordSummary = recordSummariesForSheet
     .get(String(columnId))
     ?.get(recordId);
   $: linkedTableId =
     processedColumnsMap?.get(columnId)?.linkFk?.referent_table_oid;
+  $: fileManifest = (() => {
+    if (!processedColumn?.column.metadata?.file_backend) return undefined;
+    const fileReference = parseFileReference(cellValue);
+    if (!fileReference) return undefined;
+    return fileManifestsForSheet.get(String(columnId))?.get(fileReference.mash);
+  })();
 </script>
 
-<span class="tag">
+<span class="tag" style="max-width: calc(100%/{totalColumns})">
   <span class="name">
-    {processedColumnsMap.get(columnId)?.column.name ?? ''}
+    {processedColumn?.column.name ?? ''}
     {#if preprocName}
       <span class="preproc">{preprocName}</span>
     {/if}
@@ -34,14 +46,23 @@
         tableId={linkedTableId}
         allowsHyperlinks
       />
+    {:else if processedColumn?.abstractType.identifier === 'file' && fileManifest}
+      <Truncate>
+        {fileManifest.uri}
+      </Truncate>
     {:else}
-      <CellValue value={cellValue} />
+      <Truncate>
+        <CellValue value={cellValue} />
+      </Truncate>
     {/if}
   </span>
 </span>
 
 <style lang="scss">
   .tag {
+    overflow: hidden;
+    min-width: 3em;
+
     .name {
       font-size: var(--sm1);
       color: var(--color-fg-base-muted);

--- a/mathesar_ui/src/systems/table-view/row/Row.svelte
+++ b/mathesar_ui/src/systems/table-view/row/Row.svelte
@@ -46,7 +46,7 @@
     cellModificationStatus,
     cellClientSideErrors,
   } = meta);
-  $: ({ grouping, linkedRecordSummaries } = recordsData);
+  $: ({ grouping, linkedRecordSummaries, fileManifests } = recordsData);
 
   $: ({ pkColumn } = columnsDataStore);
   $: primaryKeyColumnId = $pkColumn?.id;
@@ -126,6 +126,7 @@
         group={row.group}
         processedColumnsMap={$processedColumns}
         recordSummariesForSheet={$linkedRecordSummaries}
+        fileManifestsForSheet={$fileManifests}
       />
     {:else if isRecordRow(row)}
       {#each [...$processedColumns] as [columnId, processedColumn] (columnId)}


### PR DESCRIPTION
Fixes items **10**, **11**, **14**, and **29**  on our [Files UI checklist](https://internal.mathesar.org/db/36/schemas/112012/tables/112014/).

⚠️ **Don't merge until base branch becomes `file_attachment_feature`** ⚠️

- Improves appearance of file value in Record selector, Group header, and Cell tab in table inspector.
  - Record Selector rows & Cell tabs display thumbnails.
  - Cell tab additionally displays file uri and mimetype - It does not support opening the image from the tab yet.
  - Group header displays only the file uri.
- Fixes bug with i18n translations not readily loaded for components in AppContext.

**Screenshots**
| Record selector    |  Cell tab  |
| -------- | ------- |
| <img width="814" height="482" alt="Screenshot 2025-09-18 at 3 31 22 PM" src="https://github.com/user-attachments/assets/39406901-1fce-4d3f-824c-fe8abbb2b9a2" />  | <img width="465" height="321" alt="Screenshot 2025-09-18 at 3 31 42 PM" src="https://github.com/user-attachments/assets/d7c12066-6a40-4d16-af2a-98cb6d55b589" /> |

| Group Header    | 
| -------- |
| <img width="1377" height="708" alt="Screenshot 2025-09-18 at 3 32 07 PM" src="https://github.com/user-attachments/assets/047ff760-3499-49e4-9cc7-db07157a6f86" /> |

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
