### PR TITLE
Keep focus on selected placeholder cell on plane changes

### DIFF
--- a/mathesar_ui/src/components/sheet/selection/SheetSelectionStore.ts
+++ b/mathesar_ui/src/components/sheet/selection/SheetSelectionStore.ts
@@ -16,22 +16,14 @@ export default class SheetSelectionStore
 
   private cleanupFunctions: (() => void)[] = [];
 
-  constructor(plane: Readable<Plane>) {
+  constructor(plane: Readable<Plane>, options: { prevent?: 'focus'[] } = {}) {
     super();
     this.selection = new PreventableEffectsStore(new SheetSelection(), {
       focus: () => this.focus(),
     });
     this.cleanupFunctions.push(
       plane.subscribe((p) =>
-        // Prevent auto-focusing the new active cell when the plane changes.
-        // Originally I had allowed the auto-focus to happen, but it was causing
-        // a [bug][1] in the Data Explorer. I think it makes sense to err on the
-        // side of caution here and prevent the auto-focus. There might be some
-        // cases where we want to auto-focus the new active cell, but we can
-        // handle those cases imperatively as needed.
-        //
-        // [1]: https://github.com/mathesar-foundation/mathesar/issues/3955
-        this.selection.update((s) => s.forNewPlane(p), { prevent: ['focus'] }),
+        this.selection.update((s) => s.forNewPlane(p), options),
       ),
     );
   }

--- a/mathesar_ui/src/components/sheet/selection/basis/placeholderCellBasis.ts
+++ b/mathesar_ui/src/components/sheet/selection/basis/placeholderCellBasis.ts
@@ -1,5 +1,3 @@
-import { first } from 'iter-tools';
-
 import { ImmutableSet } from '@mathesar-component-library';
 
 import { parseCellId } from '../../cellIds';
@@ -22,15 +20,13 @@ export function basisFromPlaceholderCell(activeCellId: string): Basis {
     pasteOperation: 'insert',
     getFullySelectedColumnIds: () => new ImmutableSet(),
 
-    adaptToModifiedPlane({ oldPlane, newPlane }) {
-      const columnId = first(this.columnIds);
-      if (columnId === undefined) return emptyBasis();
-      const newPlaneHasSelectedCell =
-        newPlane.columnIds.has(columnId) &&
-        newPlane.placeholderRowId === oldPlane.placeholderRowId;
-      if (newPlaneHasSelectedCell) {
-        // If we can retain the selected placeholder cell, then do so.
-        return basisFromPlaceholderCell(columnId);
+    adaptToModifiedPlane({ newPlane }) {
+      if (this.activeCellId !== undefined) {
+        const { rowId, columnId } = parseCellId(this.activeCellId);
+        if (newPlane.rowIds.has(rowId) && newPlane.columnIds.has(columnId)) {
+          // If we can retain the selected placeholder cell, then do so.
+          return basisFromPlaceholderCell(this.activeCellId);
+        }
       }
       // Otherwise, return an empty basis
       return emptyBasis();

--- a/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
@@ -105,7 +105,9 @@ export class QueryRunner {
         return new Plane(rowIds, columnIds);
       },
     );
-    this.selection = new SheetSelectionStore(plane);
+    // Prevent autofocusing the new active cell when the plane changes.
+    // https://github.com/mathesar-foundation/mathesar/issues/3955
+    this.selection = new SheetSelectionStore(plane, { prevent: ['focus'] });
 
     this.inspector = new QueryInspector(this.query);
   }


### PR DESCRIPTION
Fixes #4751 

When a new record is added from the placeholder, it keeps the focus on the currently selected cell.

**Technical details**

I have identified the source of the bug thanks to an helpful comment in `SheetSelectionStore.ts`. This is an explanation of the PR:

- `SheetSelectionStore.ts`: Added a `options` parameter to `SheetSelectionStore`'s constructor that is directly passed to `this.selection.update`. This allows each instance of the class to show a different behavior regarding which effects (currently just `'focus'`) to prevent.\
There could be a little problem here because before the PR the default behavior was to prevent focus, while after the PR it is not to prevent it. But since `SheetSelectionStore` is instantiated only twice in the code base, it should be fine.
- `QueryRunner.ts`: Auto-focus is prevented because of #3955. I've moved here the summary of the comment from `SheetSelectionStore.ts`
- `placeholderCellBasis.ts`: Function `adaptToModifiedPlane` is modified following to the description of the parent function. Honestly, I don't really understand the original code, maybe I've missed some edge cases.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
