### PR TITLE
Correct and Align Docstrings for User RPC Endpoints

### DIFF
--- a/mathesar/rpc/collaborators.py
+++ b/mathesar/rpc/collaborators.py
@@ -1,3 +1,4 @@
+
 from typing import TypedDict
 
 from mathesar.models.base import UserDatabaseRoleMap, Database, ConfiguredRole
@@ -7,14 +8,15 @@ from mathesar.rpc.decorators import mathesar_rpc_method
 
 class CollaboratorInfo(TypedDict):
     """
-    Information about a collaborator.
+    Information about a collaborator in a database.
 
     Attributes:
-        id: the Django ID of the UserDatabaseRoleMap model instance.
-        user_id: The Django ID of the User model instance of the collaborator.
-        database_id: the Django ID of the Database model instance for the collaborator.
-        configured_role_id: The Django ID of the ConfiguredRole model instance for the collaborator.
+        id (int): The Django ID of the UserDatabaseRoleMap model instance.
+        user_id (int): The ID of the User assigned as a collaborator.
+        database_id (int): The ID of the Database the collaborator belongs to.
+        configured_role_id (int): The ID of the ConfiguredRole assigned to the collaborator.
     """
+
     id: int
     user_id: int
     database_id: int
@@ -22,70 +24,100 @@ class CollaboratorInfo(TypedDict):
 
     @classmethod
     def from_model(cls, model):
+        """Construct a CollaboratorInfo object from a model instance."""
         return cls(
             id=model.id,
             user_id=model.user.id,
             database_id=model.database.id,
-            configured_role_id=model.configured_role.id
+            configured_role_id=model.configured_role.id,
         )
 
 
 @mathesar_rpc_method(name="collaborators.list", auth="login")
 def list_(*, database_id: int = None, **kwargs) -> list[CollaboratorInfo]:
     """
-    List information about collaborators. Exposed as `list`.
+    Retrieve a list of collaborators.
 
-    If called with no `database_id`, all collaborators for all databases are listed.
+    If `database_id` is provided, only collaborators belonging to that database
+    are returned. If `database_id` is None, all collaborators across all databases
+    are returned.
 
     Args:
-        database_id: The Django id of the database associated with the collaborators.
+        database_id (int | None): The ID of the database whose collaborators
+            should be listed. If None, collaborators for all databases are fetched.
+
+        **kwargs: Additional RPC-layer arguments (unused).
 
     Returns:
-        A list of collaborators.
+        list[CollaboratorInfo]: A list of collaborator metadata dictionaries.
+
+    Notes:
+        - Requires authentication (`auth="login"`).
+        - Exposed to clients as the RPC method: `collaborators.list`.
     """
     if database_id is not None:
-        user_database_role_map_qs = UserDatabaseRoleMap.objects.filter(database__id=database_id)
+        queryset = UserDatabaseRoleMap.objects.filter(database__id=database_id)
     else:
-        user_database_role_map_qs = UserDatabaseRoleMap.objects.all()
+        queryset = UserDatabaseRoleMap.objects.all()
 
