### PR TITLE
Improve UX for long table and column descriptions

### DIFF
--- a/mathesar_ui/src/components/EditableTextWithActions.svelte
+++ b/mathesar_ui/src/components/EditableTextWithActions.svelte
@@ -10,9 +10,11 @@
   import { getErrorMessage } from '@mathesar/utils/errors';
   import {
     CancelOrProceedButtonPair,
-    TextArea,
     TextInput,
   } from '@mathesar-component-library';
+
+  // NEW — import growable textarea
+  import GrowableTextArea from '@mathesar/components/GrowableTextArea.svelte';
 
   export let initialValue = '';
   export let onSubmit: (value: string) => Promise<void>;
@@ -24,10 +26,13 @@
   let value = '';
   let isSubmitting = false;
 
+  // Dynamic component choice
+  // OLD: TextArea → remove since GrowableTextArea replaces it
+  $: inputElement = isLongText ? GrowableTextArea : TextInput;
+
   $: validationErrors =
     value === initialValue ? [] : getValidationErrors(value);
   $: canSave = validationErrors.length === 0 && value !== initialValue;
-  $: inputElement = isLongText ? TextArea : TextInput;
 
   function makeEditable() {
     value = initialValue;
@@ -69,11 +74,13 @@
         autofocus
         bind:value
       />
+
       {#if validationErrors.length}
         {#each validationErrors as error}
           <span class="error">{error}</span>
         {/each}
       {/if}
+
       <CancelOrProceedButtonPair
         onProceed={handleSave}
         onCancel={handleCancel}

--- a/mathesar_ui/src/components/EditableTextWithActions.svelte
+++ b/mathesar_ui/src/components/EditableTextWithActions.svelte
@@ -6,15 +6,13 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n';
 
+  import GrowableTextArea from '@mathesar/components/GrowableTextArea.svelte';
   import { toast } from '@mathesar/stores/toast';
   import { getErrorMessage } from '@mathesar/utils/errors';
   import {
     CancelOrProceedButtonPair,
     TextInput,
   } from '@mathesar-component-library';
-
-  // NEW — import growable textarea
-  import GrowableTextArea from '@mathesar/components/GrowableTextArea.svelte';
 
   export let initialValue = '';
   export let onSubmit: (value: string) => Promise<void>;
@@ -26,8 +24,6 @@
   let value = '';
   let isSubmitting = false;
 
-  // Dynamic component choice
-  // OLD: TextArea → remove since GrowableTextArea replaces it
   $: inputElement = isLongText ? GrowableTextArea : TextInput;
 
   $: validationErrors =


### PR DESCRIPTION
# Improve UX for long table and column descriptions

Fixes #4720

This PR improves the user experience when editing long table and column descriptions by introducing an auto-expanding textarea in the description editor. This makes the behavior consistent with the growable textareas already used on the record page.

## Technical details

### Problem

The previous description input UX had several issues:

* The textarea **did not auto-expand** when typing long content.
* Manually resized textareas would **reset their height** when clicked again.
* Editing long descriptions felt clunky and unintuitive.
* This inconsistency was noted by maintainers, who highlighted that the record page already uses an auto-growing component.

### Fix

To resolve these issues:

* Replaced the static `TextArea` with the shared `GrowableTextArea` component.
* Ensures that textareas automatically grow up to a capped height while typing.
* Prevents height resets when focusing or interacting with the field.
* Keeps cursor placement stable, even when clicking deep inside long text.

### Behavior Changes

* Description fields now **auto-grow smoothly** while typing.
* The textarea's height remains consistent during editing.
* Cursor positioning is no longer disrupted.
* Editing long descriptions is significantly more user-friendly.
* No change to the behavior of short or single-line fields.

### Files touched

* `mathesar_ui/src/components/EditableTextWithActions.svelte`

### UX Demo (Before / After)
https://github.com/user-attachments/assets/4ecf7236-46bf-48c1-9b30-a7aec4071e6b

---

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>