### PR TITLE
Support custom branding

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -310,6 +310,7 @@ MATHESAR_UI_SOURCE_LOCATION = os.path.join(BASE_DIR, 'mathesar_ui/')
 MATHESAR_STATIC_NON_CODE_FILES_LOCATION = os.path.join(BASE_DIR, 'mathesar/static/non-code/')
 MATHESAR_ANALYTICS_URL = os.environ.get('MATHESAR_ANALYTICS_URL', default='https://example.com/collector')
 MATHESAR_INIT_REPORT_URL = os.environ.get('MATHESAR_INIT_REPORT_URL', default='https://example.com/hello')
+MATHESAR_CUSTOM_LOGO_URL = os.environ.get('MATHESAR_CUSTOM_LOGO_URL')
 MATHESAR_FEEDBACK_URL = os.environ.get('MATHESAR_FEEDBACK_URL', default='https://example.com/feedback')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -23,6 +23,19 @@
     .logo img {
       width: 13.25rem;
       display: block;
+      object-fit: contain;
+    }
+    .logo .custom-logo {
+      max-height: 10rem;
+    }
+    .powered-by-tag {
+      margin-top: var(--lg2);
+      font-size: var(--sm2);
+      color: var(--color-fg-subtle);
+    }
+    .powered-by-tag a {
+      color: inherit;
+      text-decoration: underline;
     }
     .tutorial {
       max-width: 48rem;
@@ -120,7 +133,11 @@
 
 {% block content %}
   <div class="logo">
-    <img src="{% static 'images/red-logo-with-text.svg' %}" alt="Mathesar Logo" class="align-center"/>
+    {% if common_data.custom_logo_url %}
+      <img src="{{ common_data.custom_logo_url }}" alt="Custom Logo" class="align-center custom-logo"/>
+    {% else %}
+      <img src="{% static 'images/red-logo-with-text.svg' %}" alt="Mathesar Logo" class="align-center"/>
+    {% endif %}
   </div>
 
   <div class="login-card align-center">
@@ -142,4 +159,9 @@
     </form>
    
   </div>
+  {% if common_data.custom_logo_url %}
+    <div class="powered-by-tag align-center">
+      Powered by <a href="https://mathesar.org" target="_blank">Mathesar</a>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/mathesar/views/__init__.py
+++ b/mathesar/views/__init__.py
@@ -98,6 +98,7 @@ def get_base_common_data(request):
         'is_authenticated': not request.user.is_anonymous,
         'supported_languages': dict(getattr(settings, 'LANGUAGES', [])),
         'file_backends': get_file_backends(public_info=True),
+        'custom_logo_url': getattr(settings, 'MATHESAR_CUSTOM_LOGO_URL', None),
     }
 
 

--- a/mathesar_ui/src/components/LogoAndNameWithLink.svelte
+++ b/mathesar_ui/src/components/LogoAndNameWithLink.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
+  import { preloadCommonData } from '@mathesar/utils/preloadData';
+
   import Logo from './Logo.svelte';
   import MathesarName from './MathesarName.svelte';
+
+  const commonData = preloadCommonData();
+  const { custom_logo_url } = commonData;
 
   export let href: string;
   export let compactLayout = false;
 </script>
 
 <a {...$$restProps} {href} class="home-link" class:compact={compactLayout}>
-  <Logo />
-  <div class="mathesar"><MathesarName /></div>
+  {#if custom_logo_url}
+    <img src={custom_logo_url} alt="Custom Logo" class="custom-logo" />
+  {:else}
+    <Logo />
+    <div class="mathesar"><MathesarName /></div>
+  {/if}
 </a>
 
 <style>
@@ -32,5 +41,9 @@
   }
   .home-link.compact .mathesar {
     display: none;
+  }
+  .custom-logo {
+    height: 1.5rem;
+    object-fit: contain;
   }
 </style>

--- a/mathesar_ui/src/layouts/LayoutWithHeader.svelte
+++ b/mathesar_ui/src/layouts/LayoutWithHeader.svelte
@@ -15,6 +15,8 @@
   $: style = cssVariables
     ? makeStyleStringFromCssVariables(cssVariables)
     : undefined;
+
+  const { custom_logo_url } = commonData;
 </script>
 
 <div class="app-layout" class:fit-viewport={fitViewport} {style}>
@@ -23,6 +25,11 @@
       <AppHeader />
     </div>
     <slot name="secondary-header" />
+    {#if custom_logo_url}
+      <footer class="app-footer">
+        Powered by <a href="https://mathesar.org" target="_blank">Mathesar</a>
+      </footer>
+    {/if}
   {/if}
   <main class="app-layout-content" class:restrict-width={restrictWidth}>
     <slot />
@@ -30,6 +37,20 @@
 </div>
 
 <style lang="scss">
+  .app-footer {
+    padding: 0.5rem;
+    text-align: center;
+    font-size: var(--sm2);
+    color: var(--color-fg-subtle);
+    border-top: 1px solid var(--color-border-base);
+    background-color: var(--color-bg-raised);
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
   .app-layout {
     height: 100%;
     display: flex;

--- a/mathesar_ui/src/utils/preloadData.ts
+++ b/mathesar_ui/src/utils/preloadData.ts
@@ -24,6 +24,7 @@ export interface BaseCommonData {
   supported_languages: Record<string, string>;
   is_authenticated: boolean;
   file_backends: { backend: string; anonymous_access: boolean }[] | null;
+  custom_logo_url: string | null;
 }
 
 export interface AuthenticatedCommonData extends BaseCommonData {


### PR DESCRIPTION
## Description

This PR adds support for custom instance branding by allowing administrators to configure a custom logo for their Mathesar instance.

Closes #4960 

## Problem

Currently, Mathesar instances always display the default logo and branding, with no option for customization. This limits flexibility for self-hosted deployments that require organization-specific branding.

## Solution

Introduced a configurable `MATHESAR_CUSTOM_LOGO_URL` setting (via environment variable) to enable custom logo support across the application.

## Changes Made

### Backend

- Added `MATHESAR_CUSTOM_LOGO_URL` to configuration (`common_settings.py`)
- Passed the custom logo URL via `common_data` to:
  - Django templates
  - Svelte frontend

### Frontend / UI

- **Login Page**
  - Replaced default logo with custom logo (if provided)
  - Added "Powered by Mathesar" tagline with link to Mathesar.org

- **Application Header**
  - Updated `LogoAndNameWithLink.svelte` to display custom logo instead of default branding

- **Global Layout**
  - Added persistent footer showing branding ("Powered by Mathesar")

- **Data Layer**
  - Updated `BaseCommonData` interface to include custom logo support

### Styling

- Ensured proper rendering of custom logos using:
  - `object-fit: contain`
  - Controlled height constraints for layout consistency

## Impact

- Enables instance-level branding customization  
- Maintains Mathesar attribution via "Powered by Mathesar"  
- No impact on existing behavior when no custom logo is provided  

## Testing

- Verified custom logo renders correctly on:
  - Login page  
  - Application header  
- Confirmed fallback to default logo when no URL is set  
- Checked layout consistency with different logo sizes  

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
