### PR TITLE
feat: Add delete button to record page (fixes #1843)

### DIFF
--- a/mathesar_ui/src/pages/record/RecordPageContent.svelte
+++ b/mathesar_ui/src/pages/record/RecordPageContent.svelte
@@ -5,6 +5,7 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
 -->
 <script lang="ts">
   import { _ } from 'svelte-i18n';
+  import { router } from 'tinro';
 
   import { getDetailedRecordsErrors } from '@mathesar/api/rest/utils/recordUtils';
   import { api } from '@mathesar/api/rpc';
@@ -17,18 +18,28 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
   import FormStatus from '@mathesar/components/form/FormStatus.svelte';
   import { RichText } from '@mathesar/components/rich-text';
   import TableLink from '@mathesar/components/TableLink.svelte';
-  import { iconRecord, iconSave, iconUndo } from '@mathesar/icons';
+  import {
+    iconDeleteMajor,
+    iconRecord,
+    iconSave,
+    iconUndo,
+  } from '@mathesar/icons';
   import InsetPageLayout from '@mathesar/layouts/InsetPageLayout.svelte';
+  import { getTablePageUrl } from '@mathesar/routes/urls';
+  import { confirmDelete } from '@mathesar/stores/confirmation';
+  import { toast } from '@mathesar/stores/toast';
   import DirectField from '@mathesar/systems/record-view/DirectField.svelte';
   import type RecordStore from '@mathesar/systems/record-view/RecordStore';
   import RecordViewLoadingSpinner from '@mathesar/systems/record-view/RecordViewLoadingSpinner.svelte';
   import Widgets from '@mathesar/systems/record-view/Widgets.svelte';
+  import { Button, Icon } from '@mathesar-component-library';
 
   export let record: RecordStore;
 
   $: ({ table, tableStructure } = record);
   $: ({ currentRolePrivileges } = table.currentAccess);
   $: canUpdateTableRecords = $currentRolePrivileges.has('UPDATE');
+  $: canDeleteTableRecords = $currentRolePrivileges.has('DELETE');
   $: ({ processedColumns } = tableStructure);
   $: ({ recordPk, summary, fieldValues } = record);
   $: fieldPropsObjects = [...$processedColumns.values()].map((c) => ({
@@ -71,6 +82,39 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
     );
     await record.patch(patch);
   }
+
+  async function handleDeleteRecord() {
+    void confirmDelete({
+      identifierType: $_('record'),
+      body: [
+        $_('deleted_records_cannot_be_recovered', { values: { count: 1 } }),
+        $_('are_you_sure_to_proceed'),
+      ],
+      onProceed: async () => {
+        await api.records
+          .delete({
+            database_id: table.schema.database.id,
+            table_oid: table.oid,
+            record_ids: [recordPk],
+          })
+          .run();
+      },
+      onError: (e) => toast.fromError(e),
+      onSuccess: () => {
+        toast.success({
+          title: $_('count_records_deleted_successfully', {
+            values: { count: 1 },
+          }),
+        });
+        const tablePageUrl = getTablePageUrl(
+          table.schema.database.id,
+          table.schema.oid,
+          table.oid,
+        );
+        router.goto(tablePageUrl);
+      },
+    });
+  }
 </script>
 
 <div class="record-page-content">
@@ -89,6 +133,17 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
       </div>
       <div slot="action">
         <div class="form-status"><FormStatus {form} /></div>
+        <div class="delete-button">
+          <Button
+            on:click={handleDeleteRecord}
+            disabled={!canDeleteTableRecords}
+            appearance="danger"
+            size="small"
+          >
+            <Icon {...iconDeleteMajor} />
+            <span>{$_('delete_records', { values: { count: 1 } })}</span>
+          </Button>
+        </div>
       </div>
     </AppSecondaryHeader>
   </div>
@@ -159,6 +214,13 @@ TODO: Resolve code duplication between this file and RecordViewContent.svelte.
   .form-status {
     grid-row: 1 / span 2;
     grid-column: 2;
+  }
+  .delete-button {
+    grid-row: 1 / span 2;
+    grid-column: 3;
+    display: flex;
+    align-items: center;
+    margin-left: 0.5rem;
   }
 
   .fields {


### PR DESCRIPTION
- Add delete button with confirmation dialog to record page header
- Check DELETE permission before enabling button
- Navigate back to table page after successful deletion
- Show toast notifications for success/error states

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number]

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
