### PR TITLE
Replace deprecated functions in Url64 methods

### DIFF
--- a/mathesar_ui/src/utils/Url64.ts
+++ b/mathesar_ui/src/utils/Url64.ts
@@ -9,7 +9,7 @@ export default class Url64 {
   static encode(s: string): string {
     const bytes = new TextEncoder().encode(s);
     const binString = Array.from(bytes, (byte) =>
-      String.fromCodePoint(byte),
+      String.fromCharCode(byte),
     ).join('');
     const base64 = btoa(binString);
 
@@ -20,7 +20,7 @@ export default class Url64 {
     const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
 
     const binString = atob(base64);
-    const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0));
+    const bytes = Uint8Array.from(binString, (m) => m.charCodeAt(0));
     return new TextDecoder().decode(bytes);
   }
 }

--- a/mathesar_ui/src/utils/Url64.ts
+++ b/mathesar_ui/src/utils/Url64.ts
@@ -4,23 +4,23 @@
  * The resulting string won't have any characters which require URL encoding. We
  * change `+` to `-` and `/` to `_`. We remove the padding characters `=`
  * altogether because atob only needs them when inputs are concatenated.
- *
- * TODO:
- *
- * - Refactor this code to remove use of deprecated function `escape` and
- *   `unescape`.
- * - See: https://developer.mozilla.org/en-US/docs/Glossary/Base64
- * - Consider using a 3rd party library. Maybe `base64-js`, `base64url` or
- *   `utf8`.
  */
 export default class Url64 {
   static encode(s: string): string {
-    const base64 = btoa(unescape(encodeURIComponent(s)));
+    const bytes = new TextEncoder().encode(s);
+    const binString = Array.from(bytes, (byte) =>
+      String.fromCodePoint(byte),
+    ).join('');
+    const base64 = btoa(binString);
+
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   }
 
   static decode(s: string): string {
     const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
-    return decodeURIComponent(escape(atob(base64)));
+
+    const binString = atob(base64);
+    const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0));
+    return new TextDecoder().decode(bytes);
   }
 }


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #5183 

<!-- Concisely describe what the pull request does. -->
This PR changes the implementation of the `encode` and `decode` methods in the `Url64` util class, to use native encoding and decoding using `TextEncoder` and `TextDecoder` respectively with byte arrays (according to the [recommendation in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings)), instead of the previous implementation which used deprecated functions like `escape` and `unescape`.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The new implementation encodes the string using [TextEncoder's `encode()` function](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode), whose byte array result is converted into a binary string to be passed into `btoa()`. The decoding mechanisms follows the same principle, taking the binary string from `atob()`, converting it into a byte array, and then getting the decoded string with [TextDecoder's `decode()` function](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode).

This implementation deviates a bit from the MDN docs as *char codes* were used instead of *code points* during the byte array conversions. This was done for the code to work well with typescript rules, and also since char codes were more suitable for byte values.

**Demo**

The following link shows a table comparing the resultant values of the previous and new implementations (V1 and V2 respectively, to show that their results are identical): https://jsfiddle.net/yn6d1tpw/2/

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
