### PR TITLE
Split 'default' button appearance into 'control' and 'input' appearances

### DIFF
--- a/mathesar_ui/src/component-library/anchorButton/AnchorButton.svelte
+++ b/mathesar_ui/src/component-library/anchorButton/AnchorButton.svelte
@@ -8,7 +8,7 @@
    * Appearance. One of: 'default', 'primary', 'secondary', 'plain', 'ghost'.
    * @required
    */
-  export let appearance: Appearance = 'default';
+  export let appearance: Appearance = 'control';
 
   /**
    * Size. One of: 'small', 'medium', 'large'.

--- a/mathesar_ui/src/component-library/button/Button.scss
+++ b/mathesar_ui/src/component-library/button/Button.scss
@@ -134,11 +134,7 @@
       focus: (
         background: var(--color-bg-input-focused),
         outline-color:
-          color-mix(
-            in srgb,
-            var(--color-border-input-focused),
-            transparent 70%
-          ),
+          color-mix(in srgb, var(--color-border-input-focused), transparent 70%),
         box-shadow: (
           0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
           0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),
@@ -148,11 +144,7 @@
         background: var(--color-bg-input-active),
         border-color: var(--color-border-input-active),
         outline-color:
-          color-mix(
-            in srgb,
-            var(--color-border-input-focused),
-            transparent 60%
-          ),
+          color-mix(in srgb, var(--color-border-input-focused), transparent 60%),
         box-shadow: (
           0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
           0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),

--- a/mathesar_ui/src/component-library/button/Button.scss
+++ b/mathesar_ui/src/component-library/button/Button.scss
@@ -80,6 +80,86 @@
       ),
     ),
 
+    control: (
+      normal: (
+        background: var(--color-bg-control),
+        border-color: var(--color-border-control),
+      ),
+      hover: (
+        background: var(--color-bg-control-hover),
+        box-shadow: (
+          var(--color-shadow) 0 1px 3px 0,
+        ),
+      ),
+      focus: (
+        background: var(--color-bg-control-focused),
+        outline-color:
+          color-mix(
+            in srgb,
+            var(--color-border-control-focused),
+            transparent 70%
+          ),
+        box-shadow: (
+          0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
+          0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),
+        ),
+      ),
+      active: (
+        background: var(--color-bg-control-active),
+        border-color: var(--color-border-control-active),
+        outline-color:
+          color-mix(
+            in srgb,
+            var(--color-border-control-focused),
+            transparent 60%
+          ),
+        box-shadow: (
+          0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
+          0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),
+        ),
+      ),
+    ),
+
+    input: (
+      normal: (
+        background: var(--color-bg-input),
+        border-color: var(--color-border-input),
+      ),
+      hover: (
+        background: var(--color-bg-input-hover),
+        box-shadow: (
+          var(--color-shadow) 0 1px 3px 0,
+        ),
+      ),
+      focus: (
+        background: var(--color-bg-input-focused),
+        outline-color:
+          color-mix(
+            in srgb,
+            var(--color-border-input-focused),
+            transparent 70%
+          ),
+        box-shadow: (
+          0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
+          0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),
+        ),
+      ),
+      active: (
+        background: var(--color-bg-input-active),
+        border-color: var(--color-border-input-active),
+        outline-color:
+          color-mix(
+            in srgb,
+            var(--color-border-input-focused),
+            transparent 60%
+          ),
+        box-shadow: (
+          0 2px 4px color-mix(in srgb, var(--color-shadow), transparent 15%),
+          0 1px 2px color-mix(in srgb, var(--color-shadow), transparent 10%),
+        ),
+      ),
+    ),
+
     primary: (
       normal: (
         background:

--- a/mathesar_ui/src/component-library/button/Button.svelte
+++ b/mathesar_ui/src/component-library/button/Button.svelte
@@ -5,7 +5,7 @@
   } from '@mathesar-component-library-dir/commonTypes';
   import Tooltip from '@mathesar-component-library-dir/tooltip/Tooltip.svelte';
 
-  export let appearance: Appearance = 'default';
+  export let appearance: Appearance = 'control';
   export let size: Size = 'medium';
   export let active = false;
   export let type: 'button' | 'submit' = 'button';

--- a/mathesar_ui/src/component-library/button/__meta__/Button.stories.svelte
+++ b/mathesar_ui/src/component-library/button/__meta__/Button.stories.svelte
@@ -70,6 +70,8 @@
 
 <Story name="Appearances" parameters={disabledAddons}>
   <Button appearance="default">Default button</Button>
+  <Button appearance="control">Control button</Button>
+  <Button appearance="input">Input button</Button>
   <Button appearance="primary">Primary button</Button>
   <Button appearance="secondary">Secondary button</Button>
   <Button appearance="plain">Plain button</Button>

--- a/mathesar_ui/src/component-library/button/__meta__/Button.test.ts
+++ b/mathesar_ui/src/component-library/button/__meta__/Button.test.ts
@@ -11,7 +11,7 @@ test('renders button in default appearance and medium size', () => {
 
   const button = getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('btn-default');
+  expect(button).toHaveClass('btn-control');
   expect(button).toHaveClass('size-medium');
 });
 

--- a/mathesar_ui/src/component-library/collapsible/Collapsible.svelte
+++ b/mathesar_ui/src/component-library/collapsible/Collapsible.svelte
@@ -5,7 +5,7 @@
   import Icon from '@mathesar-component-library-dir/icon/Icon.svelte';
 
   export let isOpen = false;
-  export let triggerAppearance: Appearance = 'default';
+  export let triggerAppearance: Appearance = 'control';
   function toggle() {
     isOpen = !isOpen;
   }

--- a/mathesar_ui/src/component-library/commonTypes.ts
+++ b/mathesar_ui/src/component-library/commonTypes.ts
@@ -1,5 +1,7 @@
 export type Appearance =
   | 'default'
+  | 'control'
+  | 'input'
   | 'primary'
   | 'secondary'
   | 'plain'

--- a/mathesar_ui/src/component-library/data-type-based-input/EnumInput.svelte
+++ b/mathesar_ui/src/component-library/data-type-based-input/EnumInput.svelte
@@ -16,7 +16,7 @@
   export let dataType: DataTypeBasedInputType;
   export let enumValues: unknown[] | undefined = undefined;
   export let options: DataTypeBasedInputSelectElement['options'] = undefined;
-  export let triggerAppearance: Appearance = 'default';
+  export let triggerAppearance: Appearance = 'input';
   export let value = getInitialValue(dataType, enumValues);
 
   $: selectOptions = generateSelectOptions(dataType, enumValues, options);

--- a/mathesar_ui/src/component-library/dropdown/Dropdown.scss
+++ b/mathesar_ui/src/component-library/dropdown/Dropdown.scss
@@ -1,14 +1,6 @@
 button.dropdown.trigger {
   position: relative;
 
-  &.btn-default {
-    --button-background: var(--color-bg-input);
-    --button-border-color: var(--color-border-input);
-    --button-hover-background: var(--color-bg-input-hover);
-    --button-focus-background: var(--color-bg-input-focused);
-    --button-active-background: var(--color-bg-input-active);
-  }
-
   > .label {
     display: inline-flex;
     align-items: center;

--- a/mathesar_ui/src/component-library/dropdown/Dropdown.svelte
+++ b/mathesar_ui/src/component-library/dropdown/Dropdown.svelte
@@ -12,7 +12,7 @@
   import AttachableDropdown from './AttachableDropdown.svelte';
 
   export let triggerClass = '';
-  export let triggerAppearance: Appearance = 'default';
+  export let triggerAppearance: Appearance = 'control';
   export let contentClass = '';
   export let isOpen = false;
   export let closeOnInnerClick = false;

--- a/mathesar_ui/src/component-library/select/Select.svelte
+++ b/mathesar_ui/src/component-library/select/Select.svelte
@@ -63,7 +63,7 @@
   /**
    * Appearance of the trigger button. One of: 'default', 'primary', 'secondary', 'plain', 'ghost'.
    */
