### PR TITLE
Remove `data_files/` dependency on DRF

### DIFF
--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -1,19 +1,21 @@
 from django.contrib.auth.views import LoginView
 from django.urls import include, path, re_path
-from rest_framework import routers
+# from rest_framework import routers
 
 from mathesar import views
-from mathesar.api.viewsets.data_files import DataFileViewSet
+# from mathesar.api.viewsets.data_files import DataFileViewSet
 from mathesar.views.installation.decorators import installation_complete, installation_incomplete
 from mathesar.views.installation.complete_installation import CompleteInstallationFormView
 from mathesar.views.users.password_reset import MathesarPasswordResetConfirmView
 
-db_router = routers.DefaultRouter()
-db_router.register(r'data_files', DataFileViewSet, basename='data-file')
+# db_router = routers.DefaultRouter()
+# db_router.register(r'data_filess', DataFileViewSet, basename='data-file')
 
 urlpatterns = [
     path('api/rpc/v0/', views.MathesarRPCEntryPoint.as_view()),
-    path('api/db/v0/', include(db_router.urls)),
+    # path('api/db/v0/', include(db_router.urls)),
+    path('api/db/v0/data_files/', views.data_files.list_or_create_data_file, name='list_or_create_data_file'),
+    path('api/db/v0/data_files/<int:data_file_id>/', views.data_files.get_or_patch_data_file, name='get_or_patch_data_file'),
     path('api/export/v0/explorations/', views.export.export_exploration, name='export_exploration'),
     path('api/export/v0/tables/', views.export.export_table, name='export_table'),
     path('complete_installation/', installation_incomplete(CompleteInstallationFormView.as_view()), name='complete_installation'),

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -9,7 +9,7 @@ from mathesar.views.installation.complete_installation import CompleteInstallati
 from mathesar.views.users.password_reset import MathesarPasswordResetConfirmView
 
 # db_router = routers.DefaultRouter()
-# db_router.register(r'data_filess', DataFileViewSet, basename='data-file')
+# db_router.register(r'data_files', DataFileViewSet, basename='data-file')
 
 urlpatterns = [
     path('api/rpc/v0/', views.MathesarRPCEntryPoint.as_view()),

--- a/mathesar/views/__init__.py
+++ b/mathesar/views/__init__.py
@@ -17,10 +17,10 @@ from mathesar.rpc.users import get as get_user_info
 from mathesar.utils.download_links import get_backends as get_file_backends
 from mathesar import __version__
 
-from . import export, users, download_link, bulk_insert
+from . import export, users, download_link, bulk_insert, data_files
 
 
-__all__ = [export, users, download_link, bulk_insert]
+__all__ = [export, users, download_link, bulk_insert, data_files]
 
 
 def get_database_list(request):

--- a/mathesar/views/data_files.py
+++ b/mathesar/views/data_files.py
@@ -1,0 +1,218 @@
+import requests
+import json
+
+from django import forms
+from django.http import JsonResponse
+from django.utils.encoding import force_str
+from django.views.decorators.http import require_http_methods
+from django.contrib.auth.decorators import login_required
+
+from mathesar.errors import InvalidTableError, URLDownloadError
+from mathesar.utils.datafiles import create_datafile
+from mathesar.models.base import DataFile
+
+SUPPORTED_URL_CONTENT_TYPES = {'text/csv', 'text/plain'}
+
+
+class DataFileForm(forms.Form):
+    file = forms.FileField(required=False, max_length=100)
+    header = forms.BooleanField(required=False)
+    delimiter = forms.CharField(required=False)
+    escapechar = forms.CharField(required=False)
+    quotechar = forms.CharField(required=False)
+    paste = forms.CharField(required=False, empty_value=None, strip=False)
+    url = forms.URLField(required=False, empty_value=None)
+
+    # TODO: consider removing, these are left
+    # from when we had infra for uploading json & excel files
+    max_level = forms.IntegerField(initial=0, required=False)
+    sheet_index = forms.IntegerField(initial=0, required=False)
+
+    def __init__(self, request, *args, **kwargs):
+        if request.content_type == 'multipart/form-data':
+            self.data = request.POST
+        else:
+            self.data = json.loads(request.body)
+        self.file = request.FILES
+        super().__init__(self.data, self.file, *args, **kwargs)
+        self.request = request
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # Only include fields that were present in the initial request.
+        fields_from_request = list(self.data.keys()) + list(self.file.keys())
+        cleaned_data = {k: v for k, v in cleaned_data.items() if k in fields_from_request}
+
+        if self.request.method == "POST":
+            source_fields = ['file', 'paste', 'url']
+            present_fields = [
+                field for field in source_fields
+                if field in cleaned_data.keys()
+                and cleaned_data[field] is not None
+            ]
+            if len(present_fields) > 1:
+                raise forms.ValidationError(
+                    f'Multiple source fields passed: {present_fields}.'
+                    f' Only one of {source_fields} should be specified.',
+                )
+            elif len(present_fields) == 0:
+                raise forms.ValidationError(
+                    f'One of {source_fields} should be specified.'
+                )
+        return cleaned_data
+
+    def clean_url(self):
+        url = self.cleaned_data.get('url')
+        if url:
+            try:
+                response = requests.head(url, allow_redirects=True)
+            except requests.exceptions.ConnectionError:
+                raise forms.ValidationError(
+                    "URL cannot be reached."
+                )
+
+            content_type = response.headers.get('content-type')
+            if not any(x in content_type for x in SUPPORTED_URL_CONTENT_TYPES):
+                # sometimes content_type includes charset info e.g. (text/plain; charset=utf-8)
+                # so, we check whether any supported content types are present in the content_type string,
+                # and raise an error if content_type is unsupported.
+                raise forms.ValidationError(
+                    f"URL resource '{content_type}' not a valid type."
+                )
+        return url
+
+
+@require_http_methods(["GET", "POST"])
+@login_required
+def list_or_create_data_file(request):
+    user = request.user
+
+    def datafile_to_dict(df: DataFile):
+        return {
+            "id": df.id,
+            "file": request.build_absolute_uri(df.file.url),
+            "user": df.user.id,
+            "header": df.header,
+            "delimiter": df.delimiter,
+            "escapechar": df.escapechar,
+            "quotechar": df.quotechar,
+            "created_from": df.created_from,
+            # TODO: remove?
+            "max_level": df.max_level,
+            "sheet_index": df.sheet_index
+        }
+
+    if request.method == 'GET':
+        # List data files
+        if user.is_superuser:
+            data_files = DataFile.objects.all()
+        else:
+            data_files = DataFile.objects.all().filter(user=user)
+        data_files = [datafile_to_dict(df) for df in data_files]
+        return JsonResponse(
+            {
+                "count": len(data_files),
+                "results": data_files
+            },
+            status=200
+        )
+
+    elif request.method == 'POST':
+        form = DataFileForm(request)
+        if form.is_valid():
+            data = form.cleaned_data
+            try:
+                df = create_datafile(data, user)
+            except InvalidTableError:
+                return JsonResponse(
+                    {"errors": "Unable to tabulate data."},
+                    status=400
+                )
+            except URLDownloadError:
+                return JsonResponse(
+                    {"errors": "URL cannot be downloaded."},
+                    status=400
+                )
+            except Exception as e:
+                return JsonResponse(
+                    {"errors": f"Unable to create DataFile. {force_str(e)}"},
+                    status=400
+                )
+            return JsonResponse(datafile_to_dict(df), status=201)
+        else:
+            return JsonResponse({"errors": form.errors}, status=400)
+
+    else:
+        return JsonResponse({"errors": "Unexpected"}, status=400)
+
+
+@require_http_methods(["GET", "PATCH"])
+@login_required
+def get_or_patch_data_file(request, data_file_id):
+    user = request.user
+
+    def datafile_to_dict(df: DataFile):
+        return {
+            "id": df.id,
+            "file": request.build_absolute_uri(df.file.url),
+            "user": df.user.id,
+            "header": df.header,
+            "delimiter": df.delimiter,
+            "escapechar": df.escapechar,
+            "quotechar": df.quotechar,
+            "created_from": df.created_from,
+            # TODO: remove?
+            "max_level": df.max_level,
+            "sheet_index": df.sheet_index
+        }
+
+    if request.method == 'GET':
+        # Get a data file
+        if data_file_id:
+            try:
+                data_file = DataFile.objects.get(id=data_file_id, user=user)
+            except DataFile.DoesNotExist:
+                return JsonResponse(
+                    {"errors": "No DataFile matches the given query."},
+                    status=404
+                )
+            return JsonResponse(
+                datafile_to_dict(data_file),
+                status=200
+            )
+
+    elif request.method == 'PATCH':
+        if data_file_id is None:
+            return JsonResponse({"errors": "data_file_id is required."}, status=400)
+        try:
+            data_file = DataFile.objects.get(id=data_file_id, user=user)
+            form = DataFileForm(request)
+            if form.is_valid():
+                data = form.cleaned_data
+                if data.get('header') is not None:
+                    data_file.header = data['header']
+                    data_file.save()
+                    return JsonResponse(
+                        datafile_to_dict(data_file),
+                        status=200
+                    )
+                else:
+                    return JsonResponse(
+                        {"errors": 'Method "PATCH" allowed only for header.'},
+                        status=405
+                    )
+            else:
+                return JsonResponse({"errors": form.errors}, status=400)
+        except DataFile.DoesNotExist:
+            return JsonResponse(
+                {"errors": "No DataFile matches the given query."},
+                status=404
+            )
+        except Exception as e:
+            return JsonResponse(
+                {"errors": force_str(e)},
+                status=400
+            )
+    else:
+        return JsonResponse({"errors": "Unexpected"}, status=400)


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #4877 

This PR converts the functionality of our existing infrastructure for `data_files/` to use regular Django views instead of relying on DRF while maintaining feature parity.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