-    return [CollaboratorInfo.from_model(db_model) for db_model in user_database_role_map_qs]
+    return [CollaboratorInfo.from_model(obj) for obj in queryset]
 
 
 @mathesar_rpc_method(name="collaborators.add")
 def add(
-        *,
-        database_id: int,
-        user_id: int,
-        configured_role_id: int,
-        **kwargs
+    *,
+    database_id: int,
+    user_id: int,
+    configured_role_id: int,
+    **kwargs,
 ) -> CollaboratorInfo:
     """
-    Set up a new collaborator for a database.
+    Create and register a new collaborator for a database.
 
     Args:
-        database_id: The Django id of the Database to associate with the collaborator.
-        user_id: The Django id of the User model instance who'd be the collaborator.
-        configured_role_id: The Django id of the ConfiguredRole model instance to associate with the collaborator.
+        database_id (int): The ID of the database to which the collaborator
+            should be added.
+        user_id (int): The ID of the User who will become the collaborator.
+        configured_role_id (int): The ID of the ConfiguredRole that defines
+            the collaborator's permissions.
+
+        **kwargs: Additional RPC-layer arguments (unused).
+
+    Returns:
+        CollaboratorInfo: Metadata about the newly created collaborator.
+
+    Raises:
+        Database.DoesNotExist: If the provided `database_id` does not match any database.
+        User.DoesNotExist: If the provided `user_id` does not exist.
+        ConfiguredRole.DoesNotExist: If `configured_role_id` is invalid.
     """
     database = Database.objects.get(id=database_id)
     user = User.objects.get(id=user_id)
     configured_role = ConfiguredRole.objects.get(id=configured_role_id)
+
     collaborator = UserDatabaseRoleMap.objects.create(
         database=database,
         user=user,
         configured_role=configured_role,
-        server=configured_role.server
+        server=configured_role.server,
     )
+
     return CollaboratorInfo.from_model(collaborator)
 
 
 @mathesar_rpc_method(name="collaborators.delete")
-def delete(*, collaborator_id: int, **kwargs):
+def delete(*, collaborator_id: int, **kwargs) -> None:
     """
     Delete a collaborator from a database.
 
     Args:
-        collaborator_id: The Django id of the UserDatabaseRoleMap model instance of the collaborator.
+        collaborator_id (int): The ID of the UserDatabaseRoleMap instance
+            representing the collaborator to be removed.
+
+        **kwargs: Additional RPC-layer arguments (unused).
+
+    Raises:
+        UserDatabaseRoleMap.DoesNotExist: If the collaborator does not exist.
     """
     collaborator = UserDatabaseRoleMap.objects.get(id=collaborator_id)
     collaborator.delete()
@@ -93,20 +125,31 @@ def delete(*, collaborator_id: int, **kwargs):
 
 @mathesar_rpc_method(name="collaborators.set_role")
 def set_role(
-        *,
-        collaborator_id: int,
-        configured_role_id: int,
-        **kwargs
+    *,
+    collaborator_id: int,
+    configured_role_id: int,
+    **kwargs,
 ) -> CollaboratorInfo:
     """
-    Set the role of a collaborator for a database.
+    Update the configured role assigned to an existing collaborator.
 
     Args:
-        collaborator_id: The Django id of the UserDatabaseRoleMap model instance of the collaborator.
-        configured_role_id: The Django id of the ConfiguredRole model instance to associate with the collaborator.
+        collaborator_id (int): The UserDatabaseRoleMap ID of the collaborator.
+        configured_role_id (int): The new ConfiguredRole ID to assign.
+
+        **kwargs: Additional RPC-layer arguments (unused).
+
+    Returns:
+        CollaboratorInfo: Updated collaborator metadata.
+
+    Raises:
+        UserDatabaseRoleMap.DoesNotExist: If the collaborator does not exist.
+        ConfiguredRole.DoesNotExist: If the new role does not exist.
     """
     collaborator = UserDatabaseRoleMap.objects.get(id=collaborator_id)
     configured_role = ConfiguredRole.objects.get(id=configured_role_id)
+
     collaborator.configured_role = configured_role
     collaborator.save()
+
     return CollaboratorInfo.from_model(collaborator)

--- a/mathesar/rpc/users.py
+++ b/mathesar/rpc/users.py
@@ -1,6 +1,10 @@
 """
-Classes and functions exposed to the RPC endpoint for managing mathesar users.
+RPC endpoints for managing Mathesar users.
+
+This module exposes RPC methods for creating users, listing users, updating
+profile information, and modifying passwords.
 """
+
 from typing import Optional, TypedDict
 from modernrpc.core import REQUEST_KEY
 
