### PR TITLE
Fix 1758 constraint validation clean

### DIFF
--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -131,8 +131,6 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
     with connect(database_id, user) as conn:
         con_info = get_constraints_for_table(table_oid, conn)
         return [ConstraintInfo.from_dict(con) for con in con_info]
-
-        
 @mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
@@ -160,8 +158,6 @@ def add(
                             f"Invalid column id: {col}"
                         )
         return create_constraint(table_oid, constraint_def_list, conn)
-
-
 @mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:
     """

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -1,6 +1,10 @@
 """
 Classes and functions exposed to the RPC endpoint for managing table constraints.
 """
+from rest_framework import status
+from mathesar.api.exceptions.generic_exceptions.base_exceptions import MathesarAPIException
+from mathesar.utils.columns import get_column_info_for_table
+
 from typing import Optional, TypedDict, Union
 
 from modernrpc.core import REQUEST_KEY
@@ -129,27 +133,35 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
         con_info = get_constraints_for_table(table_oid, conn)
         return [ConstraintInfo.from_dict(con) for con in con_info]
 
-
 @mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
     table_oid: int,
     constraint_def_list: CreatableConstraintInfo,
-    database_id: int, **kwargs
+    database_id: int,
+    **kwargs
 ) -> list[int]:
     """
-    Add constraint(s) on a table in bulk.
+       Add constraint(s) to a table.
 
-    Args:
-        table_oid: Identity of the table to delete constraint for.
-        constraint_def_list: A list describing the constraints to add.
-        database_id: The Django id of the database containing the table.
-
-    Returns:
-        The oid(s) of all the constraints on the table.
+       Validates that all provided column IDs exist in the target table.
+       If any invalid column ID is passed, returns HTTP 400 instead of 500.
     """
+
     user = kwargs.get(REQUEST_KEY).user
     with connect(database_id, user) as conn:
+
+        valid_cols = {col["id"] for col in get_column_info_for_table(table_oid, conn)}
+
+        for constraint in constraint_def_list:
+            for col in constraint.get("columns", []):
+                if col not in valid_cols:
+                    raise MathesarAPIException(
+                        exception="Invalid column id",
+                        message=f"Invalid column id: {col}",
+                        status_code=status.HTTP_400_BAD_REQUEST
+                    )
+
         return create_constraint(table_oid, constraint_def_list, conn)
 
 

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -4,8 +4,8 @@ Classes and functions exposed to the RPC endpoint for managing table constraints
 from django.http import HttpResponseBadRequest
 from rest_framework import status
 from mathesar.models.base import ColumnMetaData
-
-
+from modernrpc.exceptions import RPCException
+from mathesar.rpc.exceptions.error_codes import mathesar_error_map
 from typing import Optional, TypedDict, Union
 
 from modernrpc.core import REQUEST_KEY
@@ -157,10 +157,9 @@ def add(
                 for col in constraint.get("columns", []):
                     if col not in valid_cols:
                         raise RPCException(
-                            error_codes.get_error_code(Exception),
+                            mathesar_error_map["MathesarAPIException"],
                             f"Invalid column id: {col}"
-                        )
-        
+                        )         
         return create_constraint(table_oid, constraint_def_list, conn)
 
 @mathesar_rpc_method(name="constraints.delete", auth="login")

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -1,9 +1,10 @@
 """
 Classes and functions exposed to the RPC endpoint for managing table constraints.
 """
+from django.http import HttpResponseBadRequest
 from rest_framework import status
-from mathesar.api.exceptions.generic_exceptions.base_exceptions import MathesarAPIException
-from mathesar.utils.columns import get_column_info_for_table
+from mathesar.models.base import ColumnMetaData
+
 
 from typing import Optional, TypedDict, Union
 
@@ -141,29 +142,26 @@ def add(
     database_id: int,
     **kwargs
 ) -> list[int]:
-    """
-       Add constraint(s) to a table.
-
-       Validates that all provided column IDs exist in the target table.
-       If any invalid column ID is passed, returns HTTP 400 instead of 500.
-    """
 
     user = kwargs.get(REQUEST_KEY).user
     with connect(database_id, user) as conn:
 
-        valid_cols = {col["id"] for col in get_column_info_for_table(table_oid, conn)}
+        valid_cols = set(
+            ColumnMetaData.objects.filter(
+                database_id=database_id, table_oid=table_oid
+            ).values_list("attnum", flat=True)
+        )
 
-        for constraint in constraint_def_list:
-            for col in constraint.get("columns", []):
-                if col not in valid_cols:
-                    raise MathesarAPIException(
-                        exception="Invalid column id",
-                        message=f"Invalid column id: {col}",
-                        status_code=status.HTTP_400_BAD_REQUEST
-                    )
-
+        if valid_cols:
+            for constraint in constraint_def_list:
+                for col in constraint.get("columns", []):
+                    if col not in valid_cols:
+                        raise RPCException(
+                            error_codes.get_error_code(Exception),
+                            f"Invalid column id: {col}"
+                        )
+        
         return create_constraint(table_oid, constraint_def_list, conn)
-
 
 @mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -1,8 +1,6 @@
 """
 Classes and functions exposed to the RPC endpoint for managing table constraints.
 """
-from django.http import HttpResponseBadRequest
-from rest_framework import status
 from mathesar.models.base import ColumnMetaData
 from modernrpc.exceptions import RPCException
 from mathesar.rpc.exceptions.error_codes import mathesar_error_map
@@ -134,6 +132,7 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
         con_info = get_constraints_for_table(table_oid, conn)
         return [ConstraintInfo.from_dict(con) for con in con_info]
 
+
 @mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
@@ -161,6 +160,7 @@ def add(
                             f"Invalid column id: {col}"
                         )         
         return create_constraint(table_oid, constraint_def_list, conn)
+
 
 @mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -131,8 +131,6 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
     with connect(database_id, user) as conn:
         con_info = get_constraints_for_table(table_oid, conn)
         return [ConstraintInfo.from_dict(con) for con in con_info]
-
-
 @mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
@@ -158,10 +156,8 @@ def add(
                         raise RPCException(
                             mathesar_error_map["MathesarAPIException"],
                             f"Invalid column id: {col}"
-                        )         
+                        )
         return create_constraint(table_oid, constraint_def_list, conn)
-
-
 @mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:
     """

