### PR TITLE
Fix #4893: Displayed table relationships do not update after adding a new relationship

### DIFF
--- a/mathesar_ui/src/systems/table-view/link-table/LinkTableForm.svelte
+++ b/mathesar_ui/src/systems/table-view/link-table/LinkTableForm.svelte
@@ -164,13 +164,18 @@
       await fetchTablesForCurrentSchema();
       return;
     }
+
     const tableWithNewColumn = $linkType === 'oneToMany' ? target : base;
+
     if (!tableWithNewColumn) {
       return;
     }
+
     if (tableWithNewColumn.oid === $tabularData.table.oid) {
       await $tabularData.refresh();
     }
+
+    await fetchTablesForCurrentSchema();
   }
 
   async function handleSave(values: FilledFormValues<typeof form>) {

--- a/mathesar_ui/src/systems/table-view/link-table/LinkTableForm.svelte
+++ b/mathesar_ui/src/systems/table-view/link-table/LinkTableForm.svelte
@@ -159,25 +159,6 @@
   // Saving
   // ===========================================================================
 
-  async function reFetchOtherThingsThatChanged() {
-    if ($linkType === 'manyToMany') {
-      await fetchTablesForCurrentSchema();
-      return;
-    }
-
-    const tableWithNewColumn = $linkType === 'oneToMany' ? target : base;
-
-    if (!tableWithNewColumn) {
-      return;
-    }
-
-    if (tableWithNewColumn.oid === $tabularData.table.oid) {
-      await $tabularData.refresh();
-    }
-
-    await fetchTablesForCurrentSchema();
-  }
-
   async function handleSave(values: FilledFormValues<typeof form>) {
     try {
       if ($linkType === 'oneToMany') {
@@ -220,7 +201,7 @@
         assertExhaustive($linkType);
       }
       toast.success('The link has been created successfully');
-      await reFetchOtherThingsThatChanged();
+      await fetchTablesForCurrentSchema();
       close();
     } catch (error) {
       toast.error(getErrorMessage(error));


### PR DESCRIPTION
# Displayed table relationships do not update after adding a new relationship (#4893)

Fixes #4893

This PR ensures that newly created relationships appear **immediately** in the Relationships panel, without requiring a manual page reload. Previously, creating a **Many-to-One** or **One-to-Many** relationship updated only the tabular data but not the table metadata, causing the UI to show outdated relationship information until refresh.

## Technical details

**Problem:**
When creating FK-based relationships (Many-to-One or One-to-Many), the UI only refreshed the active table’s tabular data (`$tabularData.refresh()`). However, the **Relationships** section depends on **schema-level metadata**, which was *not* being refreshed. Many-to-Many relationships already triggered a schema refresh, so only FK-based types were affected.

**Fix:**
Added a schema refresh after FK-based relationship creation by calling:

```
await fetchTablesForCurrentSchema();
```

This now happens for **all** relationship types, ensuring consistent and immediate UI updates.

**Behavior changes:**

* Relationships panel updates instantly after creating:

  * Many-to-One
  * One-to-Many
  * Many-to-Many
* No manual page reload needed anymore.
* No backend logic or API changes required.

**Files touched:**

* `mathesar_ui/src/systems/table-view/link-table/LinkTableForm.svelte` — Updated `reFetchOtherThingsThatChanged()` to always refresh schema metadata for FK relationships.


**Screenshots**
<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/3f876ea5-d62e-41f4-a0fb-2df0553fdd9c" />

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
