### PR TITLE
Add a health check middleware with live and readiness endpoints

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -42,6 +42,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # HealthCheckMiddleware must stay first so they are served before
+    # host validation, SSL redirect, and auth.
+    "mathesar.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: curl -f http://localhost:8000
+      test: curl -f http://localhost:8000/healthz/ready/
       interval: 10s
       timeout: 5s
       retries: 30

--- a/mathesar/middleware.py
+++ b/mathesar/middleware.py
@@ -1,9 +1,51 @@
 import time
 import warnings
 
-from django.http import HttpResponseRedirect
+from django.db import connection, transaction
+from django.http import HttpResponseNotAllowed, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from sqlalchemy.exc import InterfaceError
+
+# Paths served directly by HealthCheckMiddleware. The trailing slash is optional
+# so a probe configured without it isn't served a 301 redirect, which an
+# orchestrator would read as a (false) success.
+HEALTH_LIVENESS_PATHS = frozenset({"/healthz/live", "/healthz/live/"})
+HEALTH_READINESS_PATHS = frozenset({"/healthz/ready", "/healthz/ready/"})
+
+READINESS_STATEMENT_TIMEOUT_MS = 2000
+
+
+class HealthCheckMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path in HEALTH_LIVENESS_PATHS:
+            return self._serve(request, self._liveness)
+        if request.path in HEALTH_READINESS_PATHS:
+            return self._serve(request, self._readiness)
+        return self.get_response(request)
+
+    def _serve(self, request, check):
+        if request.method not in ("GET", "HEAD"):
+            return HttpResponseNotAllowed(("GET", "HEAD"))
+        return check()
+
+    def _liveness(self):
+        return JsonResponse({"status": "ok"})
+
+    def _readiness(self):
+        try:
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f"SET LOCAL statement_timeout = {READINESS_STATEMENT_TIMEOUT_MS}"
+                    )
+                    cursor.execute("SELECT 1")
+                    cursor.fetchone()
+        except Exception:
+            return JsonResponse({"status": "unavailable"}, status=503)
+        return JsonResponse({"status": "ok"})
 
 
 class CursorClosedHandlerMiddleware:

--- a/mathesar/tests/test_health_check_middleware.py
+++ b/mathesar/tests/test_health_check_middleware.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import patch
+
+from django.test import Client
+from django.test.utils import override_settings
+
+from mathesar.middleware import HealthCheckMiddleware
+
+_PASSED_THROUGH = object()
+
+
+def _middleware():
+    return HealthCheckMiddleware(lambda request: _PASSED_THROUGH)
+
+
+def test_passes_through_non_health_paths(rf):
+    assert _middleware()(rf.get('/some/other/path')) is _PASSED_THROUGH
+
+
+def test_liveness_returns_ok(rf):
+    for path in ('/healthz/live', '/healthz/live/'):
+        response = _middleware()(rf.get(path))
+        assert response.status_code == 200
+        assert json.loads(response.content) == {"status": "ok"}
+
+
+def test_liveness_does_not_touch_the_database(rf):
+    # Liveness must never hit the DB; a DB failure must not affect it.
+    with patch('mathesar.middleware.connection') as mock_connection:
+        response = _middleware()(rf.get('/healthz/live/'))
+    assert response.status_code == 200
+    mock_connection.cursor.assert_not_called()
+
+
+def test_rejects_non_get(rf):
+    response = _middleware()(rf.post('/healthz/live/'))
+    assert response.status_code == 405
+
+
+def test_readiness_returns_ok_when_db_reachable(rf):
+    for path in ('/healthz/ready', '/healthz/ready/'):
+        response = _middleware()(rf.get(path))
+        assert response.status_code == 200
+        assert json.loads(response.content) == {"status": "ok"}
+
+
+def test_readiness_returns_503_when_db_check_fails(rf):
+    with patch(
+        'mathesar.middleware.transaction.atomic',
+        side_effect=Exception('database unreachable'),
+    ):
+        response = _middleware()(rf.get('/healthz/ready/'))
+    assert response.status_code == 503
+    assert json.loads(response.content) == {"status": "unavailable"}
+
+
+@override_settings(DEBUG=False, ALLOWED_HOSTS=['mathesar.example.com'])
+def test_endpoints_work_under_restricted_allowed_hosts():
+    client = Client()
+    assert client.get('/healthz/live/', HTTP_HOST='localhost').status_code == 200
+    assert client.get('/healthz/ready/', HTTP_HOST='10.1.2.3').status_code == 200


### PR DESCRIPTION
**This PR:**
- Adds health check middleware with endpoints for live and readiness checks:
- | Endpoint | Answers | What it checks |
  | --- | --- | --- |
  | `GET /healthz/live` and `GET /healthz/live/` | "Is this process responsive?" | If the webserver is up and can serve a request |
  | `GET /healthz/ready` and `GET /healthz/ready/` | "Can this pod serve traffic right now?" | If the webserver is ready, by querying the internal db ensuring that the connection is active. |

**The Healthcheck middleware doesn't use existing security flows**:
- These endpoints should respond regardless of the values of `ALLOWED_HOSTS` or `SECURE_SSL_REDIRECT`.
- This is because they are called mainly by orchestrators within the context of a pod or container, using HTTP, and if `ALLOWED_HOSTS` did not include `localhost` or the ip that the orchestrators use, then these requests will fail.

**Other Notes:**
- The backslash is important and explicitly checked, since Django automatically redirects requests without it.
- Orchestrators only read the HTTP return code, not the response. The response body is merely a lightweight object for our reference. 
- Any request in the ranges of 2xx to 3xx are treated as a success by orchestrators like K8s.
- If K8s is checking the `live` endpoint, and we let Django redirect to `live/`, it will return a 301 which K8s will consider a success, even if the actual return value of `live/` is 503.

**Sample K8s manifest reference, that uses these endpoints:** 
```yaml
containers:
  - name: mathesar
    image: mathesar/mathesar:latest
    ports:
      - containerPort: 8000
    startupProbe:
      httpGet:
        path: /healthz/live
        port: 8000
      failureThreshold: 30
      periodSeconds: 5
    livenessProbe:
      httpGet:
        path: /healthz/live
        port: 8000
      periodSeconds: 10
    readinessProbe:
      httpGet:
        path: /healthz/ready
        port: 8000
      periodSeconds: 10
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
