### PR TITLE
Fix infinite recursion bug in context menu - focus behaviour

### DIFF
--- a/mathesar_ui/src/component-library/common/utils/focusUtils.ts
+++ b/mathesar_ui/src/component-library/common/utils/focusUtils.ts
@@ -85,7 +85,10 @@ export function getFirstFocusableAncestor(
   element: Element,
 ): Element | undefined {
   if (getElementFocusCapability(element).focusable) return element;
-  const ancestor = element.closest(potentiallyFocusableElementsSelector);
+  if (!element.parentElement) return undefined;
+  const ancestor = element.parentElement.closest(
+    potentiallyFocusableElementsSelector,
+  );
   if (!ancestor) return undefined;
   return getFirstFocusableAncestor(ancestor);
 }


### PR DESCRIPTION
## Issue:
- Right click to open the context menu. Move the mouse over the context menu.
- Open it on another cell which has `NULL` value, and do the same. The `Set to Null` action should be disabled.
- Notice the following "Max call stack size exceeded" error:
  - <img width="1285" height="937" alt="Screenshot 2025-10-14 at 1 47 49 PM" src="https://github.com/user-attachments/assets/ee605051-ff1f-4ab4-8d93-6a454f16382c" />

**Technical details**
- `element.closest` starts from the current element and traverses the parents. This fix ensures that the current element is not considered, since its already checked.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
