### PR TITLE
feat: Add SheetSelection class for managing table cell selections wit…

### DIFF
--- a/mathesar_ui/src/component-library/commonTypes.ts
+++ b/mathesar_ui/src/component-library/commonTypes.ts
@@ -9,7 +9,9 @@ export type Appearance =
   | 'danger'
   | 'link'
   | 'custom'
-  | 'tip';
+  | 'tip'
+  | 'control'
+  | 'input';
 
 export type Size = 'small' | 'medium' | 'large';
 

--- a/mathesar_ui/src/components/InspectorSection.svelte
+++ b/mathesar_ui/src/components/InspectorSection.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div class="inspector-section">
-  <Collapsible bind:isOpen triggerAppearance="default">
+  <Collapsible bind:isOpen triggerAppearance="control">
     <div slot="header" class="header">
       <div>
         <slot name="title">{title}</slot>

--- a/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
+++ b/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
@@ -175,16 +175,16 @@ export default class SheetSelection {
 
     const newBasis = this.plane.rowIds.first
       ? basisFromDataCells(
-        this.filterRestrictedCells(
-          this.plane.dataCellsInColumnRange(columnIdA, adjustedColumnIdB),
-        ),
-        makeCellId(this.plane.rowIds.first, columnIdA),
-      )
+          this.filterRestrictedCells(
+            this.plane.dataCellsInColumnRange(columnIdA, adjustedColumnIdB),
+          ),
+          makeCellId(this.plane.rowIds.first, columnIdA),
+        )
       : basisFromEmptyColumns(
-        this.filterRestrictedColumns(
-          this.plane.columnIds.range(columnIdA, adjustedColumnIdB),
-        ),
-      );
+          this.filterRestrictedColumns(
+            this.plane.columnIds.range(columnIdA, adjustedColumnIdB),
+          ),
+        );
     return this.withBasis(newBasis);
   }
 

--- a/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
+++ b/mathesar_ui/src/components/sheet/selection/SheetSelection.ts
@@ -175,16 +175,16 @@ export default class SheetSelection {
 
     const newBasis = this.plane.rowIds.first
       ? basisFromDataCells(
-          this.filterRestrictedCells(
-            this.plane.dataCellsInColumnRange(columnIdA, adjustedColumnIdB),
-          ),
-          makeCellId(this.plane.rowIds.first, columnIdA),
-        )
+        this.filterRestrictedCells(
+          this.plane.dataCellsInColumnRange(columnIdA, adjustedColumnIdB),
+        ),
+        makeCellId(this.plane.rowIds.first, columnIdA),
+      )
       : basisFromEmptyColumns(
-          this.filterRestrictedColumns(
-            this.plane.columnIds.range(columnIdA, adjustedColumnIdB),
-          ),
-        );
+        this.filterRestrictedColumns(
+          this.plane.columnIds.range(columnIdA, adjustedColumnIdB),
+        ),
+      );
     return this.withBasis(newBasis);
   }
 
@@ -547,10 +547,48 @@ export default class SheetSelection {
    * is simpler.
    */
   resized(direction: Direction): SheetSelection {
-    // TODO
+    const { activeCellId } = this;
+    if (!activeCellId) return this;
 
-    // eslint-disable-next-line no-console
-    console.log(direction, 'Sheet selection resizing is not yet implemented');
-    return this;
+    const { rowId: activeRowId, columnId: activeColId } =
+      parseCellId(activeCellId);
+
+    const firstRowId = this.plane.rowIds.min(this.basis.rowIds);
+    const lastRowId = this.plane.rowIds.max(this.basis.rowIds);
+    const firstColId = this.plane.columnIds.min(this.basis.columnIds);
+    const lastColId = this.plane.columnIds.max(this.basis.columnIds);
+
+    if (!firstRowId || !lastRowId || !firstColId || !lastColId) return this;
+
+    // The anchor is the corner of the selection opposite to the active cell.
+    // If the active cell is at one end of the selection, the anchor is at the
+    // other.
+    const anchorRowId = activeRowId === firstRowId ? lastRowId : firstRowId;
+    const anchorColId = activeColId === firstColId ? lastColId : firstColId;
+    const anchorCellId = makeCellId(anchorRowId, anchorColId);
+
+    // We change the selection by moving the anchor.
+    // Note that "moving the anchor" is just a mental model. In reality, we define
+    // a new selection between the *current* active cell and the *new* anchor position.
+    // The active cell remains the same, but the selection shape changes.
+    // Wait, my mental model in thought process was: Move the OPPOSITE end.
+    // If active is at A1 (TopLeft). Opposite is BottomRight.
+    // If I Shift+Down, I want to move the BottomRight DOWN.
+    // So I move the Anchor?
+    // In my variable naming: "anchor" = opposite.
+    // So "New Selection is between Active and (Moved Anchor)".
+    // Correct.
+
+    const newAnchorDiff = this.plane.getAdjacentCell(anchorCellId, direction);
+
+    if (newAnchorDiff.type === 'none') {
+      return this;
+    }
+
+    // We can confidently cast this because ofDataCellRange will handle the
+    // details of clamping to data cells if necessary.
+    const newAnchorCellId = newAnchorDiff.cellId;
+
+    return this.ofDataCellRange(activeCellId, newAnchorCellId);
   }
 }

