### PR TITLE
Add a Docker stage for minimal production setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
-#=========== STAGE: BASE =====================================================#
-
 ARG PYTHON_VERSION=3.14-bookworm
+
+#=========== BASE STAGES =====================================================#
+
+##---------- Python and essential packages -----------------------------------#
+
 FROM python:$PYTHON_VERSION AS base
 
-ENV PYTHONUNBUFFERED=1
-ENV DOCKERIZE_VERSION=v0.6.1
-ARG BUILD_PG_MAJOR=17
-ENV PG_MAJOR=$BUILD_PG_MAJOR
-
-RUN set -eux;
-
-RUN mkdir -p /etc/apt/keyrings;
-
-# Add PostgreSQL signing key and source
-RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/postgres.gpg && \
-    chmod 644 /etc/apt/keyrings/postgres.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
-    > /etc/apt/sources.list.d/pgdg.list
-
-# Install common dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     sudo \
@@ -30,39 +17,52 @@ RUN apt-get update && \
     rsync \
     && rm -rf /var/lib/apt/lists/*
 
-# Define Locale
+ENV MATHESAR_DOCKER_IMAGE='true'
+ENV PYTHONUNBUFFERED=1
+
+### Define Locale
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.utf8
 
-# Install Postgres
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
-ENV PGDATA=/var/lib/postgresql/mathesar
-ENV MATHESAR_DOCKER_IMAGE='true'
-
-VOLUME /etc/postgresql/
-VOLUME /var/lib/postgresql/
-
-EXPOSE 5432
-
-# Mathesar source
 WORKDIR /code/
 
 
-#=========== STAGE: TESTING ==================================================#
+##---------- Base with code and build time deps ------------------------------#
 
-ARG PYTHON_VERSION=3.14-bookworm
-FROM python:$PYTHON_VERSION AS testing
+FROM base AS build_deps
 
-# Mathesar source
-WORKDIR /code/
 COPY . .
 
-# Install dev requirements
+ENV NODE_MAJOR=18
+
+### Install dev requirements
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+### Compile translation files
+### We set a temporary secret key to avoid mounting a volume during buildtime.
+RUN SECRET_KEY=temporary python manage.py compilemessages
+
+### Add NodeJS signing key and source
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    chmod 644 /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+    | tee /etc/apt/sources.list.d/nodesource.list
+
+### Install node
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+
+#=========== DEV RELATED STAGES ==============================================#
+
+##---------- Testing stage ---------------------------------------------------#
+
+FROM base AS testing
+
+COPY . .
+
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
 EXPOSE 8000
@@ -70,39 +70,10 @@ EXPOSE 8000
 CMD ["bash", "./bin/mathesar_dev"]
 
 
-#=========== STAGE: DEVELOPMENT_BASE =========================================#
+##---------- Development stage -----------------------------------------------#
 
-FROM base AS development_base
+FROM build_deps AS development
 
-COPY . .
-
-ENV NODE_MAJOR=18
-
-# Install dev requirements
-RUN pip install --no-cache-dir -r requirements-dev.txt
-
-# Compile translation files
-# We set a temporary secret key to avoid mounting a volume during buildtime.
-RUN SECRET_KEY=temporary python manage.py compilemessages
-
-# Add NodeJS signing key and source
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    chmod 644 /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
-    | tee /etc/apt/sources.list.d/nodesource.list
-
-# Install node
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-
-#=========== STAGE: DEVELOPMENT ==============================================#
-
-FROM development_base AS development
-
-# Install npm packages
 RUN cd mathesar_ui && npm ci && cd ..
 
 EXPOSE 8000 3000 6006
@@ -110,28 +81,76 @@ EXPOSE 8000 3000 6006
 CMD ["bash", "./bin/mathesar_dev"]
 
 
-#=========== STAGE: PRE_PRODUCTION ===========================================#
+#=========== PRODUCTION STAGES ===============================================#
 
-FROM development_base AS pre_production
+##---------- Pre-production packaging ----------------------------------------#
 
+FROM build_deps AS pre_production
+
+## Packages source files
 RUN python3 ./build-scripts/package/package.py
 
 
-#=========== STAGE: PRODUCTION ===============================================#
+##---------- Production base -------------------------------------------------#
 
-FROM base AS production
+FROM base AS production_base
 
-# Copy packaged source files
+### Copy packaged source files
 COPY --from=pre_production /code/dist/mathesar.tar.gz ./
 
 RUN tar -xzf mathesar.tar.gz && rm mathesar.tar.gz
 
-# Create directory for media files
 RUN mkdir -p .media
 
-# Install prod requirements
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8000
+
+
+##---------- Minimal prod setup ----------------------------------------------#
+
+FROM production_base AS minimal
+
+ENV DJANGO_SETTINGS_MODULE=config.settings.production
+RUN SECRET_KEY=temporary python manage.py collectstatic --noinput
+ENV SKIP_STATIC_COLLECTION=true
+
+RUN groupadd --system --gid 1000 mathesar \
+    && useradd  --system --uid 1000 --gid 1000 --shell /usr/sbin/nologin mathesar \
+    && chown -R 1000:1000 /code
+USER 1000:1000
+
+### Do not include flags for Django setup and inbuilt db fallback
+CMD ["bash", "./bin/mathesar", "run", "-ne"]
+
+
+##---------- Prod setup ------------------------------------------------------#
+
+FROM production_base AS production
+
+ARG BUILD_PG_MAJOR=17
+ENV PG_MAJOR=$BUILD_PG_MAJOR
+
+RUN mkdir -p /etc/apt/keyrings;
+
+### Add PostgreSQL signing key and source
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/postgres.gpg && \
+    chmod 644 /etc/apt/keyrings/postgres.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+    > /etc/apt/sources.list.d/pgdg.list
+
+### Install Postgres
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
+ENV PGDATA=/var/lib/postgresql/mathesar
+
+VOLUME /etc/postgresql/
+VOLUME /var/lib/postgresql/
+
+EXPOSE 5432
 
 CMD ["bash", "./bin/mathesar", "run", "-fnse"]


### PR DESCRIPTION
This PR adds an additional Docker build stage for a minimal production setup. It differs from the default prod setup in the following ways:
- Minimal does not perform migrations during startup. It expects migrations to have been completed separately.
- Minimal does not perform collectstatic on startup. It does that during the build step.
- Minimal does not run Mathesar as the root user in the container.
- Minimal does not contain an inbuild postgres db to use as fallback.

This stage is useful for cloud deployments in K8s like environments, where we'd expect the images to be small and migrations to run as separate jobs.

This PR does not change the behaviour for the existing self-hosted production setup.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
