### PR TITLE
Made table name under record title clickable (#4916)

### DIFF
--- a/mathesar_ui/src/components/TableLink.svelte
+++ b/mathesar_ui/src/components/TableLink.svelte
@@ -10,12 +10,10 @@
   interface $$Props extends ComponentProps<TableName> {
     table: Table;
     boxed?: boolean;
-    showIcon?: boolean;
   }
 
   export let table: Table;
   export let boxed = false;
-  export let showIcon = true;
 
   $: tablePageUrl = getTablePageUrl(
     table.schema.database.id,
@@ -26,9 +24,7 @@
 
 <a class="table-link" class:boxed href={tablePageUrl}>
   <TableName {table} {...$$restProps} />
-  {#if showIcon}
-    <Icon {...iconExternalLink} />
-  {/if}
+  <Icon {...iconExternalLink} />
 </a>
 
 <style lang="scss">

--- a/mathesar_ui/src/pages/record/RecordPageContent.svelte
+++ b/mathesar_ui/src/pages/record/RecordPageContent.svelte
@@ -83,7 +83,7 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
       <div slot="subText" class="table-name">
         <RichText text={$_('record_in_table')} let:slotName>
           {#if slotName === 'tableName'}
-            <TableLink {table} truncate={false} showIcon={false} />
+            <TableLink {table} truncate={false} />
           {/if}
         </RichText>
       </div>
@@ -156,7 +156,6 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
     grid-column: 1;
     color: var(--color-fg-subtle-1);
   }
-
   .form-status {
     grid-row: 1 / span 2;
     grid-column: 2;


### PR DESCRIPTION
# Make table name under record page title clickable (#4916)

Fixes #4916

## Summary

- Wrap the table name shown under the record page title in an anchor linking to the table page.
- Add styles so the link is visibly clickable, uses the table icon yellow on hover/focus (prefers `--color-table`), shows underline on hover, and has a visible `:focus-visible` outline for keyboard users.
- File changed: `mathesar_ui/src/pages/record/RecordPageContent.svelte`

## Technical details

- HTML
  - Table name now rendered as:

    ```svelte
    <a href={tablePageUrl} class="table-name-link">
      <TableName {table} truncate={false} />
    </a>
    ```

    (rendered inside the existing `RichText` slot)

- CSS
  - New/updated rules for `.table-name-link`:
    - default: `text-decoration: none; cursor: pointer;`
    - hover/active: `color: var(--color-table, var(--entity-name-color, var(--color-record))); text-decoration: underline;`
    - `:focus-visible`: outline using `color-mix(...)` based on the same variable; `outline-offset` for clarity.

- Accessibility
  - Anchor remains keyboard-focusable. A `title` and `aria-label` can be used when desired; the component already supports adding these.

## Files modified

- `mathesar_ui/src/pages/record/RecordPageContent.svelte`

## Screenshots

-  **Before**
<img width="1912" height="1139" alt="image" src="https://github.com/user-attachments/assets/3b22a0a1-487e-4d6e-bb02-d84a44bd0c09" />

-  **After**
<img width="1921" height="1304" alt="screencapture-localhost-8000-db-1-schemas-17498-tables-17499-1-2025-11-04-01_56_53" src="https://github.com/user-attachments/assets/a90a2454-a0f4-4485-9da0-7480fe442364" />

## Checklist

- [x] My pull request has a descriptive title.
- [x] My pull request targets the `develop` branch of the repository.
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
