### PR TITLE
Support additional file icons

### DIFF
--- a/mathesar_ui/src/component-library/common/icons.ts
+++ b/mathesar_ui/src/component-library/common/icons.ts
@@ -12,8 +12,6 @@ import {
   faEllipsisH,
   faExclamationTriangle,
   faFile,
-  faFileAlt,
-  faFilePdf,
   faFileUpload,
   faGears,
   faLightbulb,
@@ -56,8 +54,6 @@ export const iconUploadFile: IconProps = { data: faFileUpload };
 // (These names should all be nouns)
 
 export const iconFile: IconProps = { data: faFile };
-export const iconFileAlt: IconProps = { data: faFileAlt };
-export const iconPDF: IconProps = { data: faFilePdf };
 export const iconSettings: IconProps = { data: faGears };
 export const iconExternalLink: IconProps = { data: faArrowUpRightFromSquare };
 

--- a/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
+++ b/mathesar_ui/src/components/file-attachments/cell-content/AttachedFileReference.svelte
@@ -6,8 +6,6 @@
     Dropdown,
     Icon,
     assertExhaustive,
-    iconFileAlt,
-    iconPDF,
   } from '@mathesar/component-library';
   import Button from '@mathesar/component-library/button/Button.svelte';
   import Spinner from '@mathesar/component-library/spinner/Spinner.svelte';
@@ -16,6 +14,7 @@
   import { toast } from '@mathesar/stores/toast';
 
   import { fetchImage, getFileName, getFileViewerType } from '../fileUtils';
+  import FileIcon from './FileIcon.svelte';
 
   export let manifest: FileManifest;
   export let canOpenViewer: boolean;
@@ -40,9 +39,6 @@
   $: fileViewerType = getFileViewerType(manifest);
   $: thumbnailUrl = `${thumbnail}?height=${thumbnailResolutionHeightPx}`;
   $: fileName = getFileName(manifest);
-  // TODO_FILES_UI: Support a wider range of filetype icons and use a
-  // more robust solution to map mime types to icons.
-  $: fileIcon = mimetype === 'application/pdf' ? iconPDF : iconFileAlt;
   // The non-image file dropdown state is managed here so the filename tooltip
   // can be hidden while the dropdown is open to reduce visual clutter.
   $: fileDropdownIsOpen = false;
@@ -110,7 +106,7 @@
         }}
         appearance="secondary"
       >
-        <Icon slot="trigger" {...fileIcon} />
+        <FileIcon slot="trigger" {mimetype} />
         <div slot="content" class="file-actions">
           <table class="info">
             <tr><th>{$_('storage_uri')}</th><td>{uri}</td></tr>

--- a/mathesar_ui/src/components/file-attachments/cell-content/FileIcon.svelte
+++ b/mathesar_ui/src/components/file-attachments/cell-content/FileIcon.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { Icon } from '@mathesar/component-library';
+  import type { IconProps } from '@mathesar/component-library/types';
+
+  import {
+    iconFileAlt,
+    iconFileCSV,
+    iconFilePDF,
+    iconFileImage,
+    iconFileVideo,
+    iconFileAudio,
+    iconFileCode,
+    iconFileArchive,
+    iconFileWord,
+    iconFileExcel,
+    iconFilePowerpoint,
+  } from '@mathesar/icons';
+
+  export let mimetype: string;
+
+  const exact: Record<string, IconProps> = {
+    'application/pdf': iconFilePDF,
+    'application/msword': iconFileWord,
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      iconFileWord,
+    'application/vnd.ms-excel': iconFileExcel,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      iconFileExcel,
+    'application/vnd.ms-powerpoint': iconFilePowerpoint,
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+      iconFilePowerpoint,
+    'application/zip': iconFileArchive,
+    'application/x-7z-compressed': iconFileArchive,
+    'application/x-rar-compressed': iconFileArchive,
+    'application/x-tar': iconFileArchive,
+    'application/json': iconFileCode,
+    'text/csv': iconFileCSV,
+    'text/x-csv': iconFileCSV,
+  };
+
+  const byCategory: Record<string, IconProps> = {
+    image: iconFileImage,
+    video: iconFileVideo,
+    audio: iconFileAudio,
+    text: iconFileCode,
+  };
+
+  function getIcon(mimetype: string) {
+    if (exact[mimetype]) return exact[mimetype];
+
+    const category = mimetype.split('/', 1).at(0);
+    if (category) {
+      return byCategory[category] ?? iconFileAlt;
+    }
+
+    return iconFileAlt;
+  }
+
+  $: fileIcon = getIcon(mimetype);
+</script>
+
+<Icon {...fileIcon} {...$$restProps} />

--- a/mathesar_ui/src/icons/index.ts
+++ b/mathesar_ui/src/icons/index.ts
@@ -31,6 +31,16 @@ import {
   faExternalLinkAlt,
   faFile,
   faFileAlt,
+  faFileArchive,
+  faFileAudio,
+  faFileCode,
+  faFileCsv,
+  faFileExcel,
+  faFileImage,
+  faFilePdf,
+  faFilePowerpoint,
+  faFileVideo,
+  faFileWord,
   faFilter,
   faFilterCircleXmark,
   faFingerprint,
@@ -243,7 +253,19 @@ export const iconAutomaticallyAdded: IconProps = { data: outcomeIcon };
 export const iconDescription: IconProps = { data: circleLowercaseIIcon };
 export const iconMathesarName: IconProps = { data: mathesarNameIcon };
 export const iconModalRecordView: IconProps = { data: modalRecordViewIcon };
+
 export const iconFile: IconProps = { data: faFile };
+export const iconFileAlt: IconProps = { data: faFileAlt };
+export const iconFileArchive: IconProps = { data: faFileArchive };
+export const iconFileAudio: IconProps = { data: faFileAudio };
+export const iconFileCode: IconProps = { data: faFileCode };
+export const iconFileCSV: IconProps = { data: faFileCsv };
+export const iconFileExcel: IconProps = { data: faFileExcel };
+export const iconFileImage: IconProps = { data: faFileImage };
+export const iconFilePDF: IconProps = { data: faFilePdf };
+export const iconFilePowerpoint: IconProps = { data: faFilePowerpoint };
+export const iconFileVideo: IconProps = { data: faFileVideo };
+export const iconFileWord: IconProps = { data: faFileWord };
 
 // STATUSES
 


### PR DESCRIPTION
I wrote this up quickly earlier as a nice to have, I don't honestly think it's particularly important. It _is_ nice to disambiguate between different file types :shrug:.

If there's any substantive concerns about the approach here or refactoring needed, particularly in terms of cell perf, I think we should just scrap it.

Also fixed a small issue where we were importing icons from the component library, which is technically incorrect. 

## Screenshots

Some examples here:

<img width="357" height="401" alt="image" src="https://github.com/user-attachments/assets/defaee2c-5159-46c9-9ef0-755a8b921b37" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
