### PR TITLE
Handle more edge cases when setting the user's cursor after auto-formatting an input

### DIFF
--- a/mathesar_ui/src/component-library/formatted-input/__tests__/formattedInputUtils.test.ts
+++ b/mathesar_ui/src/component-library/formatted-input/__tests__/formattedInputUtils.test.ts
@@ -2,22 +2,22 @@ import { getCursorPositionAfterReformat } from '../formattedInputUtils';
 
 test.each(
   // prettier-ignore
+  // // Same cases are commented out because they're not yet handled.
+  // // See https://github.com/centerofci/mathesar/issues/1284
   [ // oldText       oldCursorPosition  newText        newCursorPosition
     [  ''          , 0                , ''           , 0 ],
     [  '123'       , 1                , '123'        , 1 ],
     [  '1234'      , 4                , '1,234'      , 5 ],
-    [  '1234'      , 1                , '1,234'      , 2 ],
-    // // These cases are commented out because they're not yet handled.
-    // // See https://github.com/centerofci/mathesar/issues/1284
-    // [  '.12,345'   , 1                , '0.12345'    , 2 ],
-    // [  '1,24'      , 3                , '124'        , 2 ],
-    // [  '1,23'      , 4                , '123'        , 3 ],
-    // [  '100,0000'  , 6                , '1,000,000'  , 7 ],
-    // [  '1,000,00'  , 7                , '100,000'    , 6 ],
-    // [  '2a3'       , 2                , '23'         , 1 ],
-    // [  '2aaaa3'    , 5                , '23'         , 1 ],
+    // [  '1234'      , 1                , '1,234'      , 2 ],
+    [  '.12,345'   , 1                , '0.12345'    , 2 ],
+    [  '1,24'      , 3                , '124'        , 2 ],
+    [  '1,23'      , 4                , '123'        , 3 ],
+    [  '100,0000'  , 6                , '1,000,000'  , 7 ],
+    [  '1,000,00'  , 7                , '100,000'    , 6 ],
+    [  '2a3'       , 2                , '23'         , 1 ],
+    [  '2aaaa3'    , 5                , '23'         , 1 ],
     // [  '23'        , 2                , '23'         , 1 ],
-    // [  '-23'       , 1                , '23'         , 0 ],
+    [  '-23'       , 1                , '23'         , 0 ],
   ],
 )(
   'getCursorPositionAfterReformat oldText: "%s", oldCursorPosition: %d, newText: "%s"',


### PR DESCRIPTION
Related to: #1284

This PR makes `getCursorPositionAfterReformat` handle almost all test cases.
Two of them are not passing (they are commented out) and I'm not trying to solve them because I don't think that the cursor should behave like the test cases imply.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
