### PR TITLE
Improve color of the Mathesar link in forms

### DIFF
--- a/mathesar_ui/src/systems/data-forms/form-maker/DataFormBranding.svelte
+++ b/mathesar_ui/src/systems/data-forms/form-maker/DataFormBranding.svelte
@@ -23,9 +23,34 @@
     color: var(--color-fg-base-muted);
     a {
       text-decoration: none;
+      transition: color 0.2s ease, text-decoration 0.2s ease;
       &:hover {
         color: var(--color-fg-base);
         border-bottom: solid 2px var(--color-brand);
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 2px;
+      }
+
+      &:focus {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 2px;
+        outline: none;
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--color-focus, #4a90e2);
+        outline-offset: 2px;
+        border-radius: 2px;
+      }
+
+      &:visited {
+        color: var(--color-fg-base);
+      }
+
+      &:active {
+        opacity: 0.85;
       }
     }
   }


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4769

<!-- Concisely describe what the pull request does. -->

**Technical details**

- Updated link color to use the theme’s base text color (--color-fg-base) instead of muted text

- Added underline on hover and focus states for accessibility

- Scoped styles within .form-branding a to avoid global overrides

- Verified appearance in both light and dark themes


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