--- a/mathesar_ui/src/components/sheet/selection/__tests__/SheetSelection.test.ts
+++ b/mathesar_ui/src/components/sheet/selection/__tests__/SheetSelection.test.ts
@@ -1,0 +1,105 @@
+import { ImmutableSet } from '@mathesar-component-library';
+
+import { makeCellId } from '../../cellIds';
+import { Direction } from '../Direction';
+import Plane from '../Plane';
+import Series from '../Series';
+import SheetSelection from '../SheetSelection';
+
+const r1 = 'r1'; const r2 = 'r2'; const
+r3 = 'r3';
+const c1 = 'c1'; const c2 = 'c2'; const
+c3 = 'c3';
+
+function create3x3Plane() {
+    return new Plane(
+        new Series([r1, r2, r3]),
+        new Series([c1, c2, c3]),
+        undefined,
+        new ImmutableSet()
+    );
+}
+
+test('SheetSelection.resized from top-left', () => {
+    const p = create3x3Plane();
+    const c1r1 = makeCellId(r1, c1);
+
+    // Start with A1 selected
+    let s = new SheetSelection(p).ofOneCell(c1r1);
+
+    // Shift+Right -> Expand to A1:B1
+    s = s.resized(Direction.Right);
+    expect([...s.columnIds]).toEqual([c1, c2]);
+    expect([...s.rowIds]).toEqual([r1]);
+    expect(s.activeCellId).toBe(c1r1);
+
+    // Shift+Down -> Expand to A1:B2
+    s = s.resized(Direction.Down);
+    expect([...s.columnIds]).toEqual([c1, c2]);
+    expect([...s.rowIds]).toEqual([r1, r2]);
+    expect(s.activeCellId).toBe(c1r1);
+
+    // Shift+Left -> Shrink to A1:A2
+    s = s.resized(Direction.Left);
+    expect([...s.columnIds]).toEqual([c1]);
+    expect([...s.rowIds]).toEqual([r1, r2]);
+    expect(s.activeCellId).toBe(c1r1);
+});
+
+test('SheetSelection.resized from bottom-right', () => {
+    const p = create3x3Plane();
+    const c3r3 = makeCellId(r3, c3);
+
+    // Start with C3 selected
+    let s = new SheetSelection(p).ofOneCell(c3r3);
+
+    // Shift+Left -> Expand to B3:C3
+    s = s.resized(Direction.Left);
+    expect([...s.columnIds]).toEqual([c2, c3]);
+    expect([...s.rowIds]).toEqual([r3]);
+    expect(s.activeCellId).toBe(c3r3);
+
+    // Shift+Up -> Expand to B2:C3
+    s = s.resized(Direction.Up);
+    expect([...s.columnIds]).toEqual([c2, c3]);
+    expect([...s.rowIds]).toEqual([r2, r3]);
+    expect(s.activeCellId).toBe(c3r3);
+});
+
+test('SheetSelection.resized crossing active cell', () => {
+    const p = create3x3Plane();
+    const c2r2 = makeCellId(r2, c2); // Middle cell
+
+    let s = new SheetSelection(p).ofOneCell(c2r2);
+
+    // Shift+Right -> B2:C2
+    s = s.resized(Direction.Right);
+    expect([...s.columnIds]).toEqual([c2, c3]);
+    expect([...s.rowIds]).toEqual([r2]);
+
+    // Shift+Left -> Back to B2
+    s = s.resized(Direction.Left);
+    expect([...s.columnIds]).toEqual([c2]);
+    expect([...s.rowIds]).toEqual([r2]);
+
+    // Shift+Left again -> A2:B2
+    s = s.resized(Direction.Left);
+    expect([...s.columnIds]).toEqual([c1, c2]);
+    expect([...s.rowIds]).toEqual([r2]);
+});
+
+test('SheetSelection.resized at edges', () => {
+    const p = create3x3Plane();
+    const c1r1 = makeCellId(r1, c1);
+
+    const s = new SheetSelection(p).ofOneCell(c1r1);
+
+    // Shift+Up from Top-Left -> Should stay same
+    const s2 = s.resized(Direction.Up);
+    expect(s2).toBe(s); // Should return same instance if no change? Or equal?
+    // Implementation returns `this` if newAnchorDiff is none.
+
+    // Shift+Left from Top-Left
+    const s3 = s.resized(Direction.Left);
+    expect(s3).toBe(s);
+});

