### PR TITLE
Fixed the trucation issue

### DIFF
--- a/db/identifiers.py
+++ b/db/identifiers.py
@@ -33,13 +33,8 @@ def truncate_if_necessary(identifier):
 
 
 def is_identifier_too_long(identifier):
-    # TODO we should support POSTGRES_IDENTIFIER_SIZE_LIMIT here;
-    # Our current limit due to an unknown bug that manifests at least
-    # when importing CSVs seems to be 57 bytes. Here we're setting it even
-    # lower just in case.
-    our_temporary_identifier_size_limit = 48
     size = _get_size_of_identifier_in_bytes(identifier)
-    return size > our_temporary_identifier_size_limit
+    return size > POSTGRES_IDENTIFIER_SIZE_LIMIT
 
 
 def _get_truncation_hash(identifier):


### PR DESCRIPTION
## Fixes #5132 

Fixes identifier truncation by increasing the limit from 48 to 63 bytes (PostgreSQL standard) for CSV imports, paste, and direct text entry.

## Technical details

Updated **is_identifier_too_long()** in **identifiers.py** to use the **POSTGRES_IDENTIFIER_SIZE_LIMIT constant (63 bytes)** instead of the temporary 48-byte workaround. This aligns import pipeline validation with PostgreSQL's actual NAMEDATALEN - 1 limit and matches the behavior already present in rename operations.

## Screenshots
- Before
<img width="1668" height="829" alt="Screenshot From 2025-12-18 22-07-40" src="https://github.com/user-attachments/assets/c0a7f43f-ea04-4cfe-b46f-80e006ca1fa9" />

- After
<img width="2990" height="1570" alt="Software Table Import Interface" src="https://github.com/user-attachments/assets/b9238104-0e15-4814-a090-ace8d5a460df" />

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
