### PR TITLE
Add permission-based filtering for schemas and tables in object lists

### DIFF
--- a/db/sql/05_msar.sql
+++ b/db/sql/05_msar.sql
@@ -1083,7 +1083,16 @@ Args:
 */
 SELECT coalesce(jsonb_agg(table_data),'[]'::jsonb)
 FROM msar.table_info_table() AS table_data
-WHERE table_data.schema = sch_id;
+WHERE table_data.schema = sch_id
+AND (
+  jsonb_array_length(table_data.current_role_priv) > 0
+  OR
+  pg_has_role(current_user, (SELECT datdba FROM pg_catalog.pg_database WHERE datname = current_database()), 'MEMBER')
+  OR
+  pg_has_role(current_user, (SELECT nspowner FROM pg_catalog.pg_namespace WHERE oid = sch_id), 'MEMBER')
+  OR
+  has_schema_privilege(current_user, sch_id, 'CREATE')
+);
 $$ LANGUAGE SQL RETURNS NULL ON NULL INPUT;
 
 
@@ -1178,7 +1187,14 @@ Each returned JSON object in the array will have the form:
 SELECT jsonb_agg(schema_data)
 FROM msar.schema_info_table() AS schema_data
 WHERE schema_data.name <> 'information_schema'
-AND schema_data.name NOT LIKE 'pg_%';
+AND schema_data.name NOT LIKE 'pg_%'
+AND (
+  jsonb_array_length(schema_data.current_role_priv) > 0
+  OR
+  pg_has_role(current_user, (SELECT datdba FROM pg_catalog.pg_database WHERE datname = current_database()), 'MEMBER')
+  OR
+  has_database_privilege(current_user, current_database(), 'CREATE')
+);
 $$ LANGUAGE SQL STABLE;
 
 

--- a/db/sql/test_permissions_filtering.sql
+++ b/db/sql/test_permissions_filtering.sql
@@ -1,0 +1,107 @@
+CREATE OR REPLACE FUNCTION __setup_permissions_filtering() RETURNS SETOF TEXT AS $$
+BEGIN
+    -- Create roles
+    -- We check existence to avoid errors if roles persist (though pgTAP usually rolls back, CREATE ROLE is non-transactional)
+    
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'test_restricted_user') THEN
+        CREATE ROLE test_restricted_user LOGIN;
+    END IF;
+    
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'other_user') THEN
+        CREATE ROLE other_user;
+    END IF;
+    
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'db_creator') THEN
+        CREATE ROLE db_creator LOGIN;
+    END IF;
+
+    -- Create schemas
+    CREATE SCHEMA visible_schema;
+    CREATE SCHEMA hidden_schema;
+    CREATE SCHEMA create_only_schema;
+    CREATE SCHEMA other_schema AUTHORIZATION other_user;
+    
+    -- Create tables
+    CREATE TABLE visible_schema.visible_table (id int);
+    CREATE TABLE hidden_schema.hidden_table (id int);
+    CREATE TABLE create_only_schema.admin_table (id int);
+    CREATE TABLE visible_schema.hidden_table_in_visible_schema (id int);
+    
+    -- Grants
+    GRANT USAGE ON SCHEMA visible_schema TO test_restricted_user;
+    GRANT SELECT ON visible_schema.visible_table TO test_restricted_user;
+    GRANT CREATE ON SCHEMA create_only_schema TO test_restricted_user;
+    GRANT CREATE ON DATABASE mathesar_testing TO db_creator;
+    
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION test_permissions_filtering() RETURNS SETOF TEXT AS $$
+BEGIN
+    PERFORM __setup_permissions_filtering();
+    
+    -- Switch to restricted user
+    SET ROLE test_restricted_user;
+    
+    -- Test 1: hidden_schema should NOT be in list_schemas
+    RETURN NEXT ok(
+        NOT jsonb_path_exists(msar.list_schemas(), '$[*] ? (@.name == "hidden_schema")'),
+        'Hidden schema should not be visible to restricted user'
+    );
+    
+    -- Test 2: visible_schema SHOULD be in list_schemas
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.list_schemas(), '$[*] ? (@.name == "visible_schema")'),
+        'Visible schema should be visible to restricted user'
+    );
+    
+    -- Test 3: hidden_table_in_visible_schema should NOT be in get_table_info('visible_schema')
+    RETURN NEXT ok(
+        NOT jsonb_path_exists(msar.get_table_info('visible_schema'), '$[*] ? (@.name == "hidden_table_in_visible_schema")'),
+        'Hidden table in visible schema should not be visible to restricted user'
+    );
+    
+    -- Test 4: visible_table should be in get_table_info('visible_schema')
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.get_table_info('visible_schema'), '$[*] ? (@.name == "visible_table")'),
+        'Visible table in visible schema should be visible to restricted user'
+    );
+    
+    -- Test 5: create_only_schema SHOULD be in list_schemas
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.list_schemas(), '$[*] ? (@.name == "create_only_schema")'),
+        'Schema with CREATE permission should be visible to restricted user'
+    );
+    
+    -- Test 6: admin_table in create_only_schema SHOULD be in get_table_info because user has CREATE on schema
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.get_table_info('create_only_schema'), '$[*] ? (@.name == "admin_table")'),
+        'Table without permissions in a CREATE-only schema SHOULD be visible'
+    );
+    
+    SET ROLE NONE;
+    
+    -- Test 7: Admin (superuser/owner) should see hidden_schema
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.list_schemas(), '$[*] ? (@.name == "hidden_schema")'),
+        'Admin should see hidden schema'
+    );
+    
+    -- Test 8: Admin (superuser/owner) should see hidden_table in hidden_schema
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.get_table_info('hidden_schema'), '$[*] ? (@.name == "hidden_table")'),
+        'Admin should see hidden table'
+    );
+    
+    -- Test 9: User with CREATE on Database should see hidden schema
+    SET ROLE db_creator;
+    
+    RETURN NEXT ok(
+        jsonb_path_exists(msar.list_schemas(), '$[*] ? (@.name == "hidden_schema")'),
+        'User with CREATE on Database should see hidden schema'
+    );
+    
+    SET ROLE NONE;
+    
+END;
+$$ LANGUAGE plpgsql;

--- a/db/sql/test_startup.sql
+++ b/db/sql/test_startup.sql
@@ -17,4 +17,5 @@ CREATE DATABASE mathesar_testing;
 \ir 45_msar_type_casting.sql
 \ir 46_msar_type_inference.sql
 \ir 50_msar_permissions.sql
+\ir test_permissions_filtering.sql
 \ir test_sql_functions.sql


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4883

<!-- Concisely describe what the pull request does. -->
Add permission filtering for schemas and tables

Filter schemas and tables in list_schemas and get_table_info functions
based on user permissions. Users only see objects they have access to,
determined by explicit privileges, owner role membership, or CREATE
privileges.

This improves security by hiding inaccessible objects from restricted
users. Includes tests for various permission scenarios.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
--Added a new sql test file to separate concerns and avoid continued increase of current one

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Admin
<img width="731" height="195" alt="image" src="https://github.com/user-attachments/assets/c69a32ef-ee44-41f7-a283-b34c635ca28e" />
User with only SELECT on table_1
<img width="726" height="148" alt="image" src="https://github.com/user-attachments/assets/d5b126a2-95ac-434b-b718-3ded69fd865c" />

**Posible/Proposal TODO**
- Granular explorations access, saved on same database to support migrations
- Hiding unneeded tabs and details for users that can't create or non-owner

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.



[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
