### PR TITLE
Pass database_id to get_exploration in exploration_chunker

### DIFF
--- a/mathesar/utils/explorations.py
+++ b/mathesar/utils/explorations.py
@@ -188,6 +188,7 @@ def run_exploration(exploration_def, conn, limit=100, offset=0):
 
 def exploration_chunker(
     conn,
+    database_id,
     exploration_id,
     limit=None,
     offset=None,
@@ -195,7 +196,7 @@ def exploration_chunker(
 ):
     limit = min(limit or 50000, 50000)  # We cap limit at 50000
     # so that we can avoid loading explorations > 50000 rows into memory.
-    exp_model = get_exploration(exploration_id)
+    exp_model = get_exploration(exploration_id, database_id)
     exploration_def = {
         "database_id": exp_model.database.id,
         "base_table_oid": exp_model.base_table_oid,

--- a/mathesar/views/export.py
+++ b/mathesar/views/export.py
@@ -34,7 +34,7 @@ def export_exploration_csv_in_chunks(
 ):
     with connect(database_id, user) as conn:
         csv_buffer = StringIO()
-        exploration_chunk_gen = exploration_chunker(conn, exploration_id, **kwargs)
+        exploration_chunk_gen = exploration_chunker(conn, database_id, exploration_id, **kwargs)
         columns = next(exploration_chunk_gen)
         csv_writer = csv.DictWriter(csv_buffer, fieldnames=columns)
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #5262 

<!-- Concisely describe what the pull request does. -->
This PR adds a `database_id` parameter to the  `exploration_chunker` function that is then passed to the `get_exploration` function, which fixes the ability to export explorations to CSV downloads.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
