### PR TITLE
Fix file input size for non-images

### DIFF
--- a/mathesar_ui/src/components/cell-fabric/data-types/components/file/FileInput.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/file/FileInput.svelte
@@ -39,6 +39,8 @@
 
   $: hasValue = value !== undefined && value !== null && value !== '';
   $: labelController?.inputId.set(id);
+  $: showLargerInput =
+    hasValue && fileManifest && getFileViewerType(fileManifest) === 'image';
 
   function updateCell(newValue: unknown) {
     value = newValue;
@@ -156,7 +158,7 @@
   role="listbox"
   aria-labelledby={getLabelIdFromInputId(id)}
 >
-  <div class="file-input-content" class:filled={hasValue}>
+  <div class="file-input-content" class:large={showLargerInput}>
     <FileCellContent
       {value}
       manifest={fileManifest}
@@ -176,7 +178,7 @@
     overflow: hidden;
     padding: var(--sm5);
   }
-  .file-input-content.filled {
+  .file-input-content.large {
     height: 10em;
   }
 </style>


### PR DESCRIPTION
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This PR reduces the size of the file input for non-images. 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

<img width="1600" height="1084" alt="Screenshot From 2025-09-18 16-21-38" src="https://github.com/user-attachments/assets/01a26155-b236-4f04-beb4-5eea37b38b94" />

<img width="1600" height="1084" alt="Screenshot From 2025-09-18 16-21-49" src="https://github.com/user-attachments/assets/79957c0c-cda3-4df4-b5cc-c52e0648d981" />

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
