### PR TITLE
experiment with mocking data needed for cross-table editing

### DIFF
--- a/mathesar_ui/src/api/rpc/_common/commonTypes.ts
+++ b/mathesar_ui/src/api/rpc/_common/commonTypes.ts
@@ -6,4 +6,8 @@ export interface SummarizedRecordReference {
 export interface RecordsSummaryListResponse {
   count: number;
   results: SummarizedRecordReference[];
+  mapping?: {
+    join_table: number;
+    joined_values: Record<string, number>;
+  };
 }

--- a/mathesar_ui/src/api/rpc/records.ts
+++ b/mathesar_ui/src/api/rpc/records.ts
@@ -78,6 +78,10 @@ export interface RecordsListParams {
   grouping?: Grouping;
   filter?: SqlExpr;
   return_record_summaries?: boolean;
+  joined_columns?: Array<{
+    alias: string;
+    join_path: Array<Array<[number, number]>>;
+  }>;
 }
 
 export interface RecordsSearchParams {
@@ -115,6 +119,18 @@ export interface RecordsResponse {
   record_summaries: Record<string, string> | null;
   /** Keys are attnums. */
   download_links: Record<string, FileManifestColumnData>;
+  /** Keys are column aliases. Values contain results with record summaries. */
+  joined_record_summaries?: Record<
+    string,
+    {
+      results: Record<string, string>;
+    }
+  > | null;
+  /** Mapping information for joined columns. */
+  mapping?: {
+    join_table: number;
+    joined_values: Record<string, number>;
+  };
 }
 
 export const records = {
@@ -181,6 +197,10 @@ export const records = {
       limit?: number | null;
       offset?: number | null;
       search?: string | null;
+      linked_record_path?: {
+        record_pkey: number;
+        join_path: Array<Array<[number, number]>>;
+      };
     },
     RecordsSummaryListResponse
   >(),

--- a/mathesar_ui/src/packages/json-rpc-client-builder/mockRpcResponses.ts
+++ b/mathesar_ui/src/packages/json-rpc-client-builder/mockRpcResponses.ts
@@ -1,0 +1,154 @@
+// ===========================================================================
+// TODO_CROSS_TABLE_MVP: DELETE THIS ENTIRE FILE
+// Mock responses for joined_columns and linked_record_path until backend supports them
+// ===========================================================================
+
+import type { RpcRequest, RpcResponse } from './requests';
+
+interface RpcResult<T> {
+  status: 'ok';
+  value: T;
+}
+
+export function enhanceResponseWithMockJoinedSummaries<T>(
+  response: RpcResult<T>,
+  joinedColumns: Array<{
+    alias: string;
+    join_path: Array<Array<[number, number]>>;
+  }>,
+): RpcResult<T> {
+  const mockJoinedRecordSummaries: Record<
+    string,
+    { results: Record<string, string> }
+  > = {};
+
+  // Extract join table OID from the first join path segment
+  // The join table is the intermediate table in the path
+  const joinTableOid = joinedColumns[0]?.join_path[0]?.[1]?.[0] ?? 0;
+
+  joinedColumns.forEach((col) => {
+    const { alias } = col;
+    const realResults = response.value as {
+      results?: Array<Record<string, unknown>>;
+    };
+    const resultsList = realResults?.results ?? [];
+    const firstResult = resultsList[0];
+    const joinedIds = firstResult?.[alias] as number[] | undefined;
+
+    if (joinedIds && Array.isArray(joinedIds)) {
+      mockJoinedRecordSummaries[alias] = {
+        results: Object.fromEntries(
+          joinedIds.map((id) => {
+            const intId = parseInt(String(id), 10);
+            return [String(intId), `Summary ${intId} for ${alias}`];
+          }),
+        ),
+      };
+    } else {
+      const allIds = new Set<number>();
+
+      resultsList.forEach((result, rowIdx) => {
+        // Generate simple integer mock IDs (not based on actual data values)
+        // This avoids issues with floats, decimals, or other non-ID numeric values
+        const mockValues = [rowIdx * 10 + 1, rowIdx * 10 + 2];
+
+        // Inject mock column data into result by creating a new object
+        const resultWithMock = {
+          ...result,
+          [alias]: mockValues,
+        };
+        resultsList[rowIdx] = resultWithMock;
+
+        mockValues.forEach((id) => allIds.add(id));
+      });
+
+      mockJoinedRecordSummaries[alias] = {
+        results: Object.fromEntries(
+          Array.from(allIds).map((id) => [
+            String(id),
+            `Summary ${id} for ${alias}`,
+          ]),
+        ),
+      };
+    }
+  });
+
+  // Build mapping with joined values for all aliases
+  const joinedValues: Record<string, number> = {};
+  Object.values(mockJoinedRecordSummaries).forEach((summaryData) => {
+    Object.keys(summaryData.results).forEach((key) => {
+      // Generate a mock joined value (join table row ID)
+      const id = parseInt(key, 10);
+      if (!Number.isNaN(id)) {
+        joinedValues[key] = id * 100; // Simple mock mapping
+      }
+    });
+  });
+
+  const enhancedResponse: RpcResult<T> = {
+    status: 'ok',
+    value: {
+      ...response.value,
+      joined_record_summaries: mockJoinedRecordSummaries,
+      mapping: {
+        join_table: joinTableOid,
+        joined_values: joinedValues,
+      },
+    } as T,
+  };
+
+  /* eslint-disable no-console */
+  console.info(
+    '⚠️ [Mock] Injected fake joined_record_summaries into response:',
+    enhancedResponse,
+  );
+  /* eslint-enable no-console */
+
+  return enhancedResponse;
+}
+
+export function getMockListSummariesResponse<T>(
+  request: RpcRequest<T>,
+): RpcResponse<T> | null {
+  const params = request.params as Record<string, unknown>;
+  if (
+    request.method !== 'records.list_summaries' ||
+    !params?.linked_record_path
+  ) {
+    return null;
+  }
+
+  const linkedRecordPath = params.linked_record_path as {
+    record_pkey: number;
+    join_path: Array<Array<[number, number]>>;
+  };
+  const joinTableOid = linkedRecordPath.join_path[0]?.[1]?.[0] ?? 0;
+
+  const mockResponse: RpcResult<T> = {
+    status: 'ok',
+    value: {
+      count: 100,
+      results: [
+        { key: 3, summary: 'Summary 3' },
+        { key: 34, summary: 'Summary 34' },
+        { key: 45, summary: 'Summary 45' },
+      ],
+      mapping: {
+        join_table: joinTableOid,
+        joined_values: {
+          3: 4734,
+          45: 5467,
+        },
+      },
+    } as T,
+  };
+
+  /* eslint-disable no-console */
+  console.info(
+    '⚠️ [Mock] Returning fake response for records.list_summaries:',
+    mockResponse,
+  );
+  /* eslint-enable no-console */
+
+  return mockResponse as RpcResponse<T>;
+}

--- a/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
+++ b/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
@@ -1,5 +1,9 @@
 import { CancellablePromise, hasProperty } from '@mathesar-component-library';
 
+import {
+  enhanceResponseWithMockJoinedSummaries,
+  getMockListSummariesResponse,
+} from './mockRpcResponses';
 import { RpcError } from './RpcError';
 
 const METHOD_PATH_SEPARATOR = '.';
@@ -57,6 +61,62 @@ function makeRpcResponse<T = unknown>(value: unknown): RpcResponse<T> {
 }
 
 function send<T>(request: RpcRequest<T>): CancellablePromise<RpcResponse<T>> {
+  const { method } = request;
+  const params = request.params as Record<string, unknown>;
+
+  // ===========================================================================
+  // TODO_CROSS_TABLE_MVP: DELETE THIS BLOCK - calls mockRpcResponses.ts
+  // ===========================================================================
+  // Handle records.list_summaries mock (returns full mock response)
+  const mockListSummariesResponse = getMockListSummariesResponse(request);
+  if (mockListSummariesResponse) {
+    return new CancellablePromise((resolve) =>
+      resolve(mockListSummariesResponse),
+    );
+  }
+
+  // Handle records.list with joined_columns (enhances real response)
+  if (method === 'records.list' && params?.joined_columns) {
+    const joinedColumns = params.joined_columns as Array<{
+      alias: string;
+      join_path: Array<Array<[number, number]>>;
+    }>;
+
+    const fetch = cancellableFetch(request.endpoint, {
+      method: 'POST',
+      headers: {
+        ...request.getHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(getRpcRequestBody(request)),
+    });
+
+    return new CancellablePromise(
+      (resolve) =>
+        void fetch
+          .then(
+            (response) => response.json(),
+            (rejectionReason) =>
+              resolve(RpcError.fromAnything(rejectionReason)),
+          )
+          .then((json) => {
+            const rpcResponse = makeRpcResponse<T>(json);
+            if (rpcResponse.status === 'ok') {
+              const enhancedResponse = enhanceResponseWithMockJoinedSummaries(
+                rpcResponse,
+                joinedColumns,
+              );
+              return resolve(enhancedResponse as RpcResponse<T>);
+            }
+            return resolve(rpcResponse);
+          }),
+      () => fetch.cancel(),
+    );
+  }
+  // ===========================================================================
+  // END TODO_CROSS_TABLE_MVP
+  // ===========================================================================
+
   const fetch = cancellableFetch(request.endpoint, {
     method: 'POST',
     headers: {

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -295,6 +295,17 @@ export class RecordsData {
         ...this.contextualFilters,
       ].map(([columnId, value]) => ({ columnId, conditionId: 'equal', value }));
 
+      // TODO_CROSS_TABLE_MVP: Remove this logic once backend supports joined_columns
+      // Convert joining state to joined_columns format
+      const joining = get(this.meta.joining);
+      const joinedColumns =
+        joining.simpleManyToMany.size > 0
+          ? [...joining.simpleManyToMany].map(([intermediateTableOid, joinPath], index) => ({
+              alias: `column_alias_${index + 1}`,
+              join_path: joinPath,
+            }))
+          : undefined;
+
       const recordsListParams: RecordsListParams = {
         ...this.apiContext,
         ...params.pagination.recordsRequestParams(),
@@ -306,6 +317,7 @@ export class RecordsData {
           .withEntries(contextualFilterEntries)
           .recordsRequestParams(),
         return_record_summaries: this.loadIntrinsicRecordSummaries,
+        ...(joinedColumns && { joined_columns: joinedColumns }),
       };
 
       const fuzzySearchParams = params.searchFuzzy.getSearchParams();


### PR DESCRIPTION
Adds hardcoded data related to joined columns based on the proposal in [hackmd](https://hackmd.io/ap9L_MRLTSmP-Bj12iw13g).

Logs the additional data to the console for easier debugging. 

<img width="1926" height="1610" alt="image" src="https://github.com/user-attachments/assets/a9f6061d-1579-4bac-b2d7-e9ef3d9f4844" />

To use:

- Add some joined columns in the "Join" dropdown
- Press "refresh" on the table page
- See the new response from records.list logged in the console
  - Note: this code intercepts the response and if you look in the "Network" tab at RPC payloads you won't see any changes. That's why I implemented the logging.
