### PR TITLE
fix(static): Enable Brotli precompression

### DIFF
--- a/mathesar/tests/test_static_file_compression.py
+++ b/mathesar/tests/test_static_file_compression.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+from whitenoise.compress import Compressor, brotli_installed
+
+
+def test_staticfiles_storage_can_precompress_brotli_assets():
+    settings_path = (
+        Path(__file__).parents[2]
+        / "config"
+        / "settings"
+        / "common_settings.py"
+    )
+    settings_module = ast.parse(settings_path.read_text())
+    staticfiles_storage = next(
+        node.value.value
+        for node in settings_module.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id == "STATICFILES_STORAGE"
+    )
+
+    assert staticfiles_storage == "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    assert brotli_installed is True
+    assert Compressor().use_brotli is True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Brotli==1.1.0
 CairoSVG==2.9.0
 django-storages[azure]==1.14.6
 clevercsv==0.8.2


### PR DESCRIPTION
Add the Brotli runtime dependency so WhiteNoise can emit .br files when collectstatic runs with CompressedManifestStaticFilesStorage. Caddy is already configured to serve precompressed Brotli assets, so this lets the existing static pipeline produce the files it expects.

Fixes #2411