### PR TITLE
Fix missing "Set to null" string in single record view field menus

### DIFF
--- a/mathesar_ui/src/systems/record-view/DirectField.svelte
+++ b/mathesar_ui/src/systems/record-view/DirectField.svelte
@@ -134,7 +134,10 @@
             on:click={() => field.set(null)}
             {disabled}
           >
-            <RichText text={$_('set_to_value')} let:slotName>
+            <RichText
+              text={$_('set_count_cells_to_value', { values: { count: 1 } })}
+              let:slotName
+            >
               {#if slotName === 'value'}
                 <Null />
               {/if}


### PR DESCRIPTION
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This PR fixes a small regression introduced in 1e9f56520b8271d33ca5a1b59e00429afb6b0e5a wherein the "set to null" option for fields in the single record view reference a nonexistient "set_to_value" translation key. 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

Current bug:

<img width="794" height="777" alt="Screenshot From 2025-11-04 21-22-22" src="https://github.com/user-attachments/assets/ce257245-6885-4597-902e-b91a233b4736" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
