### PR TITLE
Fix calendar dropdown repositioning on scroll in filter records

### DIFF
--- a/mathesar_ui/src/component-library/common/actions/popper.ts
+++ b/mathesar_ui/src/component-library/common/actions/popper.ts
@@ -103,6 +103,55 @@ export default function popper(
   let prevReference: VirtualElement | undefined;
   let observer: ResizeObserver | undefined;
   const autoReposition = actionOpts.autoReposition ?? false;
+  const scrollListeners: Array<{ element: HTMLElement | Window; listener: () => void }> = [];
+
+  function handleScroll() {
+    if (popperInstance) {
+      void popperInstance.update();
+    }
+  }
+
+  function addScrollListeners(reference?: VirtualElement) {
+    // Remove existing scroll listeners
+    scrollListeners.forEach(({ element, listener }) => {
+      element.removeEventListener('scroll', listener);
+    });
+    scrollListeners.length = 0;
+
+    if (!reference || !autoReposition) {
+      return;
+    }
+
+    // Add scroll listener to window
+    scrollListeners.push({ element: window, listener: handleScroll });
+    window.addEventListener('scroll', handleScroll, true);
+
+    // Add scroll listeners to all scrollable parent elements
+    let parent = (reference as { contextElement?: HTMLElement }).contextElement?.parentElement;
+    if (!parent && 'getBoundingClientRect' in reference) {
+      // For virtual elements, try to find a real DOM element
+      const rect = reference.getBoundingClientRect();
+      parent = document.elementFromPoint(rect.x, rect.y)?.parentElement ?? null;
+    }
+
+    while (parent) {
+      const { overflow, overflowX, overflowY } = window.getComputedStyle(parent);
+      const isScrollable = /(auto|scroll)/.test(overflow + overflowX + overflowY);
+      
+      if (isScrollable) {
+        scrollListeners.push({ element: parent, listener: handleScroll });
+        parent.addEventListener('scroll', handleScroll);
+      }
+      parent = parent.parentElement;
+    }
+  }
+
+  function removeScrollListeners() {
+    scrollListeners.forEach(({ element, listener }) => {
+      element.removeEventListener('scroll', listener);
+    });
+    scrollListeners.length = 0;
+  }
 
   function create(reference?: VirtualElement, options?: Partial<Options>) {
     if (!reference) {
@@ -122,11 +171,13 @@ export default function popper(
         void popperInstance.update();
       });
       observer.observe(node);
+      addScrollListeners(reference);
     }
   }
 
   function destroy() {
     observer?.disconnect();
+    removeScrollListeners();
     popperInstance?.destroy();
     prevReference = undefined;
   }

--- a/mathesar_ui/src/component-library/common/actions/popper.ts
+++ b/mathesar_ui/src/component-library/common/actions/popper.ts
@@ -137,7 +137,7 @@ export default function popper(
     while (parent) {
       const { overflow, overflowX, overflowY } = window.getComputedStyle(parent);
       const isScrollable = /(auto|scroll)/.test(overflow + overflowX + overflowY);
-      
+
       if (isScrollable) {
         scrollListeners.push({ element: parent, listener: handleScroll });
         parent.addEventListener('scroll', handleScroll);

--- a/mathesar_ui/src/component-library/date-time-picker/DatePicker.svelte
+++ b/mathesar_ui/src/component-library/date-time-picker/DatePicker.svelte
@@ -25,6 +25,6 @@
   on:keydown
   on:input
 />
-<AttachableDropdown class={contentClass} trigger={element} bind:isOpen on:close>
+<AttachableDropdown class={contentClass} trigger={element} bind:isOpen autoReposition={true} on:close>
   <InlineDateTimePicker type="date" bind:value format={dateFormat} on:change />
 </AttachableDropdown>

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/date-time/DateTimeInput.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/date-time/DateTimeInput.svelte
@@ -100,6 +100,7 @@
   class="retain-active-cell no-max-height"
   trigger={element}
   bind:isOpen
+  autoReposition={true}
   on:close={onDropdownClose}
 >
   <InlineDateTimePicker


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #5168 

<!-- Concisely describe what the pull request does. -->

### Description

This pull request resolves a UI issue where the Date Picker calendar popover becomes detached from its anchor input field when the user scrolls the page or the record selector container. Previously, the calendar remained fixed at its original screen coordinates, overlapping unrelated elements.

This fix ensures the calendar popover is dynamically anchored to the date input field. If the container scrolls, the calendar now repositions itself to maintain alignment with the input.


 Add scroll event listeners to popper action to update dropdown position when scrolling
- Track all scrollable parent elements and listen to their scroll events
- Enable autoReposition prop for DateTimeInput and DatePicker components
- Ensures calendar dropdown repositions smoothly when scrolling through records table

Fixes issue where calendar dropdown would stick to one position instead of following the input field during scrolling.

### 
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

- Scroll Event Listeners: Added scroll event listeners to the popper action logic.

- Parent Tracking: Implemented logic to track all scrollable parent elements relative to the anchor point.

- Auto-Repositioning: Enabled the autoReposition prop for DateTimeInput and DatePicker components.
-Performance: Ensures the calendar dropdown repositions efficiently when scrolling through the records table without significant layout thrashing.

### 
**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
