### PR TITLE
Fix empty entry in Record Summary custom fields dropdown

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/record-summary/FieldChain.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record-summary/FieldChain.svelte
@@ -43,7 +43,17 @@
       value={column}
       onUpdate={(c) => onUpdate(c ? [c.id] : [])}
       allowEmpty
-    />
+
+    >
+
+      <span slot="empty"  class="do-not-import"> 
+
+        {$_('None')}
+
+      </span>
+
+    </SelectProcessedColumn>
+    
     {#if referentTable}
       <div class="delimiter">
         <FieldDelimiter />

--- a/mathesar_ui/src/systems/table-view/table-inspector/record-summary/FieldChain.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record-summary/FieldChain.svelte
@@ -43,17 +43,11 @@
       value={column}
       onUpdate={(c) => onUpdate(c ? [c.id] : [])}
       allowEmpty
-
     >
-
-      <span slot="empty"  class="do-not-import"> 
-
+      <span slot="empty" class="do-not-import"> 
         {$_('None')}
-
       </span>
-
     </SelectProcessedColumn>
-    
     {#if referentTable}
       <div class="delimiter">
         <FieldDelimiter />


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number]


<!-- Concisely describe what the pull request does. -->
This PR fixes a UI bug in the Inspector panel's Record Summary section. Previously, the "Custom Fields" dropdown displayed a single empty, selectable entry instead of the list of available table columns.

The fix ensures that the dropdown correctly populates with valid column names and filters out undefined or empty objects that were causing the blank entry.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- Modified the logic in the Record Summary component (e.g., RecordSummaryInspector.svelte) to filter the list of available columns.

- Added a check to ensure that only columns with valid names/labels are passed to the dropdown options.

- Ensured that if no fields are available, the empty state is handled gracefully rather than rendering a blank line.
**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
