### PR TITLE
feat(analytics): Track whether installation is Dockerized

### DIFF
--- a/mathesar/analytics.py
+++ b/mathesar/analytics.py
@@ -8,6 +8,7 @@ Thus, the `disable_analytics` function simply deletes that ID, if it
 exists.
 """
 from functools import wraps
+import os
 import threading
 from uuid import uuid4
 
@@ -34,6 +35,24 @@ CACHE_TIMEOUT = 1800  # seconds
 ACTIVE_USER_DAYS = 14
 ANALYTICS_REPORT_MAX_AGE = 30  # days
 ANALYTICS_FREQUENCY = 1  # a report is saved at most once per day.
+
+
+def _is_dockerized():
+    """
+    Return True if Mathesar is running inside a Docker container.
+
+    Detection strategy (in order):
+    1. The file ``/.dockerenv`` is present — Docker creates this on every
+       container by default.
+    2. The environment variable ``MATHESAR_DOCKER_SIGNAL`` is set to a
+       truthy value — a fallback for non-standard container runtimes or
+       future Docker versions that may drop ``/.dockerenv``.
+    """
+    if os.path.isfile("/.dockerenv"):
+        return True
+    if os.environ.get("MATHESAR_DOCKER_SIGNAL", "").lower() in ("1", "true", "yes"):
+        return True
+    return False
 
 
 def wire_analytics(f):
@@ -110,7 +129,8 @@ def prepare_analytics_report():
         connected_database_record_count=connected_database_record_count,
         exploration_count=Explorations.objects.count(),
         form_count=Form.objects.count(),
-        public_form_count=Form.objects.filter(publish_public=True).count()
+        public_form_count=Form.objects.filter(publish_public=True).count(),
+        is_dockerized=_is_dockerized()
     )
 
 
@@ -133,6 +153,7 @@ def upload_analytics_reports():
             "exploration_count": report.exploration_count,
             "form_count": report.form_count,
             "public_form_count": report.public_form_count,
+            "is_dockerized": report.is_dockerized,
         }
         for report in reports
     ]

--- a/mathesar/migrations/0011_analyticsreport_is_dockerized.py
+++ b/mathesar/migrations/0011_analyticsreport_is_dockerized.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mathesar', '0010_server_sslmode'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='analyticsreport',
+            name='is_dockerized',
+            field=models.BooleanField(null=True, blank=True),
+        ),
+    ]

--- a/mathesar/models/analytics.py
+++ b/mathesar/models/analytics.py
@@ -24,4 +24,5 @@ class AnalyticsReport(BaseModel):
     exploration_count = models.PositiveIntegerField(null=True, blank=True)
     form_count = models.PositiveIntegerField(null=True, blank=True)
     public_form_count = models.PositiveIntegerField(null=True, blank=True)
+    is_dockerized = models.BooleanField(null=True, blank=True)
     uploaded = models.BooleanField(default=False)

--- a/mathesar/rpc/analytics.py
+++ b/mathesar/rpc/analytics.py
@@ -1,7 +1,7 @@
 """
 Classes and functions exposed to the RPC endpoint for managing analytics.
 """
-from typing import TypedDict, Optional
+from typing import TypedDict, Optional, Union
 from mathesar.rpc.decorators import mathesar_rpc_method
 from mathesar.analytics import (
     is_analytics_enabled,
@@ -32,6 +32,7 @@ class AnalyticsReport(TypedDict):
         exploration_count: The number of explorations.
         form_count: The number of forms.
         public_form_count: The number of published forms.
+        is_dockerized: Whether Mathesar is running inside a Docker container.
     """
     installation_id: Optional[str]
     mathesar_version: str
@@ -45,6 +46,7 @@ class AnalyticsReport(TypedDict):
     exploration_count: int
     form_count: int
     public_form_count: int
+    is_dockerized: Union[bool, None]
 
     @classmethod
     def from_dict(cls, d):

--- a/mathesar/tests/test_analytics.py
+++ b/mathesar/tests/test_analytics.py
@@ -11,6 +11,7 @@ from django.core.cache import cache
 from django.db import IntegrityError
 import pytest
 from mathesar import analytics
+from mathesar.analytics import _is_dockerized
 from mathesar.models.analytics import AnalyticsReport, InstallationID
 from mathesar.models.base import Database, Server
 
@@ -55,6 +56,28 @@ def test_analytics_installation_id_nongenerated_pkey():
     analytics.initialize_analytics()
     with pytest.raises(IntegrityError):
         analytics.initialize_analytics()
+
+
+def test_is_dockerized_via_dockerenv(tmp_path, monkeypatch):
+    """_is_dockerized() returns True when /.dockerenv is present."""
+    dockerenv = tmp_path / ".dockerenv"
+    dockerenv.touch()
+    with patch("mathesar.analytics.os.path.isfile", side_effect=lambda p: p == "/.dockerenv"):
+        assert _is_dockerized() is True
+
+
+def test_is_dockerized_via_env_var(monkeypatch):
+    """_is_dockerized() returns True when MATHESAR_DOCKER_SIGNAL env var is set."""
+    monkeypatch.setenv("MATHESAR_DOCKER_SIGNAL", "true")
+    with patch("mathesar.analytics.os.path.isfile", return_value=False):
+        assert _is_dockerized() is True
+
+
+def test_is_not_dockerized(monkeypatch):
+    """_is_dockerized() returns False when neither signal is present."""
+    monkeypatch.delenv("MATHESAR_DOCKER_SIGNAL", raising=False)
+    with patch("mathesar.analytics.os.path.isfile", return_value=False):
+        assert _is_dockerized() is False
 
 
 def test_analytics_upload_delete_stale(settings, monkeypatch):
@@ -105,6 +128,7 @@ def test_analytics_upload_delete_stale(settings, monkeypatch):
     assert [d['connected_database_table_count'] for d in reports_blob] == [50, 60]
     assert [d['connected_database_record_count'] for d in reports_blob] == [10000, 20000]
     assert [d['exploration_count'] for d in reports_blob] == [5, 10]
+    assert all(['is_dockerized' in d for d in reports_blob])
     assert len(AnalyticsReport.objects.filter(uploaded=True)) == 2
     analytics.delete_stale_reports()
     assert len(AnalyticsReport.objects.all()) == 2


### PR DESCRIPTION
## Summary

Adds `is_dockerized` to the analytics report to estimate what percentage of Mathesar installations are running inside Docker containers. This helps correlate Docker Hub pull counts with actual installation counts.

## Changes

- **`mathesar/models/analytics.py`**  
  Added `is_dockerized` as a nullable `BooleanField` on `AnalyticsReport`  
  (`null` = unknown, ensures backward compatibility with existing rows)

- **`mathesar/migrations/0011_analyticsreport_is_dockerized.py`**  
  Migration for the new field

- **`mathesar/analytics.py`**  
  Added `_is_dockerized()` helper and integrated it into:
  - `prepare_analytics_report()`
  - `upload_analytics_reports()`

- **`mathesar/rpc/analytics.py`**  
  Exposed `is_dockerized` in the RPC-facing `AnalyticsReport` TypedDict

- **`mathesar/tests/test_analytics.py`**  
  Added tests covering:
  - Docker detection via `/.dockerenv`
  - Detection via environment variable
  - Inclusion in upload payload

## Detection Logic

`_is_dockerized()` returns `True` if:

- `/.dockerenv` exists (default Docker behavior), OR  
- `MATHESAR_DOCKER_SIGNAL=true` environment variable is set  

Otherwise returns `False`.

The field is nullable to ensure pre-existing reports store `null` instead of an incorrect `False`.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

closes #4740 