### PR TITLE
docs: clarify purpose of the docs folder in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+## Purpose of this folder
+
+This `docs/` folder contains documentation **for developers contributing to the Mathesar codebase**.  
+This is **not** the user documentation site (https://docs.mathesar.org).  
+Instead, this folder includes internal developer docs, notes, and style guidelines relevant while working on the repository itself.
 # Mathesar's Documentation
 
 This directory contains the source code for Mathesar's user and administrator documentation published to https://docs.mathesar.org/


### PR DESCRIPTION
This PR improves the clarity and usefulness of the docs/README.md file by adding a short explanation about the purpose of the docs directory within the Mathesar repository.

Several new contributors (including myself) initially found it unclear whether the docs/ folder was user-facing documentation, developer documentation, or a mix of both. The updated README now explicitly states that this folder contains:

Developer-focused documentation

Style guides and conventions

Internal reference material

Supporting files for documentation tooling

Providing this context makes it easier for new contributors to understand where documentation changes should go, how the folder is structured, and what types of files belong here.
