### PR TITLE
Remove explorations.run_saved API from front end

### DIFF
--- a/mathesar_ui/package-lock.json
+++ b/mathesar_ui/package-lock.json
@@ -72,7 +72,6 @@
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -87,7 +86,6 @@
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -177,7 +175,6 @@
       "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -188,7 +185,6 @@
       "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -220,7 +216,6 @@
       "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -241,7 +236,6 @@
       "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.19.0",
@@ -257,7 +251,6 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -271,7 +264,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -282,7 +274,6 @@
       "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -299,7 +290,6 @@
       "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
         "@babel/helper-validator-option": "^7.22.15",
@@ -317,7 +307,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -328,7 +317,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -338,8 +326,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
@@ -347,7 +334,6 @@
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -358,7 +344,6 @@
       "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
@@ -373,7 +358,6 @@
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -387,7 +371,6 @@
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -401,7 +384,6 @@
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -415,7 +397,6 @@
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -429,7 +410,6 @@
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -449,7 +429,6 @@
       "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -536,7 +515,6 @@
       "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -567,7 +545,6 @@
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -583,7 +560,6 @@
       "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
@@ -606,7 +582,6 @@
       "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.19",
@@ -1778,6 +1753,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
       "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/types": "5.38.0",
@@ -2654,40 +2630,6 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
-    "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -2764,8 +2706,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -2905,7 +2846,6 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -3275,8 +3215,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
       "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -3841,7 +3780,6 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3952,6 +3890,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
       "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -4281,6 +4220,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -4757,6 +4697,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5112,7 +5053,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5229,7 +5169,6 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6102,7 +6041,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6398,8 +6336,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6632,6 +6569,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -6745,6 +6683,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
       "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7036,8 +6975,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -7103,6 +7041,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
       "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -7408,6 +7347,7 @@
       "version": "3.50.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
       "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -7722,6 +7662,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
       "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -7825,7 +7766,6 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8011,6 +7951,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8063,7 +8004,6 @@
         }
       ],
       "optional": true,
-      "peer": true,
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -8080,8 +8020,7 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -8113,6 +8052,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
       "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.6",
         "postcss": "^8.4.16",

--- a/mathesar_ui/package-lock.json
+++ b/mathesar_ui/package-lock.json
@@ -72,6 +72,7 @@
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -86,6 +87,7 @@
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -175,6 +177,7 @@
       "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -185,6 +188,7 @@
       "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -216,6 +220,7 @@
       "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -236,6 +241,7 @@
       "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.19.0",
@@ -251,6 +257,7 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -264,6 +271,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -274,6 +282,7 @@
       "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -290,6 +299,7 @@
       "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
         "@babel/helper-validator-option": "^7.22.15",
@@ -307,6 +317,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -317,6 +328,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -326,7 +338,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
@@ -334,6 +347,7 @@
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -344,6 +358,7 @@
       "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
@@ -358,6 +373,7 @@
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -371,6 +387,7 @@
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -384,6 +401,7 @@
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -397,6 +415,7 @@
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -410,6 +429,7 @@
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -429,6 +449,7 @@
       "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -515,6 +536,7 @@
       "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -545,6 +567,7 @@
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -560,6 +583,7 @@
       "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
@@ -582,6 +606,7 @@
       "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.19",
@@ -1753,7 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
       "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/types": "5.38.0",
@@ -2630,6 +2654,40 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "node_modules/browserslist": {
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -2706,7 +2764,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -2846,6 +2905,7 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -3215,7 +3275,8 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
       "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -3780,6 +3841,7 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3890,7 +3952,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
       "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -4220,7 +4281,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -4697,7 +4757,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5053,6 +5112,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5169,6 +5229,7 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6041,6 +6102,7 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6336,7 +6398,8 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6569,7 +6632,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -6683,7 +6745,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
       "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6975,7 +7036,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -7041,7 +7103,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
       "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -7347,7 +7408,6 @@
       "version": "3.50.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
       "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -7662,7 +7722,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
       "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -7766,6 +7825,7 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7951,7 +8011,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8004,6 +8063,7 @@
         }
       ],
       "optional": true,