-  export let triggerAppearance: DefinedProps['triggerAppearance'] = 'default';
+  export let triggerAppearance: DefinedProps['triggerAppearance'] = 'input';
 
   /**
    * The ARIA label for this select component.

--- a/mathesar_ui/src/component-library/select/__meta__/Select.stories.svelte
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.stories.svelte
@@ -57,7 +57,7 @@
       { id: 3, label: 'Option 3' },
       { id: 4, label: 'Option 4' },
     ]}
-    triggerAppearance="default"
+    triggerAppearance="input"
   />
 
   <Select

--- a/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/svelte';
 
 import Select from '../Select.svelte';
 
-test('renders select button in default appearance', () => {
+test('renders select button in input appearance', () => {
   const options = [
     { id: 1, label: 'Option 1' },
     { id: 2, label: 'Option 2' },
@@ -12,14 +12,14 @@ test('renders select button in default appearance', () => {
   const { getByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 
   // Check if the select button is rendered, along with the correct classes.
   const selectBtn = getByRole('button');
   expect(selectBtn).toBeInTheDocument();
-  expect(selectBtn).toHaveClass('btn-default', 'size-medium');
+  expect(selectBtn).toHaveClass('btn-input', 'size-medium');
 
   // Expect the button to contain the correct label.
   expect(selectBtn).toHaveTextContent('Option 1');
@@ -59,7 +59,7 @@ test('renders select with custom classes and primary appearance', async () => {
   expect(selectUl.parentNode).toHaveClass('content-custom-class');
 });
 
-test('renders select options in default appearance', async () => {
+test('renders select options in input appearance', async () => {
   const options = [
     { id: 1, label: 'Option 1' },
     { id: 2, label: 'Option 2' },
@@ -68,7 +68,7 @@ test('renders select options in default appearance', async () => {
   const { getByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 
@@ -96,7 +96,7 @@ test('updates currently selected option', async () => {
   const { getByRole, getAllByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 
@@ -131,7 +131,7 @@ test('select option using keyboard', async () => {
   const { getByRole, getAllByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 
@@ -166,7 +166,7 @@ test('hide select dropdown by pressing ESC', async () => {
   const { getByRole, queryByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 
@@ -192,7 +192,7 @@ test('list scrolls automatically to display the currently selected option', asyn
   const { getByRole, getAllByRole } = render(Select, {
     props: {
       options,
-      triggerAppearance: 'default',
+      triggerAppearance: 'input',
     },
   });
 

--- a/mathesar_ui/src/components/InspectorSection.svelte
+++ b/mathesar_ui/src/components/InspectorSection.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div class="inspector-section">
-  <Collapsible bind:isOpen triggerAppearance="default">
+  <Collapsible bind:isOpen triggerAppearance="control">
     <div slot="header" class="header">
       <div>
         <slot name="title">{title}</slot>

--- a/mathesar_ui/src/components/file-attachments/file-detail-dropdown/FileDetailDropdown.svelte
+++ b/mathesar_ui/src/components/file-attachments/file-detail-dropdown/FileDetailDropdown.svelte
@@ -61,7 +61,7 @@
         <Icon {...iconDeleteMajor} />
         <span class="button-label">{$_('remove')}</span>
       </Button>
-      <a class="btn btn-default" href={downloadUrl}>
+      <a class="btn btn-control" href={downloadUrl}>
         <Icon {...iconDownload} />
         <span class="button-label">{$_('download')}</span>
       </a>

--- a/mathesar_ui/src/components/file-attachments/lightbox/Lightbox.svelte
+++ b/mathesar_ui/src/components/file-attachments/lightbox/Lightbox.svelte
@@ -167,7 +167,7 @@
         </Tooltip>
 
         <Tooltip enabled={!showButtonLabels}>
-          <a slot="trigger" class="btn btn-default" href={downloadUrl}>
+          <a slot="trigger" class="btn btn-control" href={downloadUrl}>
             <Icon {...iconDownload} />
             <span class="button-label">{$_('download')}</span>
           </a>

--- a/mathesar_ui/src/pages/data-forms/ShareForm.svelte
+++ b/mathesar_ui/src/pages/data-forms/ShareForm.svelte
@@ -162,7 +162,7 @@
       <div>
         <SpinnerButton
           disabled={$hasChanges}
-          appearance="default"
+          appearance="control"
           onClick={shareForm}
           label={$_('create_public_link')}
         />

--- a/mathesar_ui/src/systems/data-forms/form-maker/elements/ErrorFormFieldElement.svelte
+++ b/mathesar_ui/src/systems/data-forms/form-maker/elements/ErrorFormFieldElement.svelte
@@ -50,7 +50,7 @@
         {#if dataFormManager instanceof EditableDataFormManager}
           <div>
             <Button
-              appearance="default"
+              appearance="control"
               on:click={() => dataFormField.container.delete(dataFormField)}
             >
               <Icon {...iconDeleteMajor} />

--- a/mathesar_ui/src/systems/data-forms/form-maker/inspector/field-config/FieldConfig.svelte
+++ b/mathesar_ui/src/systems/data-forms/form-maker/inspector/field-config/FieldConfig.svelte
@@ -62,7 +62,7 @@
         {#if field.kind === 'foreign_key'}
           <LabeledInput layout="stacked" label={$_('field_fk_rule_label')}>
             <FkFormFieldRuleSelector
-              appearance="default"
+              appearance="input"
               {dataFormManager}
               dataFormField={field}
             />


### PR DESCRIPTION
- Added 'control' and 'input' appearance types to Button component
- 'control' uses --color-*-control variables for action buttons
- 'input' uses --color-*-input variables for input triggers
- Updated Button and Dropdown default to 'control'
- Updated Select default to 'input'
- Removed Dropdown style overrides for consistent styling
- Updated all component usages throughout codebase
- Updated tests and stories to reflect changes

Fixes #4901

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

Problem Solved
Buttons with "default" appearance were being used inconsistently - 
sometimes as action controls, sometimes as input triggers - causing visual 
inconsistencies throughout the UI.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
