### PR TITLE
Fix path for `.media/` volume

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,7 +12,7 @@
 
 		file_server {
 			precompressed br zstd gzip
-			root {$MEDIA_ROOT:/code/media/}
+			root {$MEDIA_ROOT:/code/.media/}
 		}
 	}
 	handle_path /static/* {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
 
     volumes:
       - ./msar/static:/code/static
-      - ./msar/media:/code/media
+      - ./msar/media:/code/.media
       - ./msar/secrets:/code/.secrets
       # Uncomment the following to mount file_storage.yml and enable
       #  an S3-compliant file storage backend
@@ -257,6 +257,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./msar/media:/code/media
+      - ./msar/media:/code/.media
       - ./msar/static:/code/static
       - ./msar/caddy:/data

--- a/docs/docs/administration/file-backend-config.md
+++ b/docs/docs/administration/file-backend-config.md
@@ -59,7 +59,7 @@ You'll either create a file named `file_storage.yml` or set up the `FILE_STORAGE
       ```diff
       volumes:
        - ./msar/static:/code/static
-       - ./msar/media:/code/media
+       - ./msar/media:/code/.media
       # Uncomment the following to mount file_storage.yml and enable
       #  an S3-compliant file storage backend
       -# - ./file_storage.yml:/code/file_storage.yml

--- a/docs/docs/administration/single-sign-on.md
+++ b/docs/docs/administration/single-sign-on.md
@@ -68,7 +68,7 @@ You'll either create a file named `sso.yml` or set up the `OIDC_CONFIG_DICT` env
     ```diff
      volumes:
        - ./msar/static:/code/static
-       - ./msar/media:/code/media
+       - ./msar/media:/code/.media
      # Uncomment the following to mount sso.yml and enable Single Sign-On (SSO).
     -# - ./sso.yml:/code/sso.yml
     +  - ./sso.yml:/code/sso.yml


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #5089

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
We were mounting `./msar/media` on `/code/media` instead of `/code/.media` which was resulting in user uploaded data files not showing up at `./msar/media` and also causing permission issues for some folks with custom setups.

Within the prod container with `/msar/media:/code/media`(Bad):
```zsh
anish@astra:~/oss/mathesar/msar$ docker exec -it mathesar_service bash
root@2f8b3596122f:/code# ls -lah
total 196K
drwxr-xr-x  1 root root 4.0K Dec  9 16:40 .
drwxr-xr-x  1 root root 4.0K Dec  9 16:39 ..
drwxr-xr-x  2 root root 4.0K Nov 11 19:31 bin
drwxr-xr-x  1 root root 4.0K Dec  9 16:40 config
drwxr-xr-x  1 root root 4.0K Dec  9 16:40 db
-rw-r--r--  1 root root  35K Nov 11 19:27 LICENSE
drwxr-xr-x  2 root root 4.0K Nov 11 19:27 LICENSES
-rwxr-xr-x  1 root root  673 Nov 11 19:27 manage.py
drwxr-xr-x  1 root root 4.0K Dec  9 16:40 mathesar
drwxr-xr-x  1 root root 4.0K Dec  9 16:41 .media
drwxr-xr-x  2 root root 4.0K Dec  9 16:39 media
-rw-r--r--  1 root root  227 Nov 11 19:27 pyproject.toml
-rw-r--r--  1 root root 8.4K Nov 11 19:27 README.md
-rw-r--r--  1 root root  450 Nov 11 19:27 requirements.txt
drwxr-xr-x  2 root root 4.0K Dec  9 16:40 .secrets
drwxr-xr-x  3 root root 4.0K Nov 11 19:27 setup
drwxr-xr-x 10 root root 4.0K Dec  9 16:40 static
-rw-r--r--  1 root root 1.7K Nov 11 19:27 THIRDPARTY
drwxr-xr-x  4 root root 4.0K Nov 11 19:27 translations
-rwxr-xr-x  1 root root  62K Nov 11 19:30 uv-installer.sh
root@2f8b3596122f:/code# ls .media/anish/
display_options_inference.csv  type_inference.csv  <--- Good
root@2f8b3596122f:/code# ls media/  <--- Bad
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