--- a/mathesar/rpc/constraints.py
+++ b/mathesar/rpc/constraints.py
@@ -131,6 +131,8 @@ def list_(*, table_oid: int, database_id: int, **kwargs) -> list[ConstraintInfo]
     with connect(database_id, user) as conn:
         con_info = get_constraints_for_table(table_oid, conn)
         return [ConstraintInfo.from_dict(con) for con in con_info]
+
+        
 @mathesar_rpc_method(name="constraints.add", auth="login")
 def add(
     *,
@@ -158,6 +160,8 @@ def add(
                             f"Invalid column id: {col}"
                         )
         return create_constraint(table_oid, constraint_def_list, conn)
+
+
 @mathesar_rpc_method(name="constraints.delete", auth="login")
 def delete(*, table_oid: int, constraint_oid: int, database_id: int, **kwargs) -> str:
     """


### PR DESCRIPTION
Fixes #1758

This PR adds validation for column IDs during constraints.add RPC calls.
When an invalid column ID is passed, it raises a clear exception instead of triggering internal server errors.
This improves stability and prevents silent failures while creating constraints.

Technical Details

Retrieved valid column IDs from ColumnMetaData.

Compared incoming columns list with actual table columns.

If a column is invalid, an exception is raised early.

Prevents accidental constraint creation with wrong column references.

Checklist

 Clear PR title and description

 Targets develop branch

 Code tested locally — all tests passing

 Lint completed successfully

 Add/update tests if needed

 No visible UI impact

Developer Certificate of Origin

I certify that this contribution is my own work and I have the right to submit it under the project's license.
