### PR TITLE
Revert "issue 4890 - Allow renaming of primary key (Mathesar ID) columns"

### DIFF
--- a/db/sql/05_msar.sql
+++ b/db/sql/05_msar.sql
@@ -3774,8 +3774,6 @@ CREATE OR REPLACE FUNCTION
 msar.alter_columns(tab_id oid, col_alters jsonb) RETURNS integer[] AS $$/*
 Alter columns of the given table in bulk, returning the IDs of the columns so altered.
 
-Exception is raised when mathesar ID column is tried to be renamed.
-
 Args:
   tab_id: The OID of the table whose columns we'll alter.
   col_alters: a JSONB describing the alterations to make.
@@ -3822,13 +3820,8 @@ BEGIN
     FROM jsonb_array_elements(col_alters) AS x(col_alter_obj)
       INNER JOIN pg_catalog.pg_attribute AS pga ON pga.attnum=(x.col_alter_obj ->> 'attnum')::smallint AND pga.attrelid=tab_id
       LEFT JOIN pg_catalog.pg_attrdef AS pgat ON pgat.adnum=(x.col_alter_obj ->> 'attnum')::smallint AND pgat.adrelid=tab_id
+    WHERE NOT msar.is_mathesar_id_column(tab_id, (x.col_alter_obj ->> 'attnum')::integer)
   LOOP
-    IF col.new_name IS NOT NULL AND msar.is_mathesar_id_column(tab_id, col.attnum) THEN
-      RAISE EXCEPTION USING
-        MESSAGE = 'Mathesar ID column cannot be renamed',
-        ERRCODE = 'check_violation';
-    END IF;
-
     PERFORM msar.set_not_null(tab_id, col.attnum, col.not_null);
     PERFORM msar.rename_column(tab_id, col.attnum, col.new_name);
 

--- a/db/sql/test_sql_functions.sql
+++ b/db/sql/test_sql_functions.sql
@@ -2178,6 +2178,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+
 CREATE OR REPLACE FUNCTION test_alter_columns_single_name() RETURNS SETOF TEXT AS $f$
 DECLARE
   col_alters_jsonb jsonb := '[{"attnum": 2, "name": "blah"}]';
@@ -2189,25 +2190,6 @@ BEGIN
     'col_alters',
     ARRAY['id', 'blah', 'col2', 'Col sp', 'col_opts', 'coltim']
   );
-END;
-$f$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION test_alter_mathesar_id_column_name()
-RETURNS SETOF TEXT AS $f$
-DECLARE
-  tab_oid oid;
-  col_alters_jsonb jsonb := '[{"attnum": 1, "name": "new_id"}]';
-BEGIN
-  PERFORM __setup_column_alter();
-  tab_oid := 'test_schema.col_alters'::regclass::oid;
-
-  BEGIN
-    PERFORM msar.alter_columns(tab_oid, col_alters_jsonb);
-  EXCEPTION
-    WHEN OTHERS THEN
-      RETURN NEXT pass('Exception was correctly raised when renaming Mathesar ID column.');
-  END;
 END;
 $f$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
Fixes #5158 

Reverts mathesar-foundation/mathesar#4931 as suggested by @Anish9901

- The Mathesar schemas need to be reinstalled in the respective databases for the fix to be observed.
- Reverting #4931 also reintroduces the problems mentioned in #4890 (primarily the silent failure).