### PR TITLE
REQUIRE_SSO_LOGIN env variable to force users to only login via SSO

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from django.core.management.utils import get_random_secret_key
 
 from config.database_config import PostgresConfig, parse_port
-from config.sso_config import load_sso_config
+from config.sso_config import load_sso_config, resolve_require_sso_login
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -74,6 +74,11 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 SOCIALACCOUNT_ADAPTER = "mathesar.sso.SocialAccountAdapter"
+
+REQUIRE_SSO_LOGIN = resolve_require_sso_login(
+    env_value=os.environ.get('REQUIRE_SSO_LOGIN'),
+    sso_config=SSO_CONFIG,
+)
 
 AUTHENTICATION_BACKENDS = [
     # Needed to login by username in Django admin, regardless of `allauth`

--- a/config/sso_config.py
+++ b/config/sso_config.py
@@ -21,6 +21,19 @@ def load_sso_config(env_value=None, config_file=None):
     return parse_sso_config(_read_raw(env_value, config_file))
 
 
+def resolve_require_sso_login(env_value, sso_config):
+    requested = env_value in ['t', 'true', 'True']
+    if not requested:
+        return False
+    if not (sso_config.oidc_apps or sso_config.github_apps):
+        logger.warning(
+            "REQUIRE_SSO_LOGIN is set but no SSO provider is configured; "
+            "password login remains active."
+        )
+        return False
+    return True
+
+
 def parse_sso_config(raw):
     if not raw:
         return SSOConfig()

--- a/config/tests/test_sso_config.py
+++ b/config/tests/test_sso_config.py
@@ -1,7 +1,12 @@
 import json
 import pytest
 
-from config.sso_config import SSOConfig, load_sso_config, parse_sso_config
+from config.sso_config import (
+    SSOConfig,
+    load_sso_config,
+    parse_sso_config,
+    resolve_require_sso_login,
+)
 
 
 def _oidc_provider(**overrides):
@@ -175,3 +180,27 @@ def test_load_env_value_takes_precedence_over_file(tmp_path):
 
 def test_load_missing_file_returns_empty(tmp_path):
     assert load_sso_config(config_file=str(tmp_path / "nope.yml")) == SSOConfig()
+
+
+@pytest.mark.parametrize("env_value", [None, "", "false", "False", "0", "no"])
+def test_resolve_require_sso_login_disabled_when_env_falsey(env_value):
+    sso = parse_sso_config({"version": 1, "oidc_providers": {"p": _oidc_provider()}})
+    assert resolve_require_sso_login(env_value, sso) is False
+
+
+@pytest.mark.parametrize("env_value", ["t", "true", "True"])
+def test_resolve_require_sso_login_true_when_env_truthy_and_provider_configured(env_value):
+    sso = parse_sso_config({"version": 1, "oidc_providers": {"p": _oidc_provider()}})
+    assert resolve_require_sso_login(env_value, sso) is True
+
+
+def test_resolve_require_sso_login_true_with_github_provider():
+    sso = parse_sso_config({"version": 2, "providers": {"gh": _github_provider()}})
+    assert resolve_require_sso_login("true", sso) is True
+
+
+def test_resolve_require_sso_login_false_when_no_provider_configured(caplog):
+    sso = SSOConfig()
+    with caplog.at_level("WARNING"):
+        assert resolve_require_sso_login("true", sso) is False
+    assert any("REQUIRE_SSO_LOGIN" in record.message for record in caplog.records)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,7 @@ services:
       - ALLOWED_HOSTS=${ALLOWED_HOSTS-*}
       - SECRET_KEY=${SECRET_KEY-}
       - SSO_CONFIG_DICT=${SSO_CONFIG_DICT-{}}
+      - REQUIRE_SSO_LOGIN=false
       - FILE_STORAGE_DICT=${FILE_STORAGE_DICT-{}}
       - MATHESAR_ANALYTICS_URL=${MATHESAR_ANALYTICS_URL-https://example.com/collector}
       - MATHESAR_INIT_REPORT_URL=${MATHESAR_INIT_REPORT_URL-https://example.com/hello}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,11 @@ x-config: &config
   SSO_CONFIG_DICT: ${SSO_CONFIG_DICT:-{}}
   OIDC_CONFIG_DICT: ${OIDC_CONFIG_DICT:-{}} # deprecated, use SSO_CONFIG_DICT
 
+  # (Optional) Set to 'true' to disable password-based login and require all
+  # users to sign in via a configured SSO provider. Has no effect unless at
+  # least one SSO provider is configured.
+  REQUIRE_SSO_LOGIN: ${REQUIRE_SSO_LOGIN:-false}
+
 #-------------------------------------------------------------------------------
 # ADDITIONAL INFO ABOUT CONFIG VARIABLES
 #
@@ -123,6 +128,15 @@ x-config: &config
 #   GitHub). This is an optional, alternative approach to configuring SSO
 #   via a configuration file. OIDC_CONFIG_DICT is the legacy name and is
 #   still accepted.
+#
+# REQUIRE_SSO_LOGIN:
+#   Default: false
+#   Info: When set to 'true', Mathesar disables password-based login and only
+#   allows users to sign in via a configured SSO provider. Users will not be
+#   able to update their own passwords or email addresses. Administrators can
+#   still reset another user's password and edit other users' emails as a
+#   break-glass mechanism. Has no effect unless at least one SSO provider is
+#   configured.
 #
 #-------------------------------------------------------------------------------
 # INFO ABOUT VOLUMES

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -126,6 +126,14 @@ The database specified in this section is used to store Mathesar's internal data
 
 - **Description**: A backwards-compatible alias for `SSO_CONFIG_DICT`. Existing installations can continue to use this name with no changes. If both are set, `SSO_CONFIG_DICT` takes precedence.
 
+### `REQUIRE_SSO_LOGIN` (optional) {: #require_sso_login}
+
+- **Description**: When enabled, Mathesar disables password-based login and only allows users to sign in via a configured SSO provider. Users will not be able to update passwords or email addresses. Administrators can still reset another user's password and edit other users' emails as a break-glass mechanism.
+- **Format**: `true` or `false`
+- **Default value**: `false`
+- **Additional information**:
+    - This setting only takes effect when at least one SSO provider is configured. If `REQUIRE_SSO_LOGIN=true` but no provider is configured in `sso.yml`/`SSO_CONFIG_DICT`, Mathesar logs a warning and continues to allow password login (so administrators can never accidentally lock everyone out).
+
 ## File backend configuration
 
 !!! info "**OPTIONAL**"

--- a/docs/docs/administration/single-sign-on.md
+++ b/docs/docs/administration/single-sign-on.md
@@ -311,6 +311,13 @@ Visit your Mathesar installation and you should see your IdP as a log in option:
 Mathesar's login screen with Okta SSO enabled.
 ///
 
+## How to require SSO-only login
+
+Once SSO is configured, you can optionally disable password-based login entirely so that all users must sign in via SSO. Set the [`REQUIRE_SSO_LOGIN`](./environment-variables.md#require_sso_login) environment variable to `true` and restart Mathesar.
+
+!!! warning "Misconfiguration is handled gracefully"
+    `REQUIRE_SSO_LOGIN` only takes effect when at least one SSO provider is configured. If you set it without configuring a provider, Mathesar logs a warning and continues to allow password login, so you cannot accidentally lock everyone out.
+
 ## How to transition existing users to SSO
 
 When a user logs in via SSO, Mathesar checks if their email address matches an existing user. If it does, they will be logged into the that existing account, with roles and access intact.

--- a/mathesar/rpc/users.py
+++ b/mathesar/rpc/users.py
@@ -2,6 +2,8 @@
 Classes and functions exposed to the RPC endpoint for managing mathesar users.
 """
 from typing import Optional, TypedDict
+
+from django.conf import settings
 from modernrpc.core import REQUEST_KEY
 
 from mathesar.rpc.decorators import mathesar_rpc_method
@@ -149,6 +151,8 @@ def patch_self(
         Updated user information of the caller.
     """
     user = kwargs.get(REQUEST_KEY).user
+    if settings.REQUIRE_SSO_LOGIN and email != user.email:
+        raise Exception('Email cannot be changed when SSO-only login is enabled.')
     updated_user_info = update_self_user_info(
         user_id=user.id,
         username=username,
@@ -211,6 +215,8 @@ def replace_own(
         old_password: Old password of the currently logged in user.
         new_password: New password of the user to set.
     """
+    if settings.REQUIRE_SSO_LOGIN:
+        raise Exception('Password authentication is disabled when SSO-only login is enabled.')
     user = kwargs.get(REQUEST_KEY).user
     if not user.check_password(old_password):
         raise Exception('Old password is incorrect')

--- a/mathesar/templates/registration/login.html
+++ b/mathesar/templates/registration/login.html
@@ -10,46 +10,48 @@
     onsubmit="showLoadingStatus({{ logging_in_loader_text }});"
   >
     {% csrf_token %}
-    <div class="labeled-input layout-stacked">
-      <label for="id_username" class="label-component">
-        <span class="label-content">
-          <span class="labeled-input-label">{% translate "Username" %}</span>
-          <span class="labeled-input-slot input">
-            <input type="text" name="username"
-            class="input-element{% if form.username.errors %} has-error{% endif %}"
-            value="{% if form.username.value %}{{form.username.value}}{% endif %}"
-            autofocus autocapitalize="none" autocomplete="username"
-            required id="id_username">
-          </span>
-          {% if form.username.errors %}
-            <span class="help error">
-              {% for error in form.username.errors %}
-                <span>{{error|escape}}</span>
-              {% endfor %}
+    {% if not is_sso_login_required %}
+      <div class="labeled-input layout-stacked">
+        <label for="id_username" class="label-component">
+          <span class="label-content">
+            <span class="labeled-input-label">{% translate "Username" %}</span>
+            <span class="labeled-input-slot input">
+              <input type="text" name="username"
+              class="input-element{% if form.username.errors %} has-error{% endif %}"
+              value="{% if form.username.value %}{{form.username.value}}{% endif %}"
+              autofocus autocapitalize="none" autocomplete="username"
+              required id="id_username">
             </span>
-          {% endif %}
-        </span>
-      </label>
-    </div>
-    <div class="labeled-input layout-stacked">
-      <label for="id_password" class="label-component">
-        <span class="label-content">
-          <span class="labeled-input-label">{% translate "Password" %}</span>
-          <span class="labeled-input-slot input">
-            <input type="password" name="password"
-            class="input-element{% if form.password.errors %} has-error{% endif %}"
-            autocomplete="current-password" required id="id_password">
+            {% if form.username.errors %}
+              <span class="help error">
+                {% for error in form.username.errors %}
+                  <span>{{error|escape}}</span>
+                {% endfor %}
+              </span>
+            {% endif %}
           </span>
-          {% if form.password.errors %}
-            <span class="help error">
-              {% for error in form.password.errors %}
-                <span>{{error|escape}}</span>
-              {% endfor %}
+        </label>
+      </div>
+      <div class="labeled-input layout-stacked">
+        <label for="id_password" class="label-component">
+          <span class="label-content">
+            <span class="labeled-input-label">{% translate "Password" %}</span>
+            <span class="labeled-input-slot input">
+              <input type="password" name="password"
+              class="input-element{% if form.password.errors %} has-error{% endif %}"
+              autocomplete="current-password" required id="id_password">
             </span>
-          {% endif %}
-        </span>
-      </label>
-    </div>
+            {% if form.password.errors %}
+              <span class="help error">
+                {% for error in form.password.errors %}
+                  <span>{{error|escape}}</span>
+                {% endfor %}
+              </span>
+            {% endif %}
+          </span>
+        </label>
+      </div>
+    {% endif %}
     <div class="footer">
       {% if form.non_field_errors %}
         <div class="message-box error-message">
@@ -61,17 +63,21 @@
           </div>
         </div>
       {% endif %}
-      <button class="btn btn-primary submit-button" type="submit">
-        {% translate "Log In" %}
-      </button>
+      {% if not is_sso_login_required %}
+        <button class="btn btn-primary submit-button" type="submit">
+          {% translate "Log In" %}
+        </button>
+      {% endif %}
 
       {% load socialaccount %}
       {% get_providers as socialaccount_providers %}
       {% if socialaccount_providers %}
-        <div class="sso_divider">
-          <div class="line"></div>
-          <span class="or">or</span>
-        </div>
+        {% if not is_sso_login_required %}
+          <div class="sso_divider">
+            <div class="line"></div>
+            <span class="or">or</span>
+          </div>
+        {% endif %}
         <div class="sso_providers">
           {% for provider in socialaccount_providers %}
             <div class="sso_provider">

--- a/mathesar/tests/rpc/test_users.py
+++ b/mathesar/tests/rpc/test_users.py
@@ -5,6 +5,8 @@ Fixtures:
     rf(pytest-django): Provides mocked `Request` objects.
     monkeypatch(pytest): Lets you monkeypatch an object for testing.
 """
+import pytest
+
 from mathesar.rpc import users
 from mathesar.models.users import User
 
@@ -260,3 +262,106 @@ def test_users_revoke(rf, monkeypatch):
 
     monkeypatch.setattr(users, 'revoke', mock_revoke_password)
     users.revoke(user_id=_user_id, new_password=_new_password)
+
+
+def test_users_replace_own_blocked_when_sso_required(rf, settings, monkeypatch):
+    settings.REQUIRE_SSO_LOGIN = True
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=2, username='bob', password='bobs_old_password')
+    request.user.set_password('bobs_old_password')
+
+    def mock_change_password(user_id, new_password):
+        raise AssertionError('change_password should not be called')
+
+    monkeypatch.setattr(users, 'change_password', mock_change_password)
+    with pytest.raises(Exception, match='Password authentication is disabled'):
+        users.replace_own(
+            old_password='bobs_old_password',
+            new_password='bobs_new_password',
+            request=request,
+        )
+
+
+def test_users_revoke_still_works_when_sso_required(rf, settings, monkeypatch):
+    settings.REQUIRE_SSO_LOGIN = True
+    called = {}
+
+    def mock_revoke_password(user_id, new_password):
+        called['args'] = (user_id, new_password)
+
+    monkeypatch.setattr(users, 'revoke_password', mock_revoke_password)
+    users.revoke(user_id=3, new_password='new')
+    assert called['args'] == (3, 'new')
+
+
+def test_users_patch_self_email_change_blocked_when_sso_required(rf, settings, monkeypatch):
+    settings.REQUIRE_SSO_LOGIN = True
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=2, username='alice', email='alice@mathesar.org')
+
+    def mock_patch_self(*args, **kwargs):
+        raise AssertionError('update_self_user_info should not be called')
+
+    monkeypatch.setattr(users, 'update_self_user_info', mock_patch_self)
+    with pytest.raises(Exception, match='Email cannot be changed'):
+        users.patch_self(
+            username='alice',
+            email='new@mathesar.org',
+            full_name='Alice',
+            display_language='en',
+            request=request,
+        )
+
+
+def test_users_patch_self_same_email_allowed_when_sso_required(rf, settings, monkeypatch):
+    settings.REQUIRE_SSO_LOGIN = True
+    request = rf.post('/api/rpc/v0', data={})
+    request.user = User(id=2, username='alice', email='alice@mathesar.org')
+
+    def mock_patch_self(user_id, username, email, full_name, display_language):
+        return User(
+            id=2,
+            username=username,
+            is_superuser=False,
+            email=email,
+            full_name=full_name,
+            display_language=display_language,
+        )
+
+    monkeypatch.setattr(users, 'update_self_user_info', mock_patch_self)
+    result = users.patch_self(
+        username='alice_l',
+        email='alice@mathesar.org',
+        full_name='Alice L',
+        display_language='en',
+        request=request,
+    )
+    assert result['email'] == 'alice@mathesar.org'
+    assert result['full_name'] == 'Alice L'
+
+
+def test_users_patch_other_email_change_allowed_when_sso_required(rf, settings, monkeypatch):
+    settings.REQUIRE_SSO_LOGIN = True
+    called = {}
+
+    def mock_patch_other(user_id, username, is_superuser, email, full_name, display_language):
+        called['email'] = email
+        return User(
+            id=user_id,
+            username=username,
+            is_superuser=is_superuser,
+            email=email,
+            full_name=full_name,
+            display_language=display_language,
+        )
+
+    monkeypatch.setattr(users, 'update_other_user_info', mock_patch_other)
+    users.patch_other(
+        user_id=3,
+        username='bob',
+        is_superuser=False,
+        email='changed@mathesar.org',
+        full_name='Bob',
+        display_language='en',
+    )
+    assert called['email'] == 'changed@mathesar.org'

--- a/mathesar/tests/views/test_login_view.py
+++ b/mathesar/tests/views/test_login_view.py
@@ -1,0 +1,31 @@
+"""
+Tests for the MathesarLoginView's behavior under SSO-only mode.
+
+Fixtures:
+    rf(pytest-django): Provides a Django RequestFactory.
+    settings(pytest-django): Lets tests temporarily override Django settings.
+"""
+from mathesar.views.users.login import MathesarLoginView
+
+
+def test_login_view_post_forbidden_when_sso_required(rf, settings):
+    settings.REQUIRE_SSO_LOGIN = True
+    request = rf.post('/auth/login/', data={'username': 'a', 'password': 'b'})
+    response = MathesarLoginView.as_view()(request)
+    assert response.status_code == 403
+
+
+def test_login_view_context_includes_sso_required_flag(rf, settings):
+    settings.REQUIRE_SSO_LOGIN = True
+    view = MathesarLoginView()
+    view.setup(rf.get('/auth/login/'))
+    ctx = view.get_context_data(form=view.get_form())
+    assert ctx['is_sso_login_required'] is True
+
+
+def test_login_view_context_flag_false_when_sso_not_required(rf, settings):
+    settings.REQUIRE_SSO_LOGIN = False
+    view = MathesarLoginView()
+    view.setup(rf.get('/auth/login/'))
+    ctx = view.get_context_data(form=view.get_form())
+    assert ctx['is_sso_login_required'] is False

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -1,9 +1,9 @@
-from django.contrib.auth.views import LoginView
 from django.urls import include, path, re_path
 
 from mathesar import views
 from mathesar.views.installation.decorators import installation_complete, installation_incomplete
 from mathesar.views.installation.complete_installation import CompleteInstallationFormView
+from mathesar.views.users.login import MathesarLoginView
 from mathesar.views.users.password_reset import MathesarPasswordResetConfirmView
 
 urlpatterns = [
@@ -14,8 +14,8 @@ urlpatterns = [
     path('api/export/v0/tables/', views.export.export_table, name='export_table'),
     path('complete_installation/', installation_incomplete(CompleteInstallationFormView.as_view()), name='complete_installation'),
     path('auth/password_reset_confirm/', MathesarPasswordResetConfirmView.as_view(), name='password_reset_confirm'),
-    path('auth/login/', installation_complete(LoginView.as_view(redirect_authenticated_user=True)), name='login'),
-    path('auth/3rdparty/<path:rest>/', installation_complete(LoginView.as_view(redirect_authenticated_user=True)), name='oidc'),  # hack to redirect '/login/cancelled', 'login/error/' 'signup/' and '' to login page
+    path('auth/login/', installation_complete(MathesarLoginView.as_view(redirect_authenticated_user=True)), name='login'),
+    path('auth/3rdparty/<path:rest>/', installation_complete(MathesarLoginView.as_view(redirect_authenticated_user=True)), name='oidc'),  # hack to redirect '/login/cancelled', 'login/error/' 'signup/' and '' to login page
     path('auth/', include('django.contrib.auth.urls')),  # default auth/
     path('auth/', include('allauth.urls')),  # catch any urls that are not available in default auth/
     path('bulk_insert/', views.bulk_insert.bulk_insert, name='bulk_insert'),

--- a/mathesar/views/__init__.py
+++ b/mathesar/views/__init__.py
@@ -96,6 +96,7 @@ def get_base_common_data(request):
     return {
         'current_release_tag_name': __version__,
         'is_authenticated': not request.user.is_anonymous,
+        'is_sso_login_required': settings.REQUIRE_SSO_LOGIN,
         'supported_languages': dict(getattr(settings, 'LANGUAGES', [])),
         'file_backends': get_file_backends(public_info=True),
     }

--- a/mathesar/views/users/login.py
+++ b/mathesar/views/users/login.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.contrib.auth.views import LoginView
+from django.http import HttpResponseForbidden
+
+
+class MathesarLoginView(LoginView):
+    def post(self, request, *args, **kwargs):
+        if settings.REQUIRE_SSO_LOGIN:
+            return HttpResponseForbidden(
+                "Password authentication is disabled. Please log in using SSO."
+            )
+        return super().post(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['is_sso_login_required'] = settings.REQUIRE_SSO_LOGIN
+        return ctx

--- a/mathesar_ui/src/components/grid-form/GridFormLabelRow.svelte
+++ b/mathesar_ui/src/components/grid-form/GridFormLabelRow.svelte
@@ -25,4 +25,7 @@
   .label-cell {
     padding-top: 0.5rem;
   }
+  .input-cell {
+    position: relative;
+  }
 </style>

--- a/mathesar_ui/src/i18n/languages/en/dict.json
+++ b/mathesar_ui/src/i18n/languages/en/dict.json
@@ -275,6 +275,7 @@
   "edit_user": "Edit User",
   "email": "Email",
   "email_address_invalid": "The email address is invalid.",
+  "email_managed_by_sso": "Your email is managed by your SSO provider and cannot be changed here.",
   "enable_anonymous_usage_data_collection": "Enable anonymous usage data collection",
   "enter_a_number_between_1_and_max": "Enter a number between 1 and {max}",
   "enter_url_import_file": "Enter the URL of the file you want to import",

--- a/mathesar_ui/src/pages/user-profile/ProfilePage.svelte
+++ b/mathesar_ui/src/pages/user-profile/ProfilePage.svelte
@@ -7,8 +7,10 @@
   import LayoutWithHeader from '@mathesar/layouts/LayoutWithHeader.svelte';
   import { getUserProfileStoreFromContext } from '@mathesar/stores/userProfile';
   import { PasswordChangeForm, UserDetailsForm } from '@mathesar/systems/users';
+  import { preloadCommonData } from '@mathesar/utils/preloadData';
 
   const userProfileStore = getUserProfileStoreFromContext();
+  const commonData = preloadCommonData();
 
   $: userProfile = $userProfileStore;
 </script>
@@ -32,9 +34,11 @@
         <h2 slot="header">{$_('account_details')}</h2>
         <UserDetailsForm user={userProfile.getUser()} />
       </InsetPageSection>
-      <InsetPageSection>
-        <PasswordChangeForm userId={userProfile.id} />
-      </InsetPageSection>
+      {#if !commonData.is_sso_login_required}
+        <InsetPageSection>
+          <PasswordChangeForm userId={userProfile.id} />
+        </InsetPageSection>
+      {/if}
 
       {#if !userProfile.isMathesarAdmin}
         <InsetPageSection>

--- a/mathesar_ui/src/systems/users/UserDetailsForm.svelte
+++ b/mathesar_ui/src/systems/users/UserDetailsForm.svelte
@@ -23,6 +23,7 @@
   import { setLanguage } from '@mathesar/i18n';
   import { iconSave, iconUndo } from '@mathesar/icons';
   import { getUserProfileStoreFromContext } from '@mathesar/stores/userProfile';
+  import { preloadCommonData } from '@mathesar/utils/preloadData';
   import {
     BooleanCheckbox,
     PasswordInput,
@@ -34,12 +35,17 @@
 
   const dispatch = createEventDispatcher<{ create: User; update: undefined }>();
   const userProfileStore = getUserProfileStoreFromContext();
+  const commonData = preloadCommonData();
   $: userProfile = $userProfileStore;
 
   export let user: User | undefined = undefined;
 
   $: isUserUpdatingThemselves = userProfile && userProfile.id === user?.id;
   $: isNewUser = user === undefined;
+  $: isEmailLocked =
+    !!isUserUpdatingThemselves &&
+    !isNewUser &&
+    commonData.is_sso_login_required;
   $: fullName = optionalField(user?.full_name ?? '');
   $: username = requiredField(user?.username ?? '', [
     maxLength(
@@ -144,7 +150,20 @@
   </GridFormLabelRow>
 
   <GridFormLabelRow label={$_('email')}>
-    <Field field={email} />
+    <Field
+      field={email}
+      input={{
+        component: TextInput,
+        props: { disabled: isEmailLocked },
+      }}
+    />
+    {#if isEmailLocked}
+      <span class="info">
+        <Help>
+          <p>{$_('email_managed_by_sso')}</p>
+        </Help>
+      </span>
+    {/if}
   </GridFormLabelRow>
 
   <GridFormLabelRow label={`${$_('username')} *`}>
@@ -214,6 +233,11 @@
     display: flex;
     align-items: flex-end;
     gap: 0.7rem;
+  }
+  .info {
+    position: absolute;
+    top: 0.4em;
+    right: 0.5em;
   }
   .submit-section {
     --form-submit-margin: var(--lg3) 0 0 0;

--- a/mathesar_ui/src/utils/preloadData.ts
+++ b/mathesar_ui/src/utils/preloadData.ts
@@ -23,6 +23,7 @@ export interface BaseCommonData {
   current_release_tag_name: string;
   supported_languages: Record<string, string>;
   is_authenticated: boolean;
+  is_sso_login_required: boolean;
   file_backends: { backend: string; anonymous_access: boolean }[] | null;
 }
 


### PR DESCRIPTION
Fixes #4731

**Technical details**
- When `REQUIRE_SSO_LOGIN` env variable is set to true AND a valid sso provider is present:
  - User name and password fields are hidden in login
  - Password reset options are hidden for normal users
  - Email field cannot be updated by normal users
- When a valid SSO provider is not configured and this flag is turned on, it has no effect on Mathesar. Username and password fields will be enabled in this scenario.
- **Note:**
  - Does not prevent admins from updating emails and resetting passwords of other users. The passwords are not relevant when REQUIRE_SSO_LOGIN is enabled, but the admin ability is not limited by the flag.
  - Admins cannot update their own email when REQUIRE_SSO_LOGIN is enabled.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
