### PR TITLE
Enable column-level UPDATE privilege support

### DIFF
--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -209,14 +209,17 @@ export class TabularData {
     );
 
     this.canUpdateRecords = derived(
-      [this.hasPrimaryKey, this.table.currentAccess.currentRolePrivileges, this.processedColumns],
+      [
+        this.hasPrimaryKey,
+        this.table.currentAccess.currentRolePrivileges,
+        this.processedColumns,
+      ],
       ([hasPrimaryKey, tableCurrentRolePrivileges, processedColumns]) =>
-        hasPrimaryKey && (
-          tableCurrentRolePrivileges.has('UPDATE') ||
-          [...processedColumns.values()].some(col =>
-            col.currentRolePrivileges.has('UPDATE')
-          )
-        ),
+        hasPrimaryKey &&
+        (tableCurrentRolePrivileges.has('UPDATE') ||
+          [...processedColumns.values()].some((col) =>
+            col.currentRolePrivileges.has('UPDATE'),
+          )),
     );
 
     this.canDeleteRecords = derived(


### PR DESCRIPTION
Addresses circumstance where users with only column-level UPDATE privileges were blocked from editing any records. The canUpdateRecords check now considers both table-level and column-level UPDATE privileges.

**Fixes #4964**

PostgreSQL allows granting UPDATE privilege on specific columns rather than entire tables. However, Mathesar blocks all editing when a user only has column-level UPDATE privileges (without table-level UPDATE). The UI disables editing for the entire table even though the user has permission to edit specific columns.

This PR fixes the issue by updating the `canUpdateRecords` check in `tabularData.ts` to consider both table-level and column-level UPDATE privileges.

**Technical details**

```SQL
CREATE ROLE test_user WITH LOGIN PASSWORD 'password';
GRANT USAGE ON SCHEMA "Bike Shop" TO test_user;
GRANT SELECT ON "Bike Shop"."Customers" TO test_user;
GRANT INSERT ON "Bike Shop"."Customers" TO test_user;
GRANT UPDATE (first_name, email, phone) ON "Bike Shop"."Customers" TO test_user;
```

The fix modifies `mathesar_ui/src/stores/table-data/tabularData.ts` (lines 211-220). The `canUpdateRecords` derived store now checks if ANY column has UPDATE privilege, not just the table-level privilege.

The infrastructure for column-level permissions was already implemented - column privileges are fetched via `msar.list_column_privileges_for_current_role()` and `ProcessedColumn.isEditable` already handles column-level checks. Only the table-level gate was blocking the feature.

**Screenshots**

**Before**
<img width="1280" height="253" alt="image" src="https://github.com/user-attachments/assets/728eb1c3-2b26-426d-be39-e7d1476e70ed" />


**After**
<img width="1294" height="263" alt="image" src="https://github.com/user-attachments/assets/c1cd0ead-f0a5-45d4-be76-6e0eed3a1493" />

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
