### PR TITLE
Send null for empty strings on special string columns

### DIFF
--- a/mathesar_ui/src/components/cell-fabric/CellFabric.svelte
+++ b/mathesar_ui/src/components/cell-fabric/CellFabric.svelte
@@ -52,7 +52,6 @@
 >
   <svelte:component
     this={component}
-    {...props}
     {columnFabric}
     {isActive}
     {disabled}
@@ -70,6 +69,7 @@
     {canViewLinkedEntities}
     {value}
     {setValue}
+    {...props}
     on:movementKeyDown
   />
 

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/formatted-input/FormattedInputCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/formatted-input/FormattedInputCell.svelte
@@ -15,6 +15,7 @@
   export let formatter: $$Props['formatter'];
   export let formatForDisplay: $$Props['formatForDisplay'];
   export let useTabularNumbers: $$Props['useTabularNumbers'] = undefined;
+  export let horizontalAlignment: $$Props['horizontalAlignment'] = undefined;
 </script>
 
 <SteppedInputCell
@@ -25,7 +26,7 @@
   {isIndependentOfSheet}
   {showTruncationPopover}
   {useTabularNumbers}
-  horizontalAlignment="right"
+  {horizontalAlignment}
   let:handleInputBlur
   let:setValueInEditMode
   formatValue={formatForDisplay}

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/typeDefinitions.ts
@@ -172,6 +172,7 @@ export interface FormattedInputCellExternalProps
   extends Omit<FormattedInputProps<string>, 'disabled' | 'value'> {
   formatForDisplay: CellValueFormatter<string>;
   useTabularNumbers?: boolean;
+  horizontalAlignment?: HorizontalAlignment;
 }
 
 export interface FormattedInputCellProps

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCell.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
+  import FormattedInput from '@mathesar/component-library/formatted-input/FormattedInput.svelte';
   import CellValue from '@mathesar/components/CellValue.svelte';
-  import {
-    PrecomputedMatchHighlighter,
-    TextInput,
-  } from '@mathesar-component-library';
+  import { PrecomputedMatchHighlighter } from '@mathesar-component-library';
 
   import SteppedInputCell from '../SteppedInputCell.svelte';
   import type { FormattedInputCellProps } from '../typeDefinitions';
 
   import UriCellContent from './UriCellContent.svelte';
-  import FormattedInput from '@mathesar/component-library/formatted-input/FormattedInput.svelte';
 
   type $$Props = FormattedInputCellProps;
 

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/uri/UriCell.svelte
@@ -6,11 +6,12 @@
   } from '@mathesar-component-library';
 
   import SteppedInputCell from '../SteppedInputCell.svelte';
-  import type { CellTypeProps } from '../typeDefinitions';
+  import type { FormattedInputCellProps } from '../typeDefinitions';
 
   import UriCellContent from './UriCellContent.svelte';
+  import FormattedInput from '@mathesar/component-library/formatted-input/FormattedInput.svelte';
 
-  type $$Props = CellTypeProps<string>;
+  type $$Props = FormattedInputCellProps;
 
   export let isActive: $$Props['isActive'];
   export let value: $$Props['value'] = undefined;
@@ -19,6 +20,8 @@
   export let searchValue: $$Props['searchValue'] = undefined;
   export let isIndependentOfSheet: $$Props['isIndependentOfSheet'];
   export let showTruncationPopover: $$Props['showTruncationPopover'] = false;
+  export let formatter: $$Props['formatter'];
+  export let formatForDisplay: $$Props['formatForDisplay'];
 </script>
 
 <SteppedInputCell
@@ -31,6 +34,7 @@
   {showTruncationPopover}
   let:handleInputBlur
   let:setValueInEditMode
+  formatValue={formatForDisplay}
   on:movementKeyDown
   on:mouseenter
 >
@@ -45,11 +49,13 @@
       </UriCellContent>
     </CellValue>
   </span>
-  <TextInput
+  <FormattedInput
     focusOnMount={true}
+    {...$$restProps}
     {disabled}
     {value}
-    onValueChange={setValueInEditMode}
+    on:artificialInput={({ detail }) => setValueInEditMode(detail)}
+    {formatter}
     on:blur={handleInputBlur}
   />
 </SteppedInputCell>

