### PR TITLE
Fix: Make Distinct List work for Time with Timezone columns (fixes #2964)

### DIFF
--- a/mathesar/utils/explorations.py
+++ b/mathesar/utils/explorations.py
@@ -21,6 +21,8 @@ from db.deprecated.functions.base import (
 from db.deprecated.functions.packed import DistinctArrayAgg
 from mathesar.models.base import Explorations, ColumnMetaData, Database
 from mathesar.rpc.columns.metadata import ColumnMetaDataRecord
+from datetime import date, time, datetime
+from collections.abc import Mapping, Sequence
 
 
 def list_explorations(database_id, schema_oid=None):
@@ -64,6 +66,44 @@ def create_exploration(exploration_def):
         display_names=exploration_def.get("display_names", {}),
         description=exploration_def.get("description")
     )
+
+
+def _serialize_value_for_json(value):
+    """
+    Convert values returned from DBQuery into JSON‑serializable forms.
+
+    Handles timezone‑aware time / datetime objects (including inside arrays)
+    by converting them to ISO 8601 strings, while leaving other types intact.
+    """
+    # Handle basic temporal types
+    if isinstance(value, (date, datetime, time)):
+        # Use ISO string, which preserves timezone info when present
+        return value.isoformat()
+
+    # Handle sequences (e.g. lists/tuples/arrays from DISTINCT LIST)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_serialize_value_for_json(v) for v in value]
+
+    # Handle mappings/dicts
+    if isinstance(value, Mapping):
+        return {k: _serialize_value_for_json(v) for k, v in value.items()}
+
+    # Fallback: leave as is (must already be serializable)
+    return value
+
+
+def _serialize_records_for_json(records):
+    """
+    Apply _serialize_value_for_json to each record row dict.
+    """
+    serialized_results = []
+    for row in records:
+        serialized_row = {
+            key: _serialize_value_for_json(val)
+            for key, val in row.items()
+        }
+        serialized_results.append(serialized_row)
+    return serialized_results
 
 
 def run_exploration(exploration_def, conn, limit=100, offset=0):
@@ -122,6 +162,9 @@ def run_exploration(exploration_def, conn, limit=100, offset=0):
     )
     query_results = db_query.get_records(limit=limit, offset=offset)
 
+    raw_results = [r._asdict() for r in query_results]
+    serialized_results = _serialize_records_for_json(raw_results)
+
     column_metadata = _get_exploration_column_metadata(
         exploration_def,
         processed_initial_columns,
@@ -134,7 +177,7 @@ def run_exploration(exploration_def, conn, limit=100, offset=0):
         "query": exploration_def,
         "records": {
             "count": db_query.count,
-            "results": [r._asdict() for r in query_results],
+            "results": serialized_results,
         },
         "output_columns": tuple(sa_col.name for sa_col in db_query.sa_output_columns),
         "column_metadata": column_metadata,


### PR DESCRIPTION
Fixes #2964

## Description

This PR fixes the bug where applying the **Distinct List** transformation to a
**Time with Timezone** column causes the backend to fail with the error
`JSON can't represent timezone-aware times`. Instead of returning a valid
response, the API crashed during JSON serialization of the exploration results.

Now, exploration results are serialized into JSON‑friendly values before being
returned, so Distinct List works correctly for Time with Timezone columns and
other temporal fields.

## What this PR changes

- Update `mathesar/utils/explorations.py` to serialize exploration results
  before returning them.
- Add `_serialize_value_for_json` to convert:
  - `date`, `datetime`, and `time` objects (including timezone‑aware ones)
    to ISO‑8601 strings.
  - Nested values inside lists/tuples and dicts using the same logic.
- Add `_serialize_records_for_json` and call it in `run_exploration` so that
  every row in `records["results"]` is converted to JSON‑serializable types.
- Leave the SQL / transformation layer (`Summarize`, `DistinctArrayAgg`) unchanged;
  the fix is isolated to the service layer that prepares the RPC response.

## Technical details

- `DBQuery.get_records` still returns row objects as before.
- `run_exploration` now converts each row to a dict (`_asdict()`), then runs
  `_serialize_records_for_json` over the list of rows.
- Temporal values inside arrays produced by Distinct List (e.g. arrays of
  `time with time zone`) become arrays of ISO‑formatted strings, which DRF’s
  JSON renderer can handle safely.

## Screenshots

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/263c1ee0-c62c-424f-b3a6-67f023e3c358" />

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests or performed thorough manual testing for the changes I made.
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