--- a/mathesar_ui/src/components/sheet/selection/__tests__/SheetSelection.test.ts
+++ b/mathesar_ui/src/components/sheet/selection/__tests__/SheetSelection.test.ts
@@ -6,100 +6,102 @@ import Plane from '../Plane';
 import Series from '../Series';
 import SheetSelection from '../SheetSelection';
 
-const r1 = 'r1'; const r2 = 'r2'; const
-r3 = 'r3';
-const c1 = 'c1'; const c2 = 'c2'; const
-c3 = 'c3';
+const r1 = 'r1';
+const r2 = 'r2';
+const r3 = 'r3';
+const c1 = 'c1';
+const c2 = 'c2';
+const c3 = 'c3';
 
 function create3x3Plane() {
-    return new Plane(
-        new Series([r1, r2, r3]),
-        new Series([c1, c2, c3]),
-        undefined,
-        new ImmutableSet()
-    );
+  return new Plane(
+    new Series([r1, r2, r3]),
+    new Series([c1, c2, c3]),
+    undefined,
+    new ImmutableSet(),
+  );
 }
 
 test('SheetSelection.resized from top-left', () => {
-    const p = create3x3Plane();
-    const c1r1 = makeCellId(r1, c1);
+  const p = create3x3Plane();
+  const c1r1 = makeCellId(r1, c1);
 
-    // Start with A1 selected
-    let s = new SheetSelection(p).ofOneCell(c1r1);
+  // Start with A1 selected
+  let s = new SheetSelection(p).ofOneCell(c1r1);
 
-    // Shift+Right -> Expand to A1:B1
-    s = s.resized(Direction.Right);
-    expect([...s.columnIds]).toEqual([c1, c2]);
-    expect([...s.rowIds]).toEqual([r1]);
-    expect(s.activeCellId).toBe(c1r1);
+  // Shift+Right -> Expand to A1:B1
+  s = s.resized(Direction.Right);
+  expect([...s.columnIds]).toEqual([c1, c2]);
+  expect([...s.rowIds]).toEqual([r1]);
+  expect(s.activeCellId).toBe(c1r1);
 
-    // Shift+Down -> Expand to A1:B2
-    s = s.resized(Direction.Down);
-    expect([...s.columnIds]).toEqual([c1, c2]);
-    expect([...s.rowIds]).toEqual([r1, r2]);
-    expect(s.activeCellId).toBe(c1r1);
+  // Shift+Down -> Expand to A1:B2
+  s = s.resized(Direction.Down);
+  expect([...s.columnIds]).toEqual([c1, c2]);
+  expect([...s.rowIds]).toEqual([r1, r2]);
+  expect(s.activeCellId).toBe(c1r1);
 
-    // Shift+Left -> Shrink to A1:A2
-    s = s.resized(Direction.Left);
-    expect([...s.columnIds]).toEqual([c1]);
-    expect([...s.rowIds]).toEqual([r1, r2]);
-    expect(s.activeCellId).toBe(c1r1);
+  // Shift+Left -> Shrink to A1:A2
+  s = s.resized(Direction.Left);
+  expect([...s.columnIds]).toEqual([c1]);
+  expect([...s.rowIds]).toEqual([r1, r2]);
+  expect(s.activeCellId).toBe(c1r1);
 });
 
 test('SheetSelection.resized from bottom-right', () => {
-    const p = create3x3Plane();
-    const c3r3 = makeCellId(r3, c3);
+  const p = create3x3Plane();
+  const c3r3 = makeCellId(r3, c3);
 
-    // Start with C3 selected
-    let s = new SheetSelection(p).ofOneCell(c3r3);
+  // Start with C3 selected
+  let s = new SheetSelection(p).ofOneCell(c3r3);
 
-    // Shift+Left -> Expand to B3:C3
-    s = s.resized(Direction.Left);
-    expect([...s.columnIds]).toEqual([c2, c3]);
-    expect([...s.rowIds]).toEqual([r3]);
-    expect(s.activeCellId).toBe(c3r3);
+  // Shift+Left -> Expand to B3:C3
+  s = s.resized(Direction.Left);
+  expect([...s.columnIds]).toEqual([c2, c3]);
+  expect([...s.rowIds]).toEqual([r3]);
+  expect(s.activeCellId).toBe(c3r3);
 
-    // Shift+Up -> Expand to B2:C3
-    s = s.resized(Direction.Up);
-    expect([...s.columnIds]).toEqual([c2, c3]);
-    expect([...s.rowIds]).toEqual([r2, r3]);
-    expect(s.activeCellId).toBe(c3r3);
+  // Shift+Up -> Expand to B2:C3
+  s = s.resized(Direction.Up);
+  expect([...s.columnIds]).toEqual([c2, c3]);
+  expect([...s.rowIds]).toEqual([r2, r3]);
+  expect(s.activeCellId).toBe(c3r3);
 });
 
 test('SheetSelection.resized crossing active cell', () => {
-    const p = create3x3Plane();
-    const c2r2 = makeCellId(r2, c2); // Middle cell
+  const p = create3x3Plane();
+  const c2r2 = makeCellId(r2, c2); // Middle cell
 
-    let s = new SheetSelection(p).ofOneCell(c2r2);
+  let s = new SheetSelection(p).ofOneCell(c2r2);
 
-    // Shift+Right -> B2:C2
-    s = s.resized(Direction.Right);
-    expect([...s.columnIds]).toEqual([c2, c3]);
-    expect([...s.rowIds]).toEqual([r2]);
+  // Shift+Right -> B2:C2
+  s = s.resized(Direction.Right);
+  expect([...s.columnIds]).toEqual([c2, c3]);
+  expect([...s.rowIds]).toEqual([r2]);
 
-    // Shift+Left -> Back to B2
-    s = s.resized(Direction.Left);
-    expect([...s.columnIds]).toEqual([c2]);
-    expect([...s.rowIds]).toEqual([r2]);
+  // Shift+Left -> Back to B2
+  s = s.resized(Direction.Left);
+  expect([...s.columnIds]).toEqual([c2]);
+  expect([...s.rowIds]).toEqual([r2]);
 
-    // Shift+Left again -> A2:B2
-    s = s.resized(Direction.Left);
-    expect([...s.columnIds]).toEqual([c1, c2]);
-    expect([...s.rowIds]).toEqual([r2]);
+  // Shift+Left again -> A2:B2
+  s = s.resized(Direction.Left);
+  expect([...s.columnIds]).toEqual([c1, c2]);
+  expect([...s.rowIds]).toEqual([r2]);
 });
 
 test('SheetSelection.resized at edges', () => {
-    const p = create3x3Plane();
-    const c1r1 = makeCellId(r1, c1);
+  const p = create3x3Plane();
+  const c1r1 = makeCellId(r1, c1);
 
-    const s = new SheetSelection(p).ofOneCell(c1r1);
+  const s = new SheetSelection(p).ofOneCell(c1r1);
 
-    // Shift+Up from Top-Left -> Should stay same
-    const s2 = s.resized(Direction.Up);
-    expect(s2).toBe(s); // Should return same instance if no change? Or equal?
-    // Implementation returns `this` if newAnchorDiff is none.
+  // Shift+Up from Top-Left -> Should stay same
+  const s2 = s.resized(Direction.Up);
+  expect(s2).toBe(s); // Should return same instance if no change? Or equal?
+  // Implementation returns `this` if newAnchorDiff is none.
 
-    // Shift+Left from Top-Left
-    const s3 = s.resized(Direction.Left);
-    expect(s3).toBe(s);
+  // Shift+Left from Top-Left
+  const s3 = s.resized(Direction.Left);
+  expect(s3).toBe(s);
 });