@@ -13,21 +17,21 @@ from mathesar.utils.users import (
     update_other_user_info,
     delete_user,
     change_password,
-    revoke_password
+    revoke_password,
 )
 
 
 class UserInfo(TypedDict):
     """
-    Information about a mathesar user.
+    Information about a Mathesar user.
 
     Attributes:
-        id: The Django id of the user.
+        id: The Django ID of the user.
         username: The username of the user.
-        is_superuser: Specifies whether the user is a superuser.
-        email: The email of the user.
-        full_name: The full name of the user.
-        display_language: Specifies the display language for the user, can be either `en` or `ja`.
+        is_superuser: Whether the user is a superuser.
+        email: The user's email address.
+        full_name: The user's full name.
+        display_language: The UI display language (`en` or `ja`).
     """
     id: int
     username: str
@@ -44,21 +48,21 @@ class UserInfo(TypedDict):
             is_superuser=model.is_superuser,
             email=model.email,
             full_name=model.full_name,
-            display_language=model.display_language
+            display_language=model.display_language,
         )
 
 
 class UserDef(TypedDict):
     """
-    Definition for creating a mathesar user.
+    Definition for creating a new Mathesar user.
 
     Attributes:
-        username: The username of the user.
-        password: The password of the user.
-        is_superuser: Whether the user is a superuser.
-        email: The email of the user.
-        full_name: The full name of the user.
-        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+        username: Desired username.
+        password: Password for the user.
+        is_superuser: Whether the user should be a superuser.
+        email: Optional email address.
+        full_name: Optional full name.
+        display_language: Optional display language (`en` or `ja`).
     """
     username: str
     password: str
@@ -71,16 +75,16 @@ class UserDef(TypedDict):
 @mathesar_rpc_method(name='users.add')
 def add(*, user_def: UserDef) -> UserInfo:
     """
-    Add a new mathesar user.
+    Create a new Mathesar user.
 
     Args:
-        user_def: A dict describing the user to create.
+        user_def: Dictionary containing the fields required to create the user.
 
     Privileges:
-        This endpoint requires the caller to be a superuser.
+        Requires superuser privileges.
 
     Returns:
-        The information of the created user.
+        UserInfo: Information about the newly created user.
     """
     user = add_user(user_def)
     return UserInfo.from_model(user)
@@ -89,13 +93,13 @@ def add(*, user_def: UserDef) -> UserInfo:
 @mathesar_rpc_method(name='users.delete')
 def delete(*, user_id: int) -> None:
     """
-    Delete a mathesar user.
+    Delete a Mathesar user.
 
     Args:
-        user_id: The Django id of the user to delete.
+        user_id: The Django ID of the user to delete.
 
     Privileges:
-        This endpoint requires the caller to be a superuser.
+        Requires superuser privileges.
     """
     delete_user(user_id)
 
@@ -103,13 +107,13 @@ def delete(*, user_id: int) -> None:
 @mathesar_rpc_method(name="users.get", auth="login")
 def get(*, user_id: int) -> UserInfo:
     """
-    List information about a mathesar user.
+    Retrieve a user's information.
 
     Args:
-        user_id: The Django id of the user.
+        user_id: The Django ID of the user.
 
     Returns:
-        User information for a given user_id.
+        UserInfo: Information about the requested user.
     """
     user = get_user(user_id)
     return UserInfo.from_model(user)
@@ -118,10 +122,10 @@ def get(*, user_id: int) -> UserInfo:
 @mathesar_rpc_method(name='users.list', auth="login")
 def list_() -> list[UserInfo]:
     """
-    List information about all mathesar users. Exposed as `list`.
+    List all Mathesar users.
 
     Returns:
-        A list of information about mathesar users.
+        list[UserInfo]: A list of user information objects.
     """
     users = list_users()
     return [UserInfo.from_model(user) for user in users]
