### PR TITLE
Fix #4894: Hide preview fieldset when recordId is NULL

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/record-summary/Preview.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record-summary/Preview.svelte
@@ -31,23 +31,25 @@
     $preview.resolvedValue?.record_summaries?.[String(recordId)];
 </script>
 
-<Fieldset label={$_('preview')} boxed>
-  {#if $preview.isLoading}
-    <Spinner />
-  {:else if recordSummary !== undefined}
-    <LinkedRecord {recordSummary} />
-  {:else}
-    <Errors errors={[$preview.error ?? $_('unknown_error')]} />
-  {/if}
+{#if recordId != null}
+  <Fieldset label={$_('preview')} boxed>
+    {#if $preview.isLoading}
+      <Spinner />
+    {:else if recordSummary !== undefined}
+      <LinkedRecord {recordSummary} />
+    {:else}
+      <Errors errors={[$preview.error ?? $_('unknown_error')]} />
+    {/if}
 
-  <div class="help">
-    <RichText text={$_('record_summary_preview_help')} let:slotName>
-      {#if slotName === 'tableName'}
-        <Identifier>{table.name}</Identifier>
-      {/if}
-    </RichText>
-  </div>
-</Fieldset>
+    <div class="help">
+      <RichText text={$_('record_summary_preview_help')} let:slotName>
+        {#if slotName === 'tableName'}
+          <Identifier>{table.name}</Identifier>
+        {/if}
+      </RichText>
+    </div>
+  </Fieldset>
+{/if}
 
 <style>
   .help {


### PR DESCRIPTION
# Fix #4894: Hide preview fieldset when recordId is NULL

 🎯 Problem
When users select a **NULL cell** in **Linked Record Summary** configuration, users see `"An unknown error occurred"` instead of a clean UI.

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number]

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