+      "peer": true,
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -8020,7 +8080,8 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -8052,7 +8113,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
       "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.6",
         "postcss": "^8.4.16",

--- a/mathesar_ui/src/api/rpc/explorations.ts
+++ b/mathesar_ui/src/api/rpc/explorations.ts
@@ -159,11 +159,11 @@ export interface QueryGeneratedColumnSource {
 
 interface QueryInitialColumnMetaData
   extends QueryResultColumn,
-  QueryInitialColumnSource { }
+    QueryInitialColumnSource {}
 
 interface QueryVirtualColumnMetaData
   extends QueryResultColumn,
-  QueryGeneratedColumnSource { }
+    QueryGeneratedColumnSource {}
 
 export type QueryColumnMetaData =
   | QueryInitialColumnMetaData
@@ -213,5 +213,4 @@ export const explorations = {
   >(),
 
   run: rpcMethodTypeContainer<ExplorationRunParams, ExplorationResult>(),
-
 };

--- a/mathesar_ui/src/api/rpc/explorations.ts
+++ b/mathesar_ui/src/api/rpc/explorations.ts
@@ -159,11 +159,11 @@ export interface QueryGeneratedColumnSource {
 
 interface QueryInitialColumnMetaData
   extends QueryResultColumn,
-    QueryInitialColumnSource {}
+  QueryInitialColumnSource { }
 
 interface QueryVirtualColumnMetaData
   extends QueryResultColumn,
-    QueryGeneratedColumnSource {}
+  QueryGeneratedColumnSource { }
 
 export type QueryColumnMetaData =
   | QueryInitialColumnMetaData
@@ -214,12 +214,4 @@ export const explorations = {
 
   run: rpcMethodTypeContainer<ExplorationRunParams, ExplorationResult>(),
 
-  run_saved: rpcMethodTypeContainer<
-    {
-      exploration_id: number;
-      limit: number;
-      offset: number;
-    },
-    ExplorationResult
-  >(),
 };

--- a/mathesar_ui/src/stores/queries.ts
+++ b/mathesar_ui/src/stores/queries.ts
@@ -38,7 +38,6 @@ import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
 import { api } from '@mathesar/api/rpc';
 import type {
   AddableExploration,
-  ExplorationResult,
   SavedExploration,
 } from '@mathesar/api/rpc/explorations';
 import type { Database } from '@mathesar/models/Database';
@@ -202,22 +201,6 @@ export function getExploration(
   id: SavedExploration['id'],
 ): CancellablePromise<SavedExploration> {
   return api.explorations.get({ exploration_id: id }).run();
-}
-
-export function runSavedExploration(
-  id: number,
-  params: {
-    limit: number;
-    offset: number;
-  },
-): CancellablePromise<ExplorationResult> {
-  return api.explorations
-    .run_saved({
-      exploration_id: id,
-      limit: params.limit,
-      offset: params.offset,
-    })
-    .run();
 }
 
 export function deleteExploration(id: number): CancellablePromise<void> {

--- a/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
@@ -17,7 +17,6 @@ import type {
 import Plane from '@mathesar/components/sheet/selection/Plane';
 import Series from '@mathesar/components/sheet/selection/Series';
 import SheetSelectionStore from '@mathesar/components/sheet/selection/SheetSelectionStore';
-import { runSavedExploration } from '@mathesar/stores/queries';
 import Pagination from '@mathesar/utils/Pagination';
 import {
   type CancellablePromise,
@@ -49,8 +48,6 @@ export interface QueryRowsData {
   rows: QueryRow[];
 }
 
-type QueryRunMode = 'queryId' | 'queryObject';
-
 export class QueryRunner {
   query: Writable<QueryModel>;
 
@@ -78,16 +75,11 @@ export class QueryRunner {
 
   private runPromise: CancellablePromise<ExplorationResult> | undefined;
 
-  private runMode: QueryRunMode;
-
   constructor({
     query,
-    runMode,
   }: {
     query: QueryModel;
-    runMode?: QueryRunMode;
   }) {
-    this.runMode = runMode ?? 'queryObject';
     this.query = writable(query);
     this.speculateProcessedColumns();
     void this.run();
@@ -151,30 +143,15 @@ export class QueryRunner {
     try {
       const paginationParams = get(this.pagination).recordsRequestParams();
       this.runState.set({ state: 'processing' });
-      if (this.runMode === 'queryObject') {
-        const internalRunPromise = api.explorations
-          .run({
-            exploration_def: queryModel.toAnonymousExploration(),
-            ...paginationParams,
-          })
-          .run();
-        this.runPromise = internalRunPromise;
-        const internalResponse = await internalRunPromise;
-        response = internalResponse;
-      } else {
-        const queryId = queryModel.id;
-        if (!queryId) {
-          this.runState.set({
-            state: 'failure',
-            errors: ['Query does not contain an id'],
-          });
-          return undefined;
-        }
-        this.runPromise = runSavedExploration(queryModel.id, {
+      const internalRunPromise = api.explorations
+        .run({
+          exploration_def: queryModel.toAnonymousExploration(),
           ...paginationParams,
-        });
-        response = await this.runPromise;
-      }
+        })
+        .run();
+      this.runPromise = internalRunPromise;
+      const internalResponse = await internalRunPromise;
+      response = internalResponse;
 
       const columnsMetaData = processColumnMetaData(response.column_metadata);
       this.columnsMetaData.set(columnsMetaData);

--- a/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryRunner.ts
@@ -75,11 +75,7 @@ export class QueryRunner {
 
   private runPromise: CancellablePromise<ExplorationResult> | undefined;
 
-  constructor({
-    query,
-  }: {
-    query: QueryModel;
-  }) {
+  constructor({ query }: { query: QueryModel }) {
     this.query = writable(query);
     this.speculateProcessedColumns();
     void this.run();


### PR DESCRIPTION
This PR removes the deprecated `explorations.run_saved` API from the frontend and cleans up the associated dead code in [QueryRunner.ts](cci:7://file:///s:/Front-end/mathesar_ui/src/systems/data-explorer/QueryRunner.ts:0:0-0:0).

No user-facing behavior changes remain, as the removed execution path was unreachable.

## Changes

### 1. API Removal
- Removed `run_saved` from the `explorations` RPC definition in [mathesar_ui/src/api/rpc/explorations.ts](cci:7://file:///s:/Front-end/mathesar_ui/src/api/rpc/explorations.ts:0:0-0:0).
- Removed `runSavedExploration` helper function from [mathesar_ui/src/stores/queries.ts](cci:7://file:///s:/Front-end/mathesar_ui/src/stores/queries.ts:0:0-0:0).

### 2. QueryRunner Cleanup
- Modified [mathesar_ui/src/systems/data-explorer/QueryRunner.ts](cci:7://file:///s:/Front-end/mathesar_ui/src/systems/data-explorer/QueryRunner.ts:0:0-0:0):
    - Removed `runMode` property and constructor argument.
    - Removed logic branching for `runMode === 'queryId'`.
    - Removed `QueryRunMode` type definition.

## Verification Results

### Automated Tests
- **Type Check**: Ran `npm run typecheck` successfully (Exit Code 0).
- **Linting**: Ran `eslint` on modified files, passing with Exit Code 0.

### Usage Verification
- Confirmed that [QueryRunner](cci:2://file:///s:/Front-end/mathesar_ui/src/systems/data-explorer/QueryRunner.ts:50:0-243:1) is now only instantiated with the default behavior.
- Confirmed that `run_saved` is no longer referenced in the `mathesar_ui` codebase.

## Safety Considerations
This frontend cleanup aligns with backend removal of `explorations.run_saved` in #4468.
Usage of `runMode: 'queryId'` was verified to be zero across the codebase.
