### PR TITLE
Remove explorations.run_saved API from frontend

### DIFF
--- a/mathesar_ui/src/api/rpc/explorations.ts
+++ b/mathesar_ui/src/api/rpc/explorations.ts
@@ -213,13 +213,4 @@ export const explorations = {
   >(),
 
   run: rpcMethodTypeContainer<ExplorationRunParams, ExplorationResult>(),
-
-  run_saved: rpcMethodTypeContainer<
-    {
-      exploration_id: number;
-      limit: number;
-      offset: number;
-    },
-    ExplorationResult
-  >(),
 };

--- a/mathesar_ui/src/stores/queries.ts
+++ b/mathesar_ui/src/stores/queries.ts
@@ -38,7 +38,6 @@ import type { RequestStatus } from '@mathesar/api/rest/utils/requestUtils';
 import { api } from '@mathesar/api/rpc';
 import type {
   AddableExploration,
-  ExplorationResult,
   SavedExploration,
 } from '@mathesar/api/rpc/explorations';
 import type { Database } from '@mathesar/models/Database';
@@ -202,22 +201,6 @@ export function getExploration(
   id: SavedExploration['id'],
 ): CancellablePromise<SavedExploration> {
   return api.explorations.get({ exploration_id: id }).run();
-}
-
-export function runSavedExploration(
-  id: number,
-  params: {
-    limit: number;
-    offset: number;
-  },
-): CancellablePromise<ExplorationResult> {
-  return api.explorations
-    .run_saved({
-      exploration_id: id,
-      limit: params.limit,
-      offset: params.offset,
-    })
-    .run();
 }
 
 export function deleteExploration(id: number): CancellablePromise<void> {


### PR DESCRIPTION
**Fixes #4469** 

Removes the explorations.run_saved RPC method from the frontend codebase as the backend API has been removed. The frontend now exclusively uses the explorations.run API with the full exploration definition.

**Technical details**
- Removed **run_saved RPC method** type definition from **explorations.ts**.
- Removed **runSavedExploration function** from queries store
- Simplify **QueryRunner** to always use **explorations.run API**
- Removed **QueryRunMode type** and **runMode parameter** from **QueryRunner**
- Removed unused **ExplorationResult import** from queries store

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
