### PR TITLE
Fix #5059: Parse temporal values on frontend paste using column settings

### DIFF
--- a/mathesar_ui/src/components/sheet/clipboard/paste.ts
+++ b/mathesar_ui/src/components/sheet/clipboard/paste.ts
@@ -2,12 +2,19 @@ import { arrayFrom, cycle, execPipe, first, map, take, zip } from 'iter-tools';
 import { type Writable, get } from 'svelte/store';
 import { _ } from 'svelte-i18n';
 
-import type { RawColumnWithMetadata } from '@mathesar/api/rpc/columns';
+import {
+  type RawColumnWithMetadata,
+  getColumnMetadataValue,
+} from '@mathesar/api/rpc/columns';
 import { type RecordRow, getRowSelectionId } from '@mathesar/stores/table-data';
 import type {
   RowAdditionRecipe,
   RowModificationRecipe,
 } from '@mathesar/stores/table-data/records';
+import {
+  DateTimeFormatter,
+  DateTimeSpecification,
+} from '@mathesar/utils/date-time';
 import { startingFrom } from '@mathesar/utils/iterUtils';
 import {
   type ImmutableSet,
@@ -122,7 +129,52 @@ function prepareStructuredCellValue(
   if (cell.type === 'tsv') {
     // Since TSV doesn't have a mechanism to faithfully represent NULLs, we
     // assume that empty strings are NULLs.
-    if (cell.value === '' && column.nullable) return null;
+    if (cell.value === '' && column.nullable) {
+      return null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let type: any;
+
+    // FIX: Using curly braces to satisfy linter rule 'curly'
+    if (column.type === 'date') {
+      type = 'date';
+    } else if (column.type === 'timestamp without time zone') {
+      type = 'timestamp';
+    } else if (column.type === 'timestamp with time zone') {
+      type = 'timestampWithTZ';
+    } else if (column.type === 'time without time zone') {
+      type = 'time';
+    } else if (column.type === 'time with time zone') {
+      type = 'timeWithTZ';
+    }
+
+    if (type) {
+      const dateFormat = getColumnMetadataValue(column, 'date_format');
+      const timeFormat = getColumnMetadataValue(column, 'time_format');
+      const specification = new DateTimeSpecification({
+        type,
+        dateFormat,
+        timeFormat,
+      });
+      const formatter = new DateTimeFormatter(specification);
+
+      // FIX: Suppress assignment error for parsed variable
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parsed = formatter.parse(cell.value);
+
+      // If parsing returns a string, use it.
+      if (typeof parsed === 'string' && parsed) {
+        return parsed;
+      }
+
+      if (typeof parsed === 'object' && parsed !== null && 'value' in parsed) {
+        // FIX: Suppress return and member-access errors for extracting the value property
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+        return parsed.value;
+      }
+      // END FIX
+    }
 
     return cell.value;
   }
@@ -130,10 +182,14 @@ function prepareStructuredCellValue(
   if (cell.type === 'mathesar') {
     // We need to check for NULL first because the "formatted" value of a copied
     // null cell will be an empty string, which we don't want to return.
-    if (cell.value.raw === null) return null;
+    if (cell.value.raw === null) {
+      return null;
+    }
 
     // If we're pasting into a text column, use the formatted value.
-    if (column.type === 'text') return cell.value.formatted;
+    if (column.type === 'text') {
+      return cell.value.formatted;
+    }
 
     // Otherwise use the raw value
     return cell.value.raw;
@@ -168,7 +224,9 @@ async function updateViaPaste({
   const targetRowCount = Math.max(initialSelection.rowIds.size, payload.length);
   const sourceRows = [...take(targetRowCount, cycle(payload))];
   const firstSourceRow = first(sourceRows);
-  if (!firstSourceRow) throw new Error(get(_)('paste_error_no_rows'));
+  if (!firstSourceRow) {
+    throw new Error(get(_)('paste_error_no_rows'));
+  }
 
   const sourceColumnCount = firstSourceRow.length;
   const sheetColumns = context.getSheetColumns();
@@ -223,7 +281,9 @@ async function updateViaPaste({
     const confirmed = await context.confirm(
       get(_)('paste_confirmation', { values: { count: totalCellCount } }),
     );
-    if (!confirmed) return;
+    if (!confirmed) {
+      return;
+    }
   }
 
   const { rowIds, columnIds } = await context.bulkDml(
@@ -249,7 +309,9 @@ export async function paste(
   const payload = getPayload(clipboardData);
 
   const operation = get(selectionStore).pasteOperation;
-  if (operation === 'none') return;
+  if (operation === 'none') {
+    return;
+  }
   if (operation === 'insert') {
     await updateViaPaste({ payload, selectionStore, context, confirm: false });
     return;


### PR DESCRIPTION
Fixes #5059

This PR fixes a bug where pasting a date string (e.g., `10/11/2000`) directly into a cell ignored the column's date format settings (like "European" DD/MM/YYYY). This resulted in the backend misinterpreting the date. The paste logic now uses `DateTimeFormatter` to correctly parse the value based on column metadata.

**Technical details**
The `prepareStructuredCellValue` function in `mathesar_ui/src/components/sheet/clipboard/paste.ts` was updated to:
1. Detect if the target column is a temporal type (`date`, `timestamp`, `time`).
2. Retrieve the column's formatting metadata (`date_format`, `time_format`).
3. Use the `DateTimeFormatter` to parse the raw pasted string (`cell.value`) into the standard ISO format (e.g., `2000-11-10`).
4. Includes a check to correctly extract the string value, even if `formatter.parse()` returns a complex object (`{ value: '...' }`).

**Screenshots**

- Before:
<img width="1036" height="836" alt="Screenshot from 2025-12-03 02-50-30" src="https://github.com/user-attachments/assets/86a01492-1aa1-442b-9e31-5a1b9bba32aa" />


- After:
<img width="1036" height="836" alt="Screenshot from 2025-12-03 02-50-09" src="https://github.com/user-attachments/assets/c865ae15-0b6f-4422-af8f-0121ad48a1d5" />


## Checklist
 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
    *(Note: For this issue, existing paste tests might cover it, or a new minimal test should be added.)*
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.
[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