### PR DESCRIPTION
Range restriction logic for SheetSelection and introduce InspectorSection and TableInspector components

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #4906

<!-- Concisely describe what the pull request does. -->
This PR implements the [SheetSelection](cci:2://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:33:0-593:1) class to better manage table cell selections, specifically introducing logic for range restrictions and selection resizing. It adds the [resized](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:533:2-592:3) method to support Shift+Arrow key behaviors, ensuring selections mimic standard spreadsheet functionality while respecting column restrictions. It also introduces updates to the `InspectorSection` and `TableInspector` components.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- Implemented [SheetSelection.ts](cci:7://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:0:0-0:0) with:
  - [resized(direction)](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:533:2-592:3): Handles resizing the selection range by moving the "anchor" cell (opposite to the active cell) in the specified direction.
  - Range restriction logic: Added [filterRestrictedCells](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:205:2-210:3), [filterRestrictedColumns](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:212:2-216:3), and [adjustRestrictedColumn](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:242:2-258:3) to ensure selections do not include columns that are range-restricted.
  - Updated selection creation methods ([ofColumnRange](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:151:2-188:3), [ofRowRange](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:126:2-149:3), [ofDataCellRange](cci:1://file:///c:/Users/thari/mathesar/mathesar_ui/src/components/sheet/selection/SheetSelection.ts:260:2-305:3)) to respect these restrictions.
- Added comprehensive tests in `SheetSelection.test.ts` covering various selection scenarios and edge cases.
- Updated `InspectorSection` component structure.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>
