### PR TITLE
Add Brotli/gzip precompression for static files in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,10 +91,11 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
     | tee /etc/apt/sources.list.d/nodesource.list
 
-# Install node
+# Install node and brotli for static precompression
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     nodejs \
+    brotli \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/build-scripts/package/package.py
+++ b/build-scripts/package/package.py
@@ -226,9 +226,33 @@ def package_mathesar(base_dir: Path, dist_dir: Path) -> None:
     # make it executable
     uv_installer_path.chmod(uv_installer_path.stat().st_mode | 0o111)
 
+
     logger.info("Building Mathesar frontend")
     run_command(["npm", "ci"], cwd=base_dir / "mathesar_ui")
     run_command(["npm", "run", "build"], cwd=base_dir / "mathesar_ui")
+
+    # Precompress static files (Brotli and gzip)
+    static_dir = base_dir / "mathesar" / "static" / "mathesar"
+    if static_dir.exists():
+        logger.info(f"Precompressing static files in {static_dir}")
+        brotli_available = shutil.which("brotli") is not None
+        if not brotli_available:
+            logger.warning("Brotli is not installed. Brotli precompression will be skipped!")
+        for path in static_dir.rglob("*"):
+            if path.is_file() and not path.suffix in {".br", ".gz"}:
+                # Brotli
+                if brotli_available:
+                    try:
+                        run_command(["brotli", "-f", "-q", "11", str(path)])
+                    except Exception as e:
+                        logger.warning(f"Brotli compression failed for {path}: {e}")
+                # Gzip
+                try:
+                    run_command(["gzip", "-kf9", str(path)])
+                except Exception as e:
+                    logger.warning(f"Gzip compression failed for {path}: {e}")
+    else:
+        logger.warning(f"Static directory {static_dir} does not exist, skipping precompression.")
 
     logger.info("Compiling Django translations")
     run_command([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], cwd=base_dir)

--- a/build-scripts/package/package.py
+++ b/build-scripts/package/package.py
@@ -226,7 +226,6 @@ def package_mathesar(base_dir: Path, dist_dir: Path) -> None:
     # make it executable
     uv_installer_path.chmod(uv_installer_path.stat().st_mode | 0o111)
 
-
     logger.info("Building Mathesar frontend")
     run_command(["npm", "ci"], cwd=base_dir / "mathesar_ui")
     run_command(["npm", "run", "build"], cwd=base_dir / "mathesar_ui")
@@ -239,7 +238,7 @@ def package_mathesar(base_dir: Path, dist_dir: Path) -> None:
         if not brotli_available:
             logger.warning("Brotli is not installed. Brotli precompression will be skipped!")
         for path in static_dir.rglob("*"):
-            if path.is_file() and not path.suffix in {".br", ".gz"}:
+            if path.is_file() and path.suffix not in {".br", ".gz"}:
                 # Brotli
                 if brotli_available:
                     try:


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2411

<!-- Concisely describe what the pull request does. -->
 - Add Brotli to the Docker build (development_base stage) to enable precompression during packaging
- Update package.py to precompress built static files with both Brotli and gzip after the frontend build step
- Ensure precompressed assets (.br and .gz files) are included in the packaged tarball for the production image
- Enable Caddy to serve precompressed files directly without runtime compression overhead

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- Installed `brotli` package alongside `nodejs` in the development_base stage of the Dockerfile
- Modified `build-scripts/package/package.py` to recursively precompress all static files in `mathesar/static/mathesar/` 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="288" height="461" alt="image" src="https://github.com/user-attachments/assets/f19d93b9-04f1-4a0c-a4ed-0b7ca7c4b8ca" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
