### PR TITLE
fix: Handle non-orderable column types in record listing (#1321)

### DIFF
--- a/db/sql/00_msar_all_objects_table.sql
+++ b/db/sql/00_msar_all_objects_table.sql
@@ -1145,6 +1145,7 @@ INSERT INTO msar.all_mathesar_objects VALUES
   ('msar', 'msar.get_table_info(regnamespace)', 'FUNCTION', NULL),
   ('msar', 'msar.get_total_order(oid)', 'FUNCTION', NULL),
   ('msar', 'msar.get_type_options(regtype,integer,integer)', 'FUNCTION', NULL),
+  ('msar', 'msar.is_column_orderable(oid,smallint)', 'FUNCTION', NULL),
   ('msar', 'msar.get_unique_local_identifier(text[],text)', 'FUNCTION', NULL),
   ('msar', 'msar.get_valid_target_type_strings(regtype)', 'FUNCTION', NULL),
   ('msar', 'msar.grant_usage_on_custom_mathesar_types_to_public()', 'FUNCTION', NULL),

--- a/db/sql/05_msar.sql
+++ b/db/sql/05_msar.sql
@@ -4542,26 +4542,64 @@ WHERE contype='p' AND conrelid=tab_id AND has_column_privilege(tab_id, attnum, '
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
 
 
+CREATE OR REPLACE FUNCTION msar.is_column_orderable(tab_id oid, col_attnum smallint) RETURNS boolean AS $$/*
+Check if a column is orderable by verifying it has a B-tree operator class.
+
+Args:
+  tab_id: The OID of the table containing the column.
+  col_attnum: The attnum of the column to check.
+
+Returns:
+  true if the column can be used in ORDER BY, false otherwise.
+*/
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_catalog.pg_attribute
+    INNER JOIN pg_catalog.pg_opclass ON atttypid = opcintype
+    INNER JOIN pg_catalog.pg_am ON opcmethod = pg_am.oid
+  WHERE
+    attrelid = tab_id
+    AND attnum = col_attnum
+    AND pg_am.amname = 'btree'
+)
+OR EXISTS (
+  SELECT 1
+  FROM pg_catalog.pg_attribute
+    INNER JOIN pg_catalog.pg_cast ON atttypid = castsource
+    INNER JOIN pg_catalog.pg_opclass ON casttarget = opcintype
+    INNER JOIN pg_catalog.pg_am ON opcmethod = pg_am.oid
+  WHERE
+    attrelid = tab_id
+    AND attnum = col_attnum
+    AND castcontext = 'i'
+    AND pg_am.amname = 'btree'
+);
+$$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;
+
+
 CREATE OR REPLACE FUNCTION msar.get_total_order(tab_id oid) RETURNS jsonb AS $$
 WITH orderable_cte AS (
   SELECT attnum
   FROM pg_catalog.pg_attribute
-    INNER JOIN pg_catalog.pg_cast ON atttypid=castsource
-    INNER JOIN pg_catalog.pg_operator ON casttarget=oprleft
+    INNER JOIN pg_catalog.pg_opclass ON atttypid = opcintype
+    INNER JOIN pg_catalog.pg_am ON opcmethod = pg_am.oid
+  WHERE
+    attrelid = tab_id
+    AND attnum > 0
+    AND NOT attisdropped
+    AND pg_am.amname = 'btree'
+  UNION
+  SELECT attnum
+  FROM pg_catalog.pg_attribute
+    INNER JOIN pg_catalog.pg_cast ON atttypid = castsource
+    INNER JOIN pg_catalog.pg_opclass ON casttarget = opcintype
+    INNER JOIN pg_catalog.pg_am ON opcmethod = pg_am.oid
   WHERE
     attrelid = tab_id
     AND attnum > 0
     AND NOT attisdropped
     AND castcontext = 'i'
-    AND oprname = '<'
-  UNION SELECT attnum
-  FROM pg_catalog.pg_attribute
-    INNER JOIN pg_catalog.pg_operator ON atttypid=oprleft
-  WHERE
-    attrelid = tab_id
-    AND attnum > 0
-    AND NOT attisdropped
-    AND oprname = '<'
+    AND pg_am.amname = 'btree'
   ORDER BY attnum
 )
 SELECT COALESCE(jsonb_agg(jsonb_build_object('attnum', attnum, 'direction', 'asc')), '[]'::jsonb)
@@ -4579,11 +4617,22 @@ Args:
   tab_id: The OID of the table whose columns we'll order by.
   order_: A JSONB array defining any desired ordering of columns.
 */
+WITH filtered_order_cte AS (
+  SELECT attnum, direction
+  FROM jsonb_to_recordset(order_) AS x(attnum smallint, direction text)
+  WHERE msar.is_column_orderable(tab_id, attnum)
+)
 SELECT string_agg(format('%I %s', attnum, msar.sanitize_direction(direction)), ', ')
 FROM jsonb_to_recordset(
     COALESCE(
-      COALESCE(order_, '[]'::jsonb) || msar.get_pkey_order(tab_id),
-      COALESCE(order_, '[]'::jsonb) || msar.get_total_order(tab_id)
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object('attnum', attnum, 'direction', direction)) FROM filtered_order_cte),
+        '[]'::jsonb
+      ) || msar.get_pkey_order(tab_id),
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object('attnum', attnum, 'direction', direction)) FROM filtered_order_cte),
+        '[]'::jsonb
+      ) || msar.get_total_order(tab_id)
     )
 )
   AS x(attnum smallint, direction text)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "mathesar",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- Added msar.is_column_orderable() to check if column has B-tree operator class
- Updated msar.get_total_order() to use pg_opclass instead of checking for < operator
- Updated msar.build_total_order_expr() to filter out non-orderable columns
- Registered new function in msar.all_mathesar_objects

This fixes the issue where tables with non-orderable column types (circle, polygon, json, etc.) could not be loaded due to ORDER BY clause errors.

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number]

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
