### PR TITLE
Fix regression in lightbox loading indicator

### DIFF
--- a/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
+++ b/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
@@ -90,19 +90,19 @@
       <!-- TODO_FILES_UI: add a loading indicator when thumbnail is loading -->
       <!-- TODO_FILES_UI: Fix hover behavior. Hovering the thumbnail of an
         inactive cell should _not_ open the tooltip. -->
-      <Tooltip>
-        <svelte:fragment slot="content">{fileName}</svelte:fragment>
-        <div slot="trigger" class="image">
-          <ContentLoading loading={imageLoading}>
+      <ContentLoading loading={imageLoading}>
+        <Tooltip>
+          <svelte:fragment slot="content">{fileName}</svelte:fragment>
+          <div slot="trigger" class="image">
             <img
               alt={uri}
               src={thumbnailUrl}
               on:click={handleImgClick}
               bind:this={thumbnailElement}
             />
-          </ContentLoading>
-        </div>
-      </Tooltip>
+          </div>
+        </Tooltip>
+      </ContentLoading>
     {:else if fileViewerType === 'default'}
       <Button
         on:click={handleDefaultFileClick}
@@ -124,6 +124,7 @@
     display: grid;
     overflow: hidden;
     height: 100%;
+    --ContentLoading__height: 100%;
   }
 
   .attached-file {
@@ -135,7 +136,6 @@
 
   .image {
     height: 100%;
-    --ContentLoading__height: 100%;
     img {
       display: block;
       height: 100%;


### PR DESCRIPTION
Fixes item 50: [regression with loading spinner positioned incorrectly over thumbnail](https://internal.mathesar.org/db/36/schemas/112012/tables/112014/50)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
