### PR TITLE
Fix for Persisting Sorting Conditions when Re-ordering Columns

### DIFF
--- a/mathesar_ui/src/stores/table-data/meta.ts
+++ b/mathesar_ui/src/stores/table-data/meta.ts
@@ -92,9 +92,15 @@ function serializeMetaProps(p: MetaProps): string {
   return Url64.encode(JSON.stringify(makeTerseMetaProps(p)));
 }
 
-/** @throws Error if string is not properly formatted. */
-function deserializeMetaProps(s: string): MetaProps {
-  return makeMetaProps(JSON.parse(Url64.decode(s)) as TerseMetaProps);
+function deserializeMetaProps(s: string): MetaProps | undefined {
+  // NOTE: it would be good to someday validate the serialized meta props in a
+  // more robust manner.
+  if (!s) return undefined;
+  try {
+    return makeMetaProps(JSON.parse(Url64.decode(s)) as TerseMetaProps);
+  } catch {
+    return undefined;
+  }
 }
 
 const defaultMetaPropsSerialization = serializeMetaProps(getFullMetaProps());
@@ -281,13 +287,8 @@ export class Meta {
     this.cellModificationStatus.clear();
   }
 
-  static fromSerialization(s: string): Meta | undefined {
-    try {
-      if (!s) return new Meta();
-      return new Meta(deserializeMetaProps(s));
-    } catch (e) {
-      return undefined;
-    }
+  static fromSerialization(s: string): Meta {
+    return new Meta(deserializeMetaProps(s));
   }
 
   destroy(): void {


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4749 

<!-- Concisely describe what the pull request does. -->
This PR fixes the issue as highlighted, that sorting conditions were not being preserved upong reordering the columns.
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Meta was returning an undefined object when given empty string.
**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

https://github.com/user-attachments/assets/ac24d547-5cb5-4133-8fb6-4df9fb3df98f


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
