### PR TITLE
Improve light bg for transparent and small images

### DIFF
--- a/mathesar_ui/src/components/file-attachments/lightbox/Lightbox.svelte
+++ b/mathesar_ui/src/components/file-attachments/lightbox/Lightbox.svelte
@@ -237,6 +237,7 @@
     align-items: center;
     justify-content: center;
     border-radius: var(--sm3);
+    background-color: var(--color-bg-base);
     box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.4);
 
     .img-holder {
@@ -252,6 +253,10 @@
         width: 100%;
         height: 100%;
         display: block;
+        // Classic "white and gray grid" background which
+        // will display behind images with transparent areas
+        background: conic-gradient(#ccc 25%, white 0 50%, #ccc 0 75%, white 0);
+        background-size: 20px 20px;
       }
     }
 


### PR DESCRIPTION
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This PR improves the appearance of the lightbox by making sure the modal area is never transparent with a visible box shadow underneath the transparency. The PR achieves this by:

1. Adding a default bg color to the image area
2. Giving the images _themselves_ a "transparency" white and gray grid background, so images with transparent areas won't look odd but still _should_ indicate to the user that they're transparent. 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

Example of the background for transparent pngs:

<img width="1961" height="1163" alt="image" src="https://github.com/user-attachments/assets/cf232447-5f3b-4dd5-9eed-7ee6a359faba" />

Example for a very small image, which show have padding around them as of #4798:

<img width="1961" height="1025" alt="Screenshot From 2025-09-19 15-48-23" src="https://github.com/user-attachments/assets/ffb191b5-2213-4b20-975a-593e6a73d66d" />

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
