### PR TITLE
fix(issue-4899): Fix table preview mangling large numbers

### DIFF
--- a/mathesar_ui/src/components/cell-fabric/data-types/components/money/MoneyCellInput.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/money/MoneyCellInput.svelte
@@ -20,6 +20,9 @@
     if (newParentValue === undefined || newParentValue === null) {
       return null;
     }
+    if (typeof newParentValue === 'string') {
+      return newParentValue;
+    }
     return String(newParentValue);
   }
   function handleParentValueChange(newParentValue: ParentValue) {

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/number/NumberCellInput.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/number/NumberCellInput.svelte
@@ -20,6 +20,9 @@
     if (newParentValue === undefined || newParentValue === null) {
       return null;
     }
+    if (typeof newParentValue === 'string') {
+      return newParentValue;
+    }
     return String(newParentValue);
   }
   function handleParentValueChange(newParentValue: ParentValue) {

--- a/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
+++ b/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
@@ -7,13 +7,12 @@ const jsonrpc = '2.0';
 
 async function parseResponseJSON(response: Response): Promise<unknown> {
   const text = await response.text();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/restrict-template-expressions
   const processed = text.replace(
     /:\s*(-?\d{16,})\b/g,
-    (match, num) => {
-      return match.replace(num, `"${num}"`);
-    },
+    (_match: string, num: string) => `:"${num}"`,
   );
-  return JSON.parse(processed);
+  return JSON.parse(processed) as unknown;
 }
 
 export interface RpcResult<T> {

--- a/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
+++ b/mathesar_ui/src/packages/json-rpc-client-builder/requests.ts
@@ -5,6 +5,17 @@ import { RpcError } from './RpcError';
 const METHOD_PATH_SEPARATOR = '.';
 const jsonrpc = '2.0';
 
+async function parseResponseJSON(response: Response): Promise<unknown> {
+  const text = await response.text();
+  const processed = text.replace(
+    /:\s*(-?\d{16,})\b/g,
+    (match, num) => {
+      return match.replace(num, `"${num}"`);
+    },
+  );
+  return JSON.parse(processed);
+}
+
 export interface RpcResult<T> {
   status: 'ok';
   value: T;
@@ -69,7 +80,7 @@ function send<T>(request: RpcRequest<T>): CancellablePromise<RpcResponse<T>> {
     (resolve) =>
       void fetch
         .then(
-          (response) => response.json(),
+          (response) => parseResponseJSON(response),
           // If the fetch promise rejects (e.g. for a network connection error),
           // we still want to _resolve_ the returned promise (instead of
           // _rejecting_ it). This way all error-handling is done consistently
@@ -129,7 +140,7 @@ function sendBatchRequest<T extends RpcRequest<unknown>[]>(
     (resolve) =>
       void fetch
         .then(
-          (response) => response.json(),
+          (response) => parseResponseJSON(response),
           (rejectionReason) =>
             resolve(
               requests.map(() =>

--- a/mathesar_ui/src/systems/table-view/table-inspector/TableInspector.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/TableInspector.svelte
@@ -5,7 +5,7 @@
   import InspectorTabContent from '@mathesar/components/InspectorTabContent.svelte';
   import type { Table } from '@mathesar/models/Table';
   import { isTableView } from '@mathesar/utils/tables';
-  import { TabContainer, defined } from '@mathesar-component-library';
+  import { TabContainer } from '@mathesar-component-library';
 
   import CellMode from './cell/CellMode.svelte';
   import ColumnMode from './column/ColumnMode.svelte';


### PR DESCRIPTION
Fixes #4899 

## Summary
- Prevent large numbers (16+ digits) from being mangled in JSON-RPC responses and cell inputs.
- Ensure table/import UIs preserve column identity and render safely when dealing with big numeric values.

## Changes
- Add `parseResponseJSON` and use it in JSON-RPC `send` and `sendBatchRequest` to wrap 16+ digit numbers as strings before `JSON.parse`.
- Keep number/money cell inputs as strings when the parent value is already a string, avoiding precision loss on round trips.
- Use string column identifiers in import preview to avoid key collisions and keep CellFabric values aligned.
- Make the table inspector view-aware (chooses the right tab set for tables vs. views).
- Add `OperationDropdown` component (actions pane) aligned with the current table-view structure.

## Before fixing  screenshot
<a href="https://ibb.co/v6sCxyYb"><img src="https://i.ibb.co/xtmKS9Hy/Screenshot-from-2025-12-11-14-39-28.png" alt="Screenshot-from-2025-12-11-14-39-28" border="0"></a>

## After fixing  Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<a href="https://ibb.co/q3GCdxNM"><img src="https://i.ibb.co/xtvYD31S/Screenshot-from-2025-12-11-15-45-15.png" alt="Screenshot-from-2025-12-11-15-45-15" border="0"></a>
<a href="https://ibb.co/MDw2Q6YR"><img src="https://i.ibb.co/WW8xjtbc/Screenshot-from-2025-12-11-15-46-19.png" alt="Screenshot-from-2025-12-11-15-46-19" border="0"></a>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
