### PR TITLE
Enhanced login

### DIFF
--- a/mathesar/templates/installation/complete_installation.html
+++ b/mathesar/templates/installation/complete_installation.html
@@ -74,8 +74,8 @@
     display: grid;
     gap: var(--lg1);
     box-shadow: 0 4px 6px -1px var(--color-shadow),
-            0 2px 4px -2px var(--color-shadow),
-            0 0 0 1px var(--color-shadow) inset;
+      0 2px 4px -2px var(--color-shadow),
+      0 0 0 1px var(--color-shadow) inset;
   }
 
   .form-card .form-group-title {
@@ -117,7 +117,7 @@
     color: var(--color-fg-subtle-1);
   }
 
-  
+
   .language-selector-form {
     position: fixed;
     top: 2%;
@@ -148,29 +148,24 @@
 <div class="container">
   <div class="heading">
     <div class="logo">
-      <img
-        src="{% static 'images/red-logo-with-text.svg' %}"
-        alt="Mathesar Logo"
-      />
+      <img src="{% static 'images/red-logo-with-text.svg' %}" alt="Mathesar Logo" />
     </div>
     <h1>{% translate "Finish Setting Up Mathesar" %}</h1>
     <div class="instruction">
       <div>{% translate "Welcome to Mathesar!" %}</div>
       <div>
-        {% translate "Create an Admin user to start using Mathesar. You can also choose to share anonymous data to help us improve." %}
+        {% translate "Create an Admin user to start using Mathesar. You can also choose to share anonymous data to help
+        us improve." %}
       </div>
     </div>
   </div>
 
-  <form
-    method="post"
-    class="form-card"
-    onsubmit="showLoadingStatus({{ creating_user_loader_text }});"
-  >
+  <form method="post" class="form-card" onsubmit="showLoadingStatus({{ creating_user_loader_text }});">
     <div>
       <div class="form-group-title">{% translate "Create Admin User" %}</div>
       <div class="help info title-help">
-        {% translate "Set up an Admin user account. This account will have full control over your Mathesar installation." %}
+        {% translate "Set up an Admin user account. This account will have full control over your Mathesar
+        installation." %}
       </div>
     </div>
 
@@ -181,17 +176,9 @@
         <label for="id_username" class="label-component">
           {% translate "Username" %}
         </label>
-        <input
-          type="text"
-          name="username"
-          class="input-element{% if form.username.errors %} has-error{% endif %}"
-          value="{% if form.username.value %}{{ form.username.value }}{% endif %}"
-          autofocus
-          autocapitalize="none"
-          autocomplete="username"
-          required
-          id="id_username"
-        />
+        <input type="text" name="username" class="input-element{% if form.username.errors %} has-error{% endif %}"
+          value="{% if form.username.value %}{{ form.username.value }}{% endif %}" autofocus autocapitalize="none"
+          autocomplete="username" required id="id_username" />
       </div>
       {% if form.username.errors %}
       <div class="help error">
@@ -207,35 +194,45 @@
             {% translate "Password" %}
           </label>
 
-          <input
-            type="password"
-            name="password1"
-            class="input-element{% if form.password1.errors %} has-error{% endif %}"
-            value="{% if form.password1.value %}{{ form.password1.value }}{% endif %}"
-            autofocus
-            autocapitalize="none"
-            autocomplete="new-password"
-            required
-            id="id_password1"
-          />
+          <div class="password-toggle-wrapper">
+            <input type="password" name="password1"
+              class="input-element{% if form.password1.errors %} has-error{% endif %}"
+              value="{% if form.password1.value %}{{ form.password1.value }}{% endif %}" autofocus autocapitalize="none"
+              autocomplete="new-password" required id="id_password1" />
+            <button type="button" class="toggle-password-btn" aria-label="Toggle password visibility">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+                <path fill="currentColor"
+                  d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z" />
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16"
+                class="icon-eye-slash" style="display: none;">
+                <path fill="currentColor"
+                  d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div>
           <label for="id_password2" class="label-component">
             {% translate "Confirm Password" %}
           </label>
 
-          <div class="input">
-            <input
-              type="password"
-              name="password2"
+          <div class="input password-toggle-wrapper">
+            <input type="password" name="password2"
               class="input-element{% if form.password2.errors %} has-error{% endif %}"
-              value="{% if form.password2.value %}{{ form.password2.value }}{% endif %}"
-              autofocus
-              autocapitalize="none"
-              autocomplete="new-password"
-              required
-              id="id_password2"
-            />
+              value="{% if form.password2.value %}{{ form.password2.value }}{% endif %}" autofocus autocapitalize="none"
+              autocomplete="new-password" required id="id_password2" />
+            <button type="button" class="toggle-password-btn" aria-label="Toggle password visibility">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+                <path fill="currentColor"
+                  d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z" />
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16"
+                class="icon-eye-slash" style="display: none;">
+                <path fill="currentColor"
+                  d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z" />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -284,13 +281,8 @@
     <div class="inputs-container">
       <div class="labeled-input layout-inline-input-first">
         <div class="label-content">
-          <input
-            class="checkbox labeled-input-slot input"
-            type="checkbox"
-            id="one_time_confirmation"
-            name="one_time_installation_confirmation"
-            checked
-          />
+          <input class="checkbox labeled-input-slot input" type="checkbox" id="one_time_confirmation"
+            name="one_time_installation_confirmation" checked />
           <label class="labeled-input-label label-component" for="one_time_confirmation">
             {% translate "Send a one-time confirmation to let us know you've installed Mathesar" %}
           </label>
@@ -302,13 +294,8 @@
       </div>
       <div class="labeled-input layout-inline-input-first">
         <div class="label-content">
-          <input
-            class="checkbox labeled-input-slot input"
-            type="checkbox"
-            id="usage_stats"
-            name="usage_stats"
-            checked
-          />
+          <input class="checkbox labeled-input-slot input" type="checkbox" id="usage_stats" name="usage_stats"
+            checked />
           <label class="labeled-input-label label-component" for="usage_stats">
             {% translate "Enable anonymous usage data collection" %}
           </label>
@@ -316,19 +303,11 @@
             {% translate "Share anonymous usage data periodically to help us improve features." %}
             {% translate "No personal data is collected, and you can change this setting anytime." %}
             <!-- TODO_BETA: Add correct link to analytics information docs-page/website -->
-            <a
-              class="help-link"
-              href="https://docs.mathesar.org/user-guide/usage-data-collection/"
-              target="_blank"
-            >
+            <a class="help-link" href="https://docs.mathesar.org/user-guide/usage-data-collection/" target="_blank">
               {% translate "See what's shared." %}
             </a>
             <div>
-              <a
-                class="help-link"
-                href="https://mathesar.org/privacy"
-                target="_blank"
-              >
+              <a class="help-link" href="https://mathesar.org/privacy" target="_blank">
                 {% translate "See our privacy policy." %}
               </a>
             </div>
@@ -345,15 +324,16 @@
   </form>
   <form class="language-selector-form" action="{% url 'set_language' %}" method="post">{% csrf_token %}
     <input name="next" type="hidden" value="{{ redirect_to }}">
-    <select name="language" onchange="form.submit()" class="language-selector align-center" aria-label="Display Language">
-        {% get_current_language as LANGUAGE_CODE %}
-        {% get_available_languages as LANGUAGES %}
-        {% get_language_info_list for LANGUAGES as languages %}
-        {% for language in languages %}
-            <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
-                {{ language.name_local }} ({{ language.code }})
-            </option>
-        {% endfor %}
+    <select name="language" onchange="form.submit()" class="language-selector align-center"
+      aria-label="Display Language">
+      {% get_current_language as LANGUAGE_CODE %}
+      {% get_available_languages as LANGUAGES %}
+      {% get_language_info_list for LANGUAGES as languages %}
+      {% for language in languages %}
+      <option value="{{ language.code }}" {% if language.code==LANGUAGE_CODE %} selected{% endif %}>
+        {{ language.name_local }} ({{ language.code }})
+      </option>
+      {% endfor %}
     </select>
   </form>
 </div>

--- a/mathesar/templates/mathesar/app_styled_base.html
+++ b/mathesar/templates/mathesar/app_styled_base.html
@@ -2,8 +2,8 @@
 {% load static %}
 
 {% block styles %}
-  {% if development_mode %}
-    <!--
+{% if development_mode %}
+<!--
       In development mode, vite loads mathesar-component-library
       styles, which takes a while. This leads to a flickering
       effect where elements are shown without styles as soon
@@ -11,58 +11,129 @@
       This block hides them until vite loads the styles.
       This is not a concern during production.
     -->
-    <style type="text/css">
-      body {
-        visibility: hidden;
-      }
-    </style>
-  {% else %}
-    {% for css_file in manifest_data.module_css %}
-      <link rel="stylesheet" href="{% static css_file %}" />
-    {% endfor %}
-  {% endif %}
+<style type="text/css">
+  body {
+    visibility: hidden;
+  }
+</style>
+{% else %}
+{% for css_file in manifest_data.module_css %}
+<link rel="stylesheet" href="{% static css_file %}" />
+{% endfor %}
+{% endif %}
 
-  <style type="text/css">
-    .message-box.error-message,
-    .message-box.warning-message {
-      border: 1px solid;
-      border-radius: var(--border-radius-m);
-      padding: var(--sm3);
-      display: flex;
-    }
-    .message-box.error-message .icon,
-    .message-box.warning-message .icon{
-      font-weight: bold;
-      margin-right: 0.5rem;
-      opacity: 0.7;
-    } 
-    .message-box.error-message {
-      background: var(--color-bg-danger);
-      border-color: var(--color-border-danger);
-      color: var(--color-fg-danger);
-    }
-    .message-box.warning-message {
-      background: var(--color-bg-warning);
-      border-color: var(--color-border-warning);
-      color: var(--color-fg-warning)
-    }
-  </style>
+<style type="text/css">
+  .message-box.error-message,
+  .message-box.warning-message {
+    border: 1px solid;
+    border-radius: var(--border-radius-m);
+    padding: var(--sm3);
+    display: flex;
+  }
+
+  .message-box.error-message .icon,
+  .message-box.warning-message .icon {
+    font-weight: bold;
+    margin-right: 0.5rem;
+    opacity: 0.7;
+  }
+
+  .message-box.error-message {
+    background: var(--color-bg-danger);
+    border-color: var(--color-border-danger);
+    color: var(--color-fg-danger);
+  }
+
+  .message-box.warning-message {
+    background: var(--color-bg-warning);
+    border-color: var(--color-border-warning);
+    color: var(--color-fg-warning)
+  }
+
+  /* Password Toggle Styles */
+  .password-toggle-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .password-toggle-wrapper input {
+    padding-right: 2.5rem !important;
+    /* Ensure text doesn't overlap button */
+  }
+
+  .toggle-password-btn {
+    position: absolute;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-fg-subtle-1, #666);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    z-index: 2;
+  }
+
+  .toggle-password-btn:hover {
+    color: var(--color-fg-base, #000);
+  }
+
+  .toggle-password-btn:focus {
+    outline: none;
+  }
+</style>
 
 
-  {% block page_styles %}{% endblock %}
+{% block page_styles %}{% endblock %}
 {% endblock %}
 
 {% block scripts %}
-  {% if development_mode %}
-    <script type="module" src="{{ client_dev_url }}/@vite/client"></script>
-    <script type="module" src="{{ client_dev_url }}/src/component-library/styles.scss"></script>
-    <script type="module" defer>
-      (function () {
-        document.body.style.visibility = 'visible';
-      })();
-    </script>
-  {% endif %}
+{% if development_mode %}
+<script type="module" src="{{ client_dev_url }}/@vite/client"></script>
+<script type="module" src="{{ client_dev_url }}/src/component-library/styles.scss"></script>
+<script type="module" defer>
+  (function () {
+    document.body.style.visibility = 'visible';
+  })();
+</script>
+{% endif %}
 
-  {% block page_scripts %}{% endblock %}
+{% block page_scripts %}{% endblock %}
+
+<script>
+  // Password Visibility Toggle Logic
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.addEventListener('click', function (e) {
+      const btn = e.target.closest('.toggle-password-btn');
+      if (!btn) return;
+
+      // Find the input within the same wrapper
+      const wrapper = btn.closest('.password-toggle-wrapper') || btn.closest('.labeled-input-slot');
+      const input = wrapper ? wrapper.querySelector('input') : null;
+
+      if (input) {
+        const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
+        input.setAttribute('type', type);
+
+        const iconEye = btn.querySelector('.icon-eye');
+        const iconEyeSlash = btn.querySelector('.icon-eye-slash');
+
+        if (type === 'text') {
+          if (iconEye) iconEye.style.display = 'none';
+          if (iconEyeSlash) iconEyeSlash.style.display = 'block';
+
+          // Optional: Focus back to input to keep typing
+          input.focus();
+        } else {
+          if (iconEye) iconEye.style.display = 'block';
+          if (iconEyeSlash) iconEyeSlash.style.display = 'none';
+
+          input.focus();
+        }
+      }
+    });
+  });
+</script>
 {% endblock %}
-

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -4,142 +4,165 @@
 {% block title %}{% translate "Login" %}{% endblock %}
 
 {% block page_styles %}
-  <style type="text/css">
-    body {
-      padding: 4rem 2rem;
-      background: var(--color-bg-base);
-      --login-page-spacing: var(--lg5);
-      color: var(--color-fg-base);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-    .align-center {
-      margin-left: auto;
-      margin-right: auto;
-    }
-    .logo img {
-      width: 13.25rem;
-      display: block;
-    }
-    .tutorial {
-      max-width: 48rem;
-      line-height: var(--lg3);
-    }
-    .tutorial .body {
-      margin-top: var(--sm3);
-    }
-    .login-card {
-      max-width: 28rem;
-      background-color: var(--card-background);
-      padding: var(--login-page-spacing);
-      border-radius: var(--border-radius-l);
-      box-shadow: 0 4px 6px -1px var(--color-shadow),
-                 0 2px 4px -2px var(--color-shadow),
-                 0 0 0 1px var(--color-shadow) inset;
-    }
-    .login-card h1 {
-      font-weight: var(--font-weight-medium);
-      font-size: var(--lg4);
-      margin: 0 0 var(--lg3);
-      text-align: center;
-      color: var(--color-fg-base);
-    }
-    .login-card .labeled-input + .labeled-input {
-      margin-top: var(--sm1);
-    }
-    .login-card .labeled-input .help.info {
-      color: var(--color-fg-subtle-2);
-    }
-    .login-card .labeled-input .help.error {
-      color: var(--color-fg-danger);
-    }
-    .login-card .footer {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: var(--lg3);
-    }
-    .tutorial, .login-card,
-    .login-card form, .login-card .footer {
-      margin-top: var(--login-page-spacing);
-    }
+<style type="text/css">
+  body {
+    padding: 4rem 2rem;
+    background: var(--color-bg-base);
+    --login-page-spacing: var(--lg5);
+    color: var(--color-fg-base);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .align-center {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .logo img {
+    width: 13.25rem;
+    display: block;
+  }
+
+  .tutorial {
+    max-width: 48rem;
+    line-height: var(--lg3);
+  }
+
+  .tutorial .body {
+    margin-top: var(--sm3);
+  }
+
+  .login-card {
+    max-width: 28rem;
+    background-color: var(--card-background);
+    padding: var(--login-page-spacing);
+    border-radius: var(--border-radius-l);
+    box-shadow: 0 4px 6px -1px var(--color-shadow),
+      0 2px 4px -2px var(--color-shadow),
+      0 0 0 1px var(--color-shadow) inset;
+  }
+
+  .login-card h1 {
+    font-weight: var(--font-weight-medium);
+    font-size: var(--lg4);
+    margin: 0 0 var(--lg3);
+    text-align: center;
+    color: var(--color-fg-base);
+  }
+
+  .login-card .labeled-input+.labeled-input {
+    margin-top: var(--sm1);
+  }
+
+  .login-card .labeled-input .help.info {
+    color: var(--color-fg-subtle-2);
+  }
+
+  .login-card .labeled-input .help.error {
+    color: var(--color-fg-danger);
+  }
+
+  .login-card .footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--lg3);
+  }
+
+  .tutorial,
+  .login-card,
+  .login-card form,
+  .login-card .footer {
+    margin-top: var(--login-page-spacing);
+  }
+
+  .unsupported-device {
+    display: none;
+    margin-top: var(--lg3);
+    background: var(--color-bg-danger);
+    border: solid 1px var(--color-border-danger);
+    border-radius: var(--border-radius-m);
+    padding: var(--sm1) var(--lg1);
+  }
+
+  .unsupported-device .title {
+    margin-top: var(--sm3);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--lg1);
+    text-align: center;
+    color: var(--color-fg-base);
+  }
+
+  .unsupported-device .warning-icon {
+    margin-top: var(--sm3);
+    font-size: var(--lg3);
+    text-align: center;
+  }
+
+  .login-card .language-selector {
+    display: block;
+    background-color: var(--color-bg-input);
+    border: 1px solid var(--color-border-input);
+    border-radius: var(--border-radius-m);
+    color: var(--color-fg-base);
+    padding: var(--sm3);
+    cursor: pointer;
+  }
+
+  @media (max-width: 50rem) {
     .unsupported-device {
-      display: none;
-      margin-top: var(--lg3);
-      background: var(--color-bg-danger);
-      border: solid 1px var(--color-border-danger);
-      border-radius: var(--border-radius-m);
-      padding: var(--sm1) var(--lg1);
-    }
-    .unsupported-device .title {
-      margin-top: var(--sm3);
-      font-weight: var(--font-weight-bold);
-      font-size: var(--lg1);
-      text-align: center;
-      color: var(--color-fg-base);
-    }
-    .unsupported-device .warning-icon {
-      margin-top: var(--sm3);
-      font-size: var(--lg3);
-      text-align: center;
-    }
-    .login-card .language-selector {
       display: block;
-      background-color: var(--color-bg-input);
-      border: 1px solid var(--color-border-input);
-      border-radius: var(--border-radius-m);
-      color: var(--color-fg-base);
-      padding: var(--sm3);
-      cursor: pointer;
     }
-    @media (max-width: 50rem) {
-      .unsupported-device {
-        display: block;
-      }
+  }
+
+  @media (max-height: 30rem) {
+    .unsupported-device {
+      display: block;
     }
-    @media (max-height: 30rem) {
-      .unsupported-device {
-        display: block;
-      }
-    }
-  </style>
+  }
+</style>
 {% endblock %}
 
 {% block page_scripts %}
-  <script>
-    function showLoadingStatus(newText) {
-      const loginButton = document.querySelector('form button[type="submit"]');
+<script>
+  function showLoadingStatus(newText) {
+    const loginButton = document.querySelector('form button[type="submit"]');
+    if (loginButton) {
       loginButton.disabled = true;
       loginButton.innerText = newText ?? 'Loading...';
     }
-  </script>
+  }
+</script>
 {% endblock %}
 
 {% block content %}
-  <div class="logo">
-    <img src="{% static 'images/red-logo-with-text.svg' %}" alt="Mathesar Logo" class="align-center"/>
-  </div>
+<div class="logo">
+  <img src="{% static 'images/red-logo-with-text.svg' %}" alt="Mathesar Logo" class="align-center" />
+</div>
 
-  <div class="login-card align-center">
-    <h1>{% block h1 %} {% endblock %}</h1>
-    {% block box_content %} {% endblock %}
-    {% comment %} set_language https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#the-set-language-redirect-view  {% endcomment %}
-    <form action="{% url 'set_language' %}" method="post">{% csrf_token %}
-      <input name="next" type="hidden" value="{{ redirect_to }}">
-      <select name="language" onchange="form.submit()" class="language-selector align-center" aria-label="Display Language">
-          {% get_current_language as LANGUAGE_CODE %}
-          {% get_available_languages as LANGUAGES %}
-          {% get_language_info_list for LANGUAGES as languages %}
-          {% for language in languages %}
-              <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
-                  {{ language.name_local }} ({{ language.code }})
-              </option>
-          {% endfor %}
-      </select>
-    </form>
-   
-  </div>
+<div class="login-card align-center">
+  <h1>{% block h1 %} {% endblock %}</h1>
+  {% block box_content %} {% endblock %}
+  {% comment %} set_language
+  https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#the-set-language-redirect-view {% endcomment %}
+  <form action="{% url 'set_language' %}" method="post">{% csrf_token %}
+    <input name="next" type="hidden" value="{{ redirect_to }}">
+    <select name="language" onchange="form.submit()" class="language-selector align-center"
+      aria-label="Display Language">
+      {% get_current_language as LANGUAGE_CODE %}
+      {% get_available_languages as LANGUAGES %}
+      {% get_language_info_list for LANGUAGES as languages %}
+      {% for language in languages %}
+      <option value="{{ language.code }}" {% if language.code==LANGUAGE_CODE %} selected{% endif %}>
+        {{ language.name_local }} ({{ language.code }})
+      </option>
+      {% endfor %}
+    </select>
+  </form>
+
+</div>
 {% endblock %}

--- a/mathesar/templates/registration/login.html
+++ b/mathesar/templates/registration/login.html
@@ -31,14 +31,26 @@
         </span>
       </label>
     </div>
+
     <div class="labeled-input layout-stacked">
       <label for="id_password" class="label-component">
         <span class="label-content">
           <span class="labeled-input-label">{% translate "Password" %}</span>
-          <span class="labeled-input-slot input">
+          <span class="labeled-input-slot input" style="position: relative; display: flex; align-items: center;">
             <input type="password" name="password"
             class="input-element{% if form.password.errors %} has-error{% endif %}"
-            autocomplete="current-password" required id="id_password">
+            autocomplete="current-password" required id="id_password"
+            style="padding-right: 2.5rem;">
+            <button type="button" id="togglePasswordBtn" class="toggle-password-btn" aria-label="Toggle password visibility">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+                <!-- faEye -->
+                <path fill="currentColor" d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"/>
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16" class="icon-eye-slash" style="display: none;">
+                <!-- faEyeSlash -->
+                <path fill="currentColor" d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z"/>
+              </svg>
+            </button>
           </span>
           {% if form.password.errors %}
             <span class="help error">
@@ -89,4 +101,50 @@
 
     </div>
   </form>
+
+  <style>
+    .toggle-password-btn {
+      position: absolute;
+      right: 0.5rem;
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--color-fg-subtle-1, #666);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.25rem;
+      z-index: 2;
+    }
+    .toggle-password-btn:hover {
+      color: var(--color-fg-base, #000);
+    }
+    .toggle-password-btn:focus {
+      outline: none;
+    }
+  </style>
+
+  <script>
+    (function() {
+      const toggleBtn = document.getElementById('togglePasswordBtn');
+      const passwordInput = document.getElementById('id_password');
+      const iconEye = toggleBtn.querySelector('.icon-eye');
+      const iconEyeSlash = toggleBtn.querySelector('.icon-eye-slash');
+
+      if (toggleBtn && passwordInput) {
+        toggleBtn.addEventListener('click', function() {
+          const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+          passwordInput.setAttribute('type', type);
+          
+          if (type === 'text') {
+            iconEye.style.display = 'none';
+            iconEyeSlash.style.display = 'block';
+          } else {
+            iconEye.style.display = 'block';
+            iconEyeSlash.style.display = 'none';
+          }
+        });
+      }
+    })();
+  </script>
 {% endblock %}

--- a/mathesar/templates/registration/login.html
+++ b/mathesar/templates/registration/login.html
@@ -5,146 +5,99 @@
 {% block h1 %}{% translate "Log in to Mathesar" %}{% endblock %}
 
 {% block box_content %}
-  <form
-    method="post"
-    onsubmit="showLoadingStatus({{ logging_in_loader_text }});"
-  >
-    {% csrf_token %}
-    <div class="labeled-input layout-stacked">
-      <label for="id_username" class="label-component">
-        <span class="label-content">
-          <span class="labeled-input-label">{% translate "Username" %}</span>
-          <span class="labeled-input-slot input">
-            <input type="text" name="username"
-            class="input-element{% if form.username.errors %} has-error{% endif %}"
-            value="{% if form.username.value %}{{form.username.value}}{% endif %}"
-            autofocus autocapitalize="none" autocomplete="username"
-            required id="id_username">
-          </span>
-          {% if form.username.errors %}
-            <span class="help error">
-              {% for error in form.username.errors %}
-                <span>{{error|escape}}</span>
-              {% endfor %}
-            </span>
-          {% endif %}
+<form method="post" onsubmit="showLoadingStatus({{ logging_in_loader_text }});">
+  {% csrf_token %}
+  <div class="labeled-input layout-stacked">
+    <label for="id_username" class="label-component">
+      <span class="label-content">
+        <span class="labeled-input-label">{% translate "Username" %}</span>
+        <span class="labeled-input-slot input">
+          <input type="text" name="username" class="input-element{% if form.username.errors %} has-error{% endif %}"
+            value="{% if form.username.value %}{{form.username.value}}{% endif %}" autofocus autocapitalize="none"
+            autocomplete="username" required id="id_username">
         </span>
-      </label>
-    </div>
-
-    <div class="labeled-input layout-stacked">
-      <label for="id_password" class="label-component">
-        <span class="label-content">
-          <span class="labeled-input-label">{% translate "Password" %}</span>
-          <span class="labeled-input-slot input" style="position: relative; display: flex; align-items: center;">
-            <input type="password" name="password"
-            class="input-element{% if form.password.errors %} has-error{% endif %}"
-            autocomplete="current-password" required id="id_password"
-            style="padding-right: 2.5rem;">
-            <button type="button" id="togglePasswordBtn" class="toggle-password-btn" aria-label="Toggle password visibility">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
-                <!-- faEye -->
-                <path fill="currentColor" d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"/>
-              </svg>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16" class="icon-eye-slash" style="display: none;">
-                <!-- faEyeSlash -->
-                <path fill="currentColor" d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z"/>
-              </svg>
-            </button>
-          </span>
-          {% if form.password.errors %}
-            <span class="help error">
-              {% for error in form.password.errors %}
-                <span>{{error|escape}}</span>
-              {% endfor %}
-            </span>
-          {% endif %}
-        </span>
-      </label>
-    </div>
-    {% if form.non_field_errors %}
-      <div class="message-box error-message">
-        <div class="icon">&#9888;</div>
-        <div>
-          {% for error in form.non_field_errors %}
-            <span>{{error|escape}}</span>
+        {% if form.username.errors %}
+        <span class="help error">
+          {% for error in form.username.errors %}
+          <span>{{error|escape}}</span>
           {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-    <div class="footer">
-      <button class="btn btn-primary submit-button" type="submit">
-        {% translate "Log In" %}
-      </button>
+        </span>
+        {% endif %}
+      </span>
+    </label>
+  </div>
 
-
-      {% load socialaccount %}
-      {% get_providers as socialaccount_providers %}
-      {% for provider in socialaccount_providers %}
-        <a class="btn btn-secondary" href="{% provider_login_url provider process='login'%}">
-        <img src="{% static 'images/sso/' %}{{ provider }}.svg" alt="{{ provider|capfirst }} logo"
-          style="height:1em; vertical-align:middle; margin-right:0.5em" onerror="this.onerror=null; this.src='{% static 'images/sso/default.svg' %}';"/>
-        Login with {{provider|capfirst}}</a>
+  <div class="labeled-input layout-stacked">
+    <label for="id_password" class="label-component">
+      <span class="label-content">
+        <span class="labeled-input-label">{% translate "Password" %}</span>
+        <span class="labeled-input-slot input password-toggle-wrapper">
+          <input type="password" name="password" class="input-element{% if form.password.errors %} has-error{% endif %}"
+            autocomplete="current-password" required id="id_password">
+          <button type="button" id="togglePasswordBtn" class="toggle-password-btn"
+            aria-label="Toggle password visibility">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+              <!-- faEye -->
+              <path fill="currentColor"
+                d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z" />
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16" class="icon-eye-slash"
+              style="display: none;">
+              <!-- faEyeSlash -->
+              <path fill="currentColor"
+                d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z" />
+            </svg>
+          </button>
+        </span>
+        {% if form.password.errors %}
+        <span class="help error">
+          {% for error in form.password.errors %}
+          <span>{{error|escape}}</span>
+          {% endfor %}
+        </span>
+        {% endif %}
+      </span>
+    </label>
+  </div>
+  {% if form.non_field_errors %}
+  <div class="message-box error-message">
+    <div class="icon">&#9888;</div>
+    <div>
+      {% for error in form.non_field_errors %}
+      <span>{{error|escape}}</span>
       {% endfor %}
-      {% if messages %}
-        {% for message in messages %}
-          {% if 'error' in message.tags %}
-            <div class="message-box error-message">
-              <div class="icon">&#9888;</div>
-              <div>
-                  {{ message }}
-              </div>
-            </div>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-
     </div>
-  </form>
+  </div>
+  {% endif %}
+  <div class="footer">
+    <button class="btn btn-primary submit-button" type="submit">
+      {% translate "Log In" %}
+    </button>
 
-  <style>
-    .toggle-password-btn {
-      position: absolute;
-      right: 0.5rem;
-      background: none;
-      border: none;
-      cursor: pointer;
-      color: var(--color-fg-subtle-1, #666);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.25rem;
-      z-index: 2;
-    }
-    .toggle-password-btn:hover {
-      color: var(--color-fg-base, #000);
-    }
-    .toggle-password-btn:focus {
-      outline: none;
-    }
-  </style>
 
-  <script>
-    (function() {
-      const toggleBtn = document.getElementById('togglePasswordBtn');
-      const passwordInput = document.getElementById('id_password');
-      const iconEye = toggleBtn.querySelector('.icon-eye');
-      const iconEyeSlash = toggleBtn.querySelector('.icon-eye-slash');
+    {% load socialaccount %}
+    {% get_providers as socialaccount_providers %}
+    {% for provider in socialaccount_providers %}
+    <a class="btn btn-secondary" href="{% provider_login_url provider process='login'%}">
+      <img src="{% static 'images/sso/' %}{{ provider }}.svg" alt="{{ provider|capfirst }} logo"
+        style="height:1em; vertical-align:middle; margin-right:0.5em"
+        onerror="this.onerror=null; this.src='{% static 'images/sso/default.svg' %}';" />
+      Login with {{provider|capfirst}}</a>
+    {% endfor %}
+    {% if messages %}
+    {% for message in messages %}
+    {% if 'error' in message.tags %}
+    <div class="message-box error-message">
+      <div class="icon">&#9888;</div>
+      <div>
+        {{ message }}
+      </div>
+    </div>
+    {% endif %}
+    {% endfor %}
+    {% endif %}
 
-      if (toggleBtn && passwordInput) {
-        toggleBtn.addEventListener('click', function() {
-          const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-          passwordInput.setAttribute('type', type);
-          
-          if (type === 'text') {
-            iconEye.style.display = 'none';
-            iconEyeSlash.style.display = 'block';
-          } else {
-            iconEye.style.display = 'block';
-            iconEyeSlash.style.display = 'none';
-          }
-        });
-      }
-    })();
-  </script>
+  </div>
+</form>
+
 {% endblock %}

--- a/mathesar/templates/users/password_reset_confirmation.html
+++ b/mathesar/templates/users/password_reset_confirmation.html
@@ -4,75 +4,84 @@
 {% block h1 %}{% translate "Update Your Password" %}{% endblock %}
 
 {% block box_content %}
-  {% if validlink %}
-    <p>{% translate "Since your password was set by an administrator, you need to update your password to continue." %}</p>
-    <form method="post" onsubmit="showLoadingStatus('Updating...');">
-      {% csrf_token %}
-      <div class="labeled-input layout-stacked">
-        <label for="id_new_password1" class="label-component">
-          <span class="label-content">
-            <span class="labeled-input-label">{% translate "New Password" %}</label>
-            <span class="labeled-input-slot input">
-              <input
-                type="password"
-                name="new_password1"
-                class="input-element{% if form.new_password1.errors %} has-error{% endif %}"
-                value="{% if form.new_password1.value %}{{form.new_password1.value}}{% endif %}"
-                autofocus
-                autocapitalize="none"
-                autocomplete="new-password"
-                required
-                id="id_new_password1"
-              />
-            </span>
-            {% if form.new_password1.errors %}
-              <span class="help error">
-                {% for error in form.new_password1.errors %}
-                  <span>{{error|escape}}</span>
-                {% endfor %}
-              </span>
-            {% endif %}
-          </span>
-        </label>
-      </div>
-      <div class="labeled-input layout-stacked">
-        <label for="id_new_password2" class="label-component">
-          <span class="label-content">
-            <span class="labeled-input-label">{% translate "Confirm" %}</span>
-            <span class="labeled-input-slot input">
-              <input
-                type="password"
-                name="new_password2"
-                class="input-element{% if form.new_password2.errors %} has-error{% endif %}"
-                value="{% if form.new_password2.value %}{{form.new_password2.value}}{% endif %}"
-                autofocus
-                autocapitalize="none"
-                autocomplete="new-password"
-                required
-                id="id_new_password2"
-              />
-            </span>
-            {% if form.new_password2.errors %}
-              <span class="help error">
-                {% for error in form.new_password2.errors %}
-                  <span>{{error|escape}}</span>
-                {% endfor %}
-              </span>
-            {% endif %}
-          </span>
-        </label>
-      </div>
-      <div class="footer">
-        <div class="message-box warning-message">
-          <div class="icon">&#9432;</div>
-          <div>{% translate "After updating your password, you'll need to log in again." %}</div>
-        </div>
-        <button class="btn btn-primary submit-button" type="submit">
-          {% translate "Update Password" %}
-        </button>
-      </div>
-    </form>
-  {% else %}
-    <p>{% translate "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}</p>
-  {% endif %}
+{% if validlink %}
+<p>{% translate "Since your password was set by an administrator, you need to update your password to continue." %}</p>
+<form method="post" onsubmit="showLoadingStatus('Updating...');">
+  {% csrf_token %}
+  <div class="labeled-input layout-stacked">
+    <label for="id_new_password1" class="label-component">
+      <span class="label-content">
+        <span class="labeled-input-label">{% translate "New Password" %}</label>
+    <span class="labeled-input-slot input password-toggle-wrapper">
+      <input type="password" name="new_password1"
+        class="input-element{% if form.new_password1.errors %} has-error{% endif %}"
+        value="{% if form.new_password1.value %}{{form.new_password1.value}}{% endif %}" autofocus autocapitalize="none"
+        autocomplete="new-password" required id="id_new_password1" />
+      <button type="button" class="toggle-password-btn" aria-label="Toggle password visibility">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+          <path fill="currentColor"
+            d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z" />
+        </svg>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16" class="icon-eye-slash"
+          style="display: none;">
+          <path fill="currentColor"
+            d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z" />
+        </svg>
+      </button>
+    </span>
+    {% if form.new_password1.errors %}
+    <span class="help error">
+      {% for error in form.new_password1.errors %}
+      <span>{{error|escape}}</span>
+      {% endfor %}
+    </span>
+    {% endif %}
+    </span>
+    </label>
+  </div>
+  <div class="labeled-input layout-stacked">
+    <label for="id_new_password2" class="label-component">
+      <span class="label-content">
+        <span class="labeled-input-label">{% translate "Confirm" %}</span>
+        <span class="labeled-input-slot input password-toggle-wrapper">
+          <input type="password" name="new_password2"
+            class="input-element{% if form.new_password2.errors %} has-error{% endif %}"
+            value="{% if form.new_password2.value %}{{form.new_password2.value}}{% endif %}" autofocus
+            autocapitalize="none" autocomplete="new-password" required id="id_new_password2" />
+          <button type="button" class="toggle-password-btn" aria-label="Toggle password visibility">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="16" height="16" class="icon-eye">
+              <path fill="currentColor"
+                d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z" />
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" width="16" height="16" class="icon-eye-slash"
+              style="display: none;">
+              <path fill="currentColor"
+                d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a33.06 33.06 0 0 0 0-26.5c-53.6-106.7-160.7-177.9-281.5-177.9-39.7 0-78.6 7.7-115 22L47.7 7.7c-.5-.4-1.1-.3-1.5-.2zM324 100c92.8 0 174.5 54.4 213.9 133.5a242.4 242.4 0 0 1-52.1 66.1L480 305.4a100.06 100.06 0 0 0-33.8-37.5l-33.3-26.1c-9.1-7.1-18.7-13.4-28.7-18.7L330.6 182c8.9-1.3 17.9-2 27.2-2zm-46.7 32l62.2 48.8c.8 3.5 1.1 7.1 1.1 10.6 0 26.5-21.5 48-48 48-.8 0-1.6-.1-2.4-.2l-51.4-40.3c1.6-9.6 6.3-18.4 13.3-25.5 6.4-6.4 15.2-10.4 24.8-11.4l.4-.1zm-136 6L285 249.2a99.45 99.45 0 0 0 71.9 85.3l-28.9 22.7a143.95 143.95 0 0 1-52.1 3.2 144.17 144.17 0 0 1-131-155.1c0-21.4 5.3-41.5 14.5-59.5l-18-14.1A246.34 246.34 0 0 0 32 233.5 33.06 33.06 0 0 0 32 260c53.6 106.7 160.7 177.9 281.5 177.9 59.8 0 115.8-17.7 163.7-48.4L515 419.1 141.2 138z" />
+            </svg>
+          </button>
+        </span>
+        {% if form.new_password2.errors %}
+        <span class="help error">
+          {% for error in form.new_password2.errors %}
+          <span>{{error|escape}}</span>
+          {% endfor %}
+        </span>
+        {% endif %}
+      </span>
+    </label>
+  </div>
+  <div class="footer">
+    <div class="message-box warning-message">
+      <div class="icon">&#9432;</div>
+      <div>{% translate "After updating your password, you'll need to log in again." %}</div>
+    </div>
+    <button class="btn btn-primary submit-button" type="submit">
+      {% translate "Update Password" %}
+    </button>
+  </div>
+</form>
+{% else %}
+<p>{% translate "The password reset link was invalid, possibly because it has already been used. Please request a new
+  password reset." %}</p>
+{% endif %}
 {% endblock %}

--- a/mathesar_ui/src/component-library/password-input/PasswordInput.svelte
+++ b/mathesar_ui/src/component-library/password-input/PasswordInput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import BaseInput from '@mathesar-component-library-dir/common/base-components/BaseInput.svelte';
+  import Icon from '../icon/Icon.svelte';
+  import { iconShow, iconHide } from '@mathesar/icons';
 
   import type { PasswordInputProps } from './PasswordInputTypes';
 
@@ -22,22 +24,67 @@
 
   // Id for the input
   export let id: $$Props['id'] = undefined;
+
+  let showPassword = false;
+  $: type = showPassword ? 'text' : 'password';
 </script>
 
 <BaseInput {...$$restProps} bind:id />
 
-<input
-  bind:this={element}
-  {...$$restProps}
-  type="password"
-  class={['input-element', 'password-input', ...classes.split(' ')].join(' ')}
-  class:has-error={hasError}
-  bind:value
-  {id}
-  on:input
-  on:focus
-  on:blur
-  on:keydown
-  on:beforeinput
-  on:change
-/>
+<div class={`password-input-container ${classes}`}>
+  <input
+    bind:this={element}
+    {...$$restProps}
+    {type}
+    class="input-element password-input"
+    class:has-error={hasError}
+    bind:value
+    {id}
+    on:input
+    on:focus
+    on:blur
+    on:keydown
+    on:beforeinput
+    on:change
+  />
+  <button
+    class="toggle-visibility"
+    type="button"
+    on:click={() => (showPassword = !showPassword)}
+    tabindex="-1"
+  >
+    <Icon icon={showPassword ? iconHide : iconShow} size="sm" />
+  </button>
+</div>
+
+<style lang="scss">
+  .password-input-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+
+    .password-input {
+      width: 100%;
+      padding-right: 2.25rem;
+    }
+
+    .toggle-visibility {
+      position: absolute;
+      right: 0.5rem;
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--color-fg-subtle-1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      height: 100%;
+      
+      &:hover {
+        color: var(--color-fg-base);
+      }
+    }
+  }
+</style>

--- a/mathesar_ui/src/icons/index.ts
+++ b/mathesar_ui/src/icons/index.ts
@@ -31,6 +31,7 @@ import {
   faExternalLink,
   faExternalLinkAlt,
   faEyeSlash,
+  faEye,
   faFile,
   faFileAlt,
   faFileArchive,
@@ -199,6 +200,8 @@ export const iconFillOutForm: IconProps = { data: faPlay };
 export const iconDownload: IconProps = { data: faCloudDownloadAlt };
 export const iconSelectMultipleCells: IconProps = { data: faExpand };
 export const iconHideColumn: IconProps = { data: faEyeSlash };
+export const iconShow: IconProps = { data: faEye };
+export const iconHide: IconProps = { data: faEyeSlash };
 
 // THINGS
 //


### PR DESCRIPTION
feat(ui): add password visibility toggle to input fields

Added a password visibility toggle (eye icon) to password input fields to improve user experience and reduce entry errors.

Changes:
- Updated `PasswordInput` component in the component library to include a toggle button that switches between 'password' and 'text' types.
- Added `iconShow` (faEye) and `iconHide` (faEyeSlash) to the shared icons library.
- Implemented a similar visibility toggle on the Django-rendered login page ([login.html](cci:7://file:///Users/sapnilbiswas/Sapnil/Web-Dev/API/mathesar/mathesar/templates/registration/login.html:0:0-0:0)) using vanilla JS and inline SVGs.