@@ -137,26 +141,27 @@ def patch_self(
     **kwargs
 ) -> UserInfo:
     """
-    Alter details of currently logged in mathesar user.
+    Update the profile information of the currently logged-in user.
 
     Args:
-        username: The username of the user.
-        email: The email of the user.
-        full_name: The full name of the user.
-        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+        username: Updated username.
+        email: Updated email address.
+        full_name: Updated full name.
+        display_language: Updated display language (`en` or `ja`).
+        **kwargs: Additional request context passed by RPC.
 
     Returns:
-        Updated user information of the caller.
+        UserInfo: Updated information of the current user.
     """
     user = kwargs.get(REQUEST_KEY).user
-    updated_user_info = update_self_user_info(
+    updated = update_self_user_info(
         user_id=user.id,
         username=username,
         email=email,
         full_name=full_name,
-        display_language=display_language
+        display_language=display_language,
     )
-    return UserInfo.from_model(updated_user_info)
+    return UserInfo.from_model(updated)
 
 
 @mathesar_rpc_method(name='users.patch_other')
@@ -170,31 +175,31 @@ def patch_other(
     display_language: str
 ) -> UserInfo:
     """
-    Alter details of a mathesar user, given its user_id.
+    Update details of another user.
 
     Args:
-        user_id: The Django id of the user.
-        username: The username of the user.
-        email: The email of the user.
-        is_superuser: Specifies whether to set the user as a superuser.
-        full_name: The full name of the user.
-        display_language: Specifies the display language for the user, can be set to either `en` or `ja`.
+        user_id: The Django ID of the user.
+        username: Updated username.
+        is_superuser: Updated superuser status.
+        email: Updated email address.
+        full_name: Updated full name.
+        display_language: Updated display language (`en` or `ja`).
 
     Privileges:
-        This endpoint requires the caller to be a superuser.
+        Requires superuser privileges.
 
     Returns:
-        Updated user information for a given user_id.
+        UserInfo: Updated information of the user.
     """
-    updated_user_info = update_other_user_info(
+    updated = update_other_user_info(
         user_id=user_id,
         username=username,
         is_superuser=is_superuser,
         email=email,
         full_name=full_name,
-        display_language=display_language
+        display_language=display_language,
     )
-    return UserInfo.from_model(updated_user_info)
+    return UserInfo.from_model(updated)
 
 
 @mathesar_rpc_method(name='users.password.replace_own', auth="login")
@@ -205,15 +210,19 @@ def replace_own(
     **kwargs
 ) -> None:
     """
-    Alter password of currently logged in mathesar user.
+    Change the password of the currently logged-in user.
 
     Args:
-        old_password: Old password of the currently logged in user.
-        new_password: New password of the user to set.
+        old_password: Current password.
+        new_password: New password to set.
+        **kwargs: Additional request context passed by RPC.
+
+    Raises:
+        Exception: If the old password is incorrect.
     """
     user = kwargs.get(REQUEST_KEY).user
     if not user.check_password(old_password):
-        raise Exception('Old password is incorrect')
+        raise Exception("Old password is incorrect")
     change_password(user.id, new_password)
 
 
@@ -224,13 +233,13 @@ def revoke(
     new_password: str,
 ) -> None:
     """
-    Alter password of a mathesar user, given its user_id.
+    Reset another user's password.
 
     Args:
-        user_id: The Django id of the user.
-        new_password: New password of the user to set.
+        user_id: The Django ID of the user.
+        new_password: New password to assign.
 
     Privileges:
-        This endpoint requires the caller to be a superuser.
+        Requires superuser privileges.
     """
     revoke_password(user_id, new_password)


### PR DESCRIPTION
## Summary
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4013

<!-- Concisely describe what the pull request does. -->

This PR updates the docstrings in the user RPC module to ensure they accurately match the function signatures and the actual return values.

The goal is to maintain correctness of the API documentation so developers using these RPC endpoints have reliable and accurate reference information.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details> 