--- a/mathesar_ui/src/components/cell-fabric/data-types/date.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/date.ts
@@ -36,7 +36,7 @@ function getProps(column: RawColumnWithMetadata): DateTimeCellExternalProps {
   };
 }
 
-const stringType: CellComponentFactory = {
+const dateType: CellComponentFactory = {
   get: (
     column: RawColumnWithMetadata,
   ): ComponentAndProps<DateTimeCellExternalProps> => ({
@@ -59,4 +59,4 @@ const stringType: CellComponentFactory = {
   },
 };
 
-export default stringType;
+export default dateType;

--- a/mathesar_ui/src/components/cell-fabric/data-types/duration.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/duration.ts
@@ -26,6 +26,7 @@ function getProps(
   const formatter = new DurationFormatter(durationSpecification);
   return {
     useTabularNumbers: true,
+    horizontalAlignment: 'right',
     formatter,
     placeholder: durationSpecification.getFormattingString(),
     formatForDisplay: (

--- a/mathesar_ui/src/components/cell-fabric/data-types/email.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/email.ts
@@ -1,0 +1,41 @@
+import {
+  FormattedInput,
+  isDefinedNonNullable,
+} from '@mathesar-component-library';
+import type { ComponentAndProps } from '@mathesar-component-library/types';
+
+import FormattedInputCell from './components/formatted-input/FormattedInputCell.svelte';
+import type { CellComponentFactory } from './typeDefinitions';
+import { SpecialStringFormatter } from './utils';
+
+function getProps() {
+  const formatter = SpecialStringFormatter;
+  return {
+    formatter,
+    formatForDisplay: (
+      v: string | null | undefined,
+    ): string | null | undefined => {
+      if (!isDefinedNonNullable(v)) {
+        return v;
+      }
+      return formatter.format(v);
+    },
+  };
+}
+
+const emailType: CellComponentFactory = {
+  initialInputValue: '',
+  get: (): ComponentAndProps => ({
+    component: FormattedInputCell,
+    props: getProps(),
+  }),
+  getInput: (): ComponentAndProps => ({
+    component: FormattedInput,
+    props: getProps(),
+  }),
+  getDisplayFormatter() {
+    return (v) => getProps().formatForDisplay(String(v));
+  },
+};
+
+export default emailType;

--- a/mathesar_ui/src/components/cell-fabric/data-types/index.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/index.ts
@@ -3,6 +3,7 @@ import boolean from './boolean';
 import date from './date';
 import datetime from './datetime';
 import duration from './duration';
+import email from './email';
 import file from './file';
 import money from './money';
 import number from './number';
@@ -25,6 +26,7 @@ const simpleDataTypeComponentFactories: Record<
   number,
   money,
   uri,
+  email,
   duration,
   date,
   time,

--- a/mathesar_ui/src/components/cell-fabric/data-types/index.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/index.ts
@@ -5,6 +5,7 @@ import datetime from './datetime';
 import duration from './duration';
 import email from './email';
 import file from './file';
+import json from './json';
 import money from './money';
 import number from './number';
 import string from './string';
@@ -16,6 +17,7 @@ import type {
   SimpleCellDataTypes,
 } from './typeDefinitions';
 import uri from './uri';
+import uuid from './uuid';
 
 const simpleDataTypeComponentFactories: Record<
   SimpleCellDataTypes,
@@ -27,6 +29,8 @@ const simpleDataTypeComponentFactories: Record<
   money,
   uri,
   email,
+  uuid,
+  json,
   duration,
   date,
   time,

--- a/mathesar_ui/src/components/cell-fabric/data-types/json.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/json.ts
@@ -1,0 +1,41 @@
+import {
+  FormattedInput,
+  isDefinedNonNullable,
+} from '@mathesar-component-library';
+import type { ComponentAndProps } from '@mathesar-component-library/types';
+
+import FormattedInputCell from './components/formatted-input/FormattedInputCell.svelte';
+import type { CellComponentFactory } from './typeDefinitions';
+import { SpecialStringFormatter } from './utils';
+
+function getProps() {
+  const formatter = SpecialStringFormatter;
+  return {
+    formatter,
+    formatForDisplay: (
+      v: string | null | undefined,
+    ): string | null | undefined => {
+      if (!isDefinedNonNullable(v)) {
+        return v;
+      }
+      return formatter.format(v);
+    },
+  };
+}
+
+const jsonType: CellComponentFactory = {
+  initialInputValue: '',
+  get: (): ComponentAndProps => ({
+    component: FormattedInputCell,
+    props: getProps(),
+  }),
+  getInput: (): ComponentAndProps => ({
+    component: FormattedInput,
+    props: getProps(),
+  }),
+  getDisplayFormatter() {
+    return (v) => getProps().formatForDisplay(String(v));
+  },
+};
+
+export default jsonType;

--- a/mathesar_ui/src/components/cell-fabric/data-types/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/typeDefinitions.ts
@@ -16,6 +16,8 @@ export type SimpleCellDataTypes =
   | 'number'
   | 'uri'
   | 'email'
+  | 'uuid'
+  | 'json'
   | 'duration'
   | 'date'
   | 'money'

--- a/mathesar_ui/src/components/cell-fabric/data-types/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/typeDefinitions.ts
@@ -15,6 +15,7 @@ export type SimpleCellDataTypes =
   | 'boolean'
   | 'number'
   | 'uri'
+  | 'email'
   | 'duration'
   | 'date'
   | 'money'

--- a/mathesar_ui/src/components/cell-fabric/data-types/uri.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/uri.ts
@@ -1,14 +1,38 @@
-import { TextInput } from '@mathesar-component-library';
+import {
+  FormattedInput,
+  isDefinedNonNullable,
+} from '@mathesar-component-library';
 import type { ComponentAndProps } from '@mathesar-component-library/types';
 
 import UriCell from './components/uri/UriCell.svelte';
 import type { CellComponentFactory } from './typeDefinitions';
+import { SpecialStringFormatter } from './utils';
+
+function getProps() {
+  const formatter = SpecialStringFormatter;
+  return {
+    formatter,
+    formatForDisplay: (
+      v: string | null | undefined,
+    ): string | null | undefined => {
+      if (!isDefinedNonNullable(v)) {
+        return v;
+      }
+      return formatter.format(v);
+    },
+  };
+}
 
 const uriType: CellComponentFactory = {
   initialInputValue: '',
-  get: (): ComponentAndProps => ({ component: UriCell }),
-  getInput: (): ComponentAndProps => ({ component: TextInput }),
-  getDisplayFormatter: () => String,
+  get: (): ComponentAndProps => ({ component: UriCell, props: getProps() }),
+  getInput: (): ComponentAndProps => ({
+    component: FormattedInput,
+    props: getProps(),
+  }),
+  getDisplayFormatter() {
+    return (v) => getProps().formatForDisplay(String(v));
+  },
 };
 
 export default uriType;

--- a/mathesar_ui/src/components/cell-fabric/data-types/utils.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/utils.ts
@@ -1,5 +1,9 @@
 import type { ColumnMetadata } from '@mathesar/api/rpc/_common/columnDisplayOptions';
 import type { DbType } from '@mathesar/AppTypes';
+import type {
+  InputFormatter,
+  ParseResult,
+} from '@mathesar/component-library/types';
 import { getAbstractTypeForDbType } from '@mathesar/stores/abstract-types';
 import type { CellInfo } from '@mathesar/stores/abstract-types/types';
 
@@ -22,3 +26,14 @@ export function getCellConfiguration(
     ...conditionalConfig,
   };
 }
+
+export const SpecialStringFormatter: InputFormatter<string> = {
+  parse: (input: string): ParseResult<string> => {
+    const cleanedInput = input.trim();
+    return {
+      value: cleanedInput || null,
+      intermediateDisplay: input,
+    };
+  },
+  format: (input: string): string => input.trim(),
+};

--- a/mathesar_ui/src/components/cell-fabric/data-types/uuid.ts
+++ b/mathesar_ui/src/components/cell-fabric/data-types/uuid.ts
@@ -1,0 +1,41 @@
+import {
+  FormattedInput,
+  isDefinedNonNullable,
+} from '@mathesar-component-library';
+import type { ComponentAndProps } from '@mathesar-component-library/types';
+
+import FormattedInputCell from './components/formatted-input/FormattedInputCell.svelte';
+import type { CellComponentFactory } from './typeDefinitions';
+import { SpecialStringFormatter } from './utils';
+
+function getProps() {
+  const formatter = SpecialStringFormatter;
+  return {
+    formatter,
+    formatForDisplay: (
+      v: string | null | undefined,
+    ): string | null | undefined => {
+      if (!isDefinedNonNullable(v)) {
+        return v;
+      }
+      return formatter.format(v);
+    },
+  };
+}
+
+const uuidType: CellComponentFactory = {
+  initialInputValue: '',
+  get: (): ComponentAndProps => ({
+    component: FormattedInputCell,
+    props: getProps(),
+  }),
+  getInput: (): ComponentAndProps => ({
+    component: FormattedInput,
+    props: getProps(),
+  }),
+  getDisplayFormatter() {
+    return (v) => getProps().formatForDisplay(String(v));
+  },
+};
+
+export default uuidType;

--- a/mathesar_ui/src/stores/abstract-types/type-configs/email.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/email.ts
@@ -7,7 +7,7 @@ const emailType: AbstractTypeConfiguration = {
   getIcon: () => ({ ...iconUiTypeEmail, label: 'Email' }),
   defaultDbType: DB_TYPES.MSAR__EMAIL,
   cellInfo: {
-    type: 'string',
+    type: 'email',
   },
 };
 

--- a/mathesar_ui/src/stores/abstract-types/type-configs/json.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/json.ts
@@ -7,7 +7,7 @@ const jsonType: AbstractTypeConfiguration = {
   getIcon: () => ({ ...iconUiTypeJson, label: 'JSON' }),
   defaultDbType: DB_TYPES.JSONB,
   cellInfo: {
-    type: 'string',
+    type: 'json',
     config: {
       multiLine: true,
     },

--- a/mathesar_ui/src/stores/abstract-types/type-configs/uuid.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/uuid.ts
@@ -7,7 +7,7 @@ const uuidType: AbstractTypeConfiguration = {
   getIcon: () => ({ ...iconUiTypeUuid, label: 'UUID' }),
   defaultDbType: DB_TYPES.UUID,
   cellInfo: {
-    type: 'string',
+    type: 'uuid',
   },
 };
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3784 

<!-- Concisely describe what the pull request does. -->
This PR introduces a simple formatter that checks for an empty string and passes `null` instead, and applies that formatter to the `uri`, `email`, `uuid` and `json` UI types.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- Created a new formatter in [cell-fabric/data-types/util.ts](https://github.com/mathesar-foundation/mathesar/blob/develop/mathesar_ui/src/components/cell-fabric/data-types/utils.ts) called `SpecialStringFormatter` that implements the `InputFormatter` interface, that parses a string and returns a `null` in case of an empty string. Both `parse()` and `format()` return a trimmed version of the string.
- Changed the existing `uri` cell fabric type to use the new formatter. Also replaced its usage of the `TextInput` component with `FormattedInput` (also inside `UriCell`) to make it work with the formatter, taking inspiration from its usage inside `FormattedInputCell`.
- Introduced cell fabric types for the `email`, `uuid` and `json` UI types, copying most of their behavior from the `duration` cell fabric type, but using the new formatter.
- The `FormattedInput` and `FormattedInputCell` components were reused for almost everything as it worked well for the `duration` type, and were the most barebones pieces that could be used in this case without much changes. I had to take out its hard-coded right alignment and pass it as an optional prop from the duration type. Also changed the prop ordering inside `CellFabric` so that external props passed in could override the default ones (in this case, for `horizontalAlignment`).
- Also a simple typo fix for the default export for the `date` type.

**Notes**
- The issue mentioned that the date/time types were affected too, but from my testing and searching around, it seemed to have been fixed in #4713 (specifically commit https://github.com/mathesar-foundation/mathesar/commit/669b6843238ea6c29b50979b72432ec4a6a6d1ed)
- From further testing, the same issue seemed to appearing on the `uuid` and `json` types, which I felt were relevant enough to be included in the fix.

**Demo**

_Before_

https://github.com/user-attachments/assets/e2c0b272-95ab-4980-a13c-7e4d21caa5b3

_After_

https://github.com/user-attachments/assets/be3e2e32-5aa0-4f7a-9eff-879c42613087


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
