### PR TITLE
Config web concurrency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
       SECRET_KEY: ${SECRET_KEY-}
 
       # If you are running Mathesar on a particularly powerful machine, you can
-      # improve performance by increasing this setting. Replace '5' below with
+      # improve performance by increasing this setting. Replace '3' below with
       # 2 * $(NUM_CORES) + 1. So if you have a VPS with 4 vCPUs you can use a
       # value of 2 * 4 + 1, or 9. The default is workable as long as you have at
       # least 1 logical core.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,13 @@ services:
       # leave this as-is.
       SECRET_KEY: ${SECRET_KEY-}
 
+      # If you are running Mathesar on a particularly powerful machine, you can
+      # improve performance by increasing this setting. Replace '5' below with
+      # 2 * $(NUM_CORES) + 1. So if you have a VPS with 4 vCPUs you can use a
+      # value of 2 * 4 + 1, or 9. The default is workable as long as you have at
+      # least 1 logical core.
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY-3}
+
     volumes:
       - ./msar/static:/code/static
       - ./msar/media:/code/media
@@ -208,8 +215,10 @@ services:
     environment: *config
     # Expose the internal port 5432 only to other containers and not
     # the underlying host.
-    expose:
-      - "5432"
+    # expose:
+    #   - "5432"
+    ports:
+      - "5432:5432"
     volumes:
       - ./msar/pgdata:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,10 +215,8 @@ services:
     environment: *config
     # Expose the internal port 5432 only to other containers and not
     # the underlying host.
-    # expose:
-    #   - "5432"
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
     volumes:
       - ./msar/pgdata:/var/lib/postgresql/data
 

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -21,6 +21,11 @@ This page contains all available environment variables supported by Mathesar. Se
 - **Format**: A set of host/domain names separated by a comma
 - **Default value**: `.localhost,127.0.0.1,[::1]`
 
+### `WEB_CONCURRENCY` {: #web_concurrency}
+
+- **Description**: Sets the number of Gunicorn workers, affecting the number of concurrent requests Mathesar can handle. Bigger is better, subject to system resources. The typically-recommended number is `2 * $(NUM_PROC) + 1`, where `NUM_PROC` is the number of logical cores on your machine. So, if Mathesar is running on a server with 4 vCPUs, then this should be set to 9.
+- **Format**: An integer.
+
 
 ## Internal database configuration {: #db}
 

--- a/setup/process_env.py
+++ b/setup/process_env.py
@@ -123,6 +123,9 @@ def main():
 
     updates = {}
 
+    if not env_vars.get("WEB_CONCURRENCY"):
+        updates["WEB_CONCURRENCY"] = 3
+
     connection_string = sys.argv[1].strip() if (len(sys.argv) > 1 and sys.argv[1].strip()) else None
 
     if connection_string:

--- a/setup/tests/test_process_env.py
+++ b/setup/tests/test_process_env.py
@@ -221,7 +221,8 @@ def test_main_generates_env_vars(monkeypatch):
     )
     assert code == 0
     parsed = dict(line.split("=", 1) for line in out.splitlines() if "=" in line)
-    assert len(parsed) == 5
+    assert 'WEB_CONCURRENCY="3"\n' in out
+    assert len(parsed) == 6
     assert 'POSTGRES_USER="user"\n' in out
     assert 'POSTGRES_HOST="localhost"\n' in out
     assert 'POSTGRES_PORT="5411"\n' in out
@@ -238,7 +239,8 @@ def test_main_generates_replaces_existing_pg_env_vars(monkeypatch):
     )
     assert code == 0
     parsed = dict(line.split("=", 1) for line in out.splitlines() if "=" in line)
-    assert len(parsed) == 5
+    assert len(parsed) == 6
+    assert 'WEB_CONCURRENCY="3"\n' in out
     assert 'POSTGRES_USER="newuser"\n' in out
     assert 'POSTGRES_HOST="someserver"\n' in out
     assert 'POSTGRES_PORT="5444"\n' in out


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4831 

<!-- Concisely describe what the pull request does. -->

This adds a `WEB_CONCURRENCY` environment variable to the docker compose setup. Appropriate settings are documented in the same file.

TODO

- [x] Document the variable for from scratch installs.
- [ ] Document the variable for 1-click deployments.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This variable is used by Gunicorn to set the number of workers, and is the only variable supported for changing concurrency settings, other than the variable to set _all_ command-line arguments. The default I chose is "3", which is reasonable as long as Mathesar is running with at least 1 logical core available. This will improve the situation, but only a bit. Basically, with the `sync` worker type, we need one worker per concurrent request. So, this takes us from 1 to 3 :confetti_ball: .

Long-term, we should try to use the `gevent` worker type, since that enables async I/O, and Mathesar is extremely I/O, rather than CPU, bound. However, that doesn't work (easily) in Psycopg2, which means it doesn't affect Explorations. It _does_ improve (fix, really) performance in the non-exploration part of the codebase, but I didn't want to make the change in the current limited-QA situation. If we decide we are not going to try to squeeze this PR into 0.6.0, then I think we should make that change as well, to get the benefits in the parts of the codebase where we're using `psycopg3`.

This is yet another spot where our failure to deal with Explorations and the deprecated SQLAlchemy part of the codebase is biting us.

To test this, you can just load big tables in multiple browsers manually, or follow the instructions in #4841 .

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
