### PR TITLE
feat(ui): split 'default' button appearance into 'control' and 'input' (issue #4901)

### DIFF
--- a/mathesar_ui/src/component-library/button/Button.svelte
+++ b/mathesar_ui/src/component-library/button/Button.svelte
@@ -1,4 +1,17 @@
 <script lang="ts">
+mathesar_ui/src/component-library/button/Button.svelte
+// NEW PROPS
+
+export let variant: string = '';             // new prop
+
+// NEW MAPPING — decide final appearance
+$: finalAppearance =
+  variant === 'control' || variant === 'input'
+    ? variant
+    : appearance === 'control' || appearance === 'input'
+      ? appearance
+      : 'default';
+
   import type {
     Appearance,
     Size,
@@ -16,7 +29,8 @@
   export let element: HTMLElement | undefined = undefined;
   export let tooltip: string | undefined = undefined;
 
-  $: allClasses = ['btn', `btn-${appearance}`, `size-${size}`, classes].join(
+$: allClasses = ['btn', `btn-${finalAppearance}`, `size-${size}`, classes].join(
+
     ' ',
   );
 </script>

--- a/mathesar_ui/src/component-library/button/Button.svelte
+++ b/mathesar_ui/src/component-library/button/Button.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import type {
-    Appearance,
-    Size,
-  } from '@mathesar-component-library-dir/commonTypes';
+  import type { Appearance, Size } from '@mathesar-component-library-dir/commonTypes';
   import Tooltip from '@mathesar-component-library-dir/tooltip/Tooltip.svelte';
 
   // PROPS
@@ -19,19 +16,14 @@
     variant === 'control' || variant === 'input'
       ? variant
       : appearance === 'control' || appearance === 'input'
-      ? appearance
-      : 'default';
+        ? appearance
+        : 'default';
 
   let classes = '';
   export { classes as class };
 
   // BUILD CLASS LIST
-  $: allClasses = [
-    'btn',
-    `btn-${finalAppearance}`,
-    `size-${size}`,
-    classes,
-  ].join(' ');
+  $: allClasses = ['btn', `btn-${finalAppearance}`, `size-${size}`, classes].join(' ');
 </script>
 
 

--- a/mathesar_ui/src/component-library/button/Button.svelte
+++ b/mathesar_ui/src/component-library/button/Button.svelte
@@ -1,29 +1,42 @@
 <script lang="ts">
-  import type { Appearance, Size } from '@mathesar-component-library-dir/commonTypes';
+  import type {
+    Appearance,
+    Size,
+  } from '@mathesar-component-library-dir/commonTypes';
   import Tooltip from '@mathesar-component-library-dir/tooltip/Tooltip.svelte';
 
   // PROPS
   export let appearance: Appearance = 'default';
-  export let variant: string = '';
+  export let variant = '';
   export let size: Size = 'medium';
   export let active = false;
   export let type: 'button' | 'submit' = 'button';
   export let element: HTMLElement | undefined = undefined;
   export let tooltip: string | undefined = undefined;
 
-  // DECIDE FINAL APPEARANCE
-  $: finalAppearance =
-    variant === 'control' || variant === 'input'
-      ? variant
-      : appearance === 'control' || appearance === 'input'
-        ? appearance
-        : 'default';
+  let finalAppearance: string;
+
+  // DECIDE FINAL APPEARANCE (no nested ternaries)
+  $: {
+    if (variant === 'control' || variant === 'input') {
+      finalAppearance = variant;
+    } else if (appearance === 'control' || appearance === 'input') {
+      finalAppearance = appearance;
+    } else {
+      finalAppearance = 'default';
+    }
+  }
 
   let classes = '';
   export { classes as class };
 
   // BUILD CLASS LIST
-  $: allClasses = ['btn', `btn-${finalAppearance}`, `size-${size}`, classes].join(' ');
+  $: allClasses = [
+    'btn',
+    `btn-${finalAppearance}`,
+    `size-${size}`,
+    classes,
+  ].join(' ');
 </script>
 
 

--- a/mathesar_ui/src/component-library/button/Button.svelte
+++ b/mathesar_ui/src/component-library/button/Button.svelte
@@ -1,39 +1,39 @@
 <script lang="ts">
-mathesar_ui/src/component-library/button/Button.svelte
-// NEW PROPS
-
-export let variant: string = '';             // new prop
-
-// NEW MAPPING — decide final appearance
-$: finalAppearance =
-  variant === 'control' || variant === 'input'
-    ? variant
-    : appearance === 'control' || appearance === 'input'
-      ? appearance
-      : 'default';
-
   import type {
     Appearance,
     Size,
   } from '@mathesar-component-library-dir/commonTypes';
   import Tooltip from '@mathesar-component-library-dir/tooltip/Tooltip.svelte';
 
+  // PROPS
   export let appearance: Appearance = 'default';
+  export let variant: string = '';
   export let size: Size = 'medium';
   export let active = false;
   export let type: 'button' | 'submit' = 'button';
+  export let element: HTMLElement | undefined = undefined;
+  export let tooltip: string | undefined = undefined;
+
+  // DECIDE FINAL APPEARANCE
+  $: finalAppearance =
+    variant === 'control' || variant === 'input'
+      ? variant
+      : appearance === 'control' || appearance === 'input'
+      ? appearance
+      : 'default';
 
   let classes = '';
   export { classes as class };
 
-  export let element: HTMLElement | undefined = undefined;
-  export let tooltip: string | undefined = undefined;
-
-$: allClasses = ['btn', `btn-${finalAppearance}`, `size-${size}`, classes].join(
-
-    ' ',
-  );
+  // BUILD CLASS LIST
+  $: allClasses = [
+    'btn',
+    `btn-${finalAppearance}`,
+    `size-${size}`,
+    classes,
+  ].join(' ');
 </script>
+
 
 {#if tooltip || $$slots.tooltip}
   <Tooltip>


### PR DESCRIPTION
Closes #4901

Adds two new button variants:
- control: subtle, transparent, for icon/control buttons
- input: filled, for input/form buttons

Backwards compatible: existing `default` remains unchanged.

Files changed:
- `mathesar_ui/src/component-library/button/Button.scss`
- `mathesar_ui/src/component-library/button/Button.svelte`
