### PR TITLE
Add azure blob storage support for file attachments

### DIFF
--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -141,12 +141,17 @@ The database specified in this section is used to store Mathesar's internal data
 
 ### `FILE_STORAGE_DICT` (optional)
 
-- **Description**: The configuration to connect Mathesar to an S3-compatible [file storage backend](../administration/file-backend-config.md).
+- **Description**: The configuration to connect Mathesar to an S3-compatible or Azure Blob Storage [file storage backend](../administration/file-backend-config.md).
 - **Format**: A stringified JSON representation of the config in the [`file_storage.yml` file](https://github.com/mathesar-foundation/mathesar/raw/{{mathesar_version}}/file_storage.yml.example).
 
-    !!! example
+    !!! example "S3-compatible"
         ```env
          FILE_STORAGE_DICT="{\"default\":{\"protocol\":\"s3\",\"nickname\":\"Example\",\"prefix\":\"mathesar-storage\",\"kwargs\":{\"client_kwargs\":{\"endpoint_url\":\"https:\/\/storage-example.mathesar.org\",\"region_name\":\"auto\",\"aws_access_key_id\":\"XXX\",\"aws_secret_access_key\":\"XXX\"}}}}"
+        ```
+
+    !!! example "Azure Blob Storage (managed identity)"
+        ```env
+         FILE_STORAGE_DICT="{\"default\":{\"protocol\":\"az\",\"nickname\":\"Example\",\"prefix\":\"mathesar-file-attachments\",\"kwargs\":{\"account_name\":\"my-storage-account\"}}}"
         ```
 
 - **Additional information**: The following tools might help you convert the YAML syntax from `file_storage.yml` into the proper format:

--- a/docs/docs/administration/file-backend-config.md
+++ b/docs/docs/administration/file-backend-config.md
@@ -5,7 +5,7 @@
 
 	[Talk to us for 20 min](https://cal.com/mathesar/users)! We'll give you a $25 gift card as a thank you.
 
-Mathesar's [**file data type**](../user-guide/files.md) requires you to configure an **S3-compatible object storage backend**. File storage allows users to upload, preview, and download files directly within Mathesar.
+Mathesar's [**file data type**](../user-guide/files.md) requires you to configure an object storage backend — either an **S3-compatible** service or **Azure Blob Storage**. File storage allows users to upload, preview, and download files directly within Mathesar.
 
 **Configuring file storage and using file columns is optional.** By default, Mathesar does not expose file column controls unless a storage backend is set up. If you do not set up a backend, users will not be able to work directly with files in Mathesar.
 
@@ -96,7 +96,7 @@ From your chosen storage backend, collect the following details:
 * **Access key ID**: generated credential for programmatic access.
 * **Secret access key**: generated credential paired with the access key ID.
 
-#### 3b. Basic setup
+#### 3b. Basic setup with S3 compatible object store
 
 Once you have those details, update `file_storage.yml` with your values:
 
@@ -113,10 +113,39 @@ default:
 +      region_name: us-east-2
 +      aws_access_key_id: YOUR_ACCESS_KEY
 +      aws_secret_access_key: YOUR_SECRET_KEY
-+ public_form_access:
++  public_form_access:
 +    enabled: true # Set to false to disable files upload via public form
 +    max_upload_size: 1073741824 # 1GB in bytes, adjust as-needed or remove for limitless uploads
 ```
+
+#### 3c. Azure Blob Storage setup
+
+To use Azure Blob Storage instead of an S3-compatible backend, set `protocol: az` and use a flat `kwargs` block (Azure does not use the nested `client_kwargs` that S3 does). Here, `prefix` is the **container name**, not a bucket.
+
+```diff
+default:
++  protocol: az
++  nickname: "Backend name"            # A friendly label for this backend
++  prefix: my-mathesar-container       # This should match your container name exactly
++  kwargs:
++    account_name: my-storage-account
++  public_form_access:
++    enabled: true # Set to false to disable files upload via public form
++    max_upload_size: 1073741824 # 1GB in bytes, adjust as-needed or remove for limitless uploads
+```
+
+Authentication is selected by which keys you place under `kwargs`:
+
+| Auth method | Add under `kwargs` |
+| --- | --- |
+| Managed identity / workload identity | _nothing extra_ — Mathesar uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential) automatically, which resolves credentials from the environment (managed identity, workload identity, `az login`, etc.) |
+| Account key | `account_key: <key>` |
+| SAS token | `sas_token: <token>` |
+| Connection string | `connection_string: <connection-string>` (no `account_name` needed) |
+| Service principal | `tenant_id`, `client_id`, and `client_secret` |
+
+!!! note "Managed identity and private storage accounts"
+    Because Mathesar streams every file through its own backend (it never hands the browser a direct or pre-signed blob URL), a **private** storage account works as long as Mathesar can reach it over the network with its identity. Grant the identity the **Storage Blob Data Contributor** role on the account (or container). To use a public, anonymously-readable container instead, add `anon: true` under `kwargs`.
 
 ### 4. Activate file storage
 

--- a/file_storage.yml.example
+++ b/file_storage.yml.example
@@ -1,6 +1,6 @@
 default:
   protocol: s3
-  nickname: "Local object store"
+  nickname: "Object store supporting S3 protocol"
   prefix: mathesar-storages
   kwargs:
     client_kwargs:
@@ -11,3 +11,22 @@ default:
   public_form_access:
     enabled: false
     max_upload_size: 1073741824
+
+# Azure Blob Storage example (uses the `adlfs` backend).
+# Replace the `default` block above with this.
+#
+# default:
+#   protocol: az
+#   nickname: "Azure blobs"
+#   prefix: mathesar-file-attachments   # The Azure container name
+#   kwargs:
+#     account_name: my-storage-account
+#     # Managed identity / workload identity needs nothing more: adlfs uses
+#     # DefaultAzureCredential automatically. For other auth, add ONE of:
+#     #   account_key: <key>
+#     #   sas_token: <token>
+#     #   connection_string: <connection-string>
+#     #   tenant_id, client_id, client_secret   # service principal
+#   public_form_access:
+#     enabled: false
+#     max_upload_size: 1073741824

--- a/mathesar/tests/utils/test_download_links.py
+++ b/mathesar/tests/utils/test_download_links.py
@@ -126,3 +126,70 @@ def test_get_download_links(monkeypatch):
     for li in download_links:
         assert li.sessions.filter(session_key=first_session_key).count() == 1
         assert li.sessions.filter(session_key=second_session_key).count() == 1
+
+
+def test_get_download_links_azure(monkeypatch):
+    """The link/mash/uri flow is protocol-agnostic and must work for `az://`."""
+    session_key = 'azuresession',
+    request = MagicMock()
+    request.session = Session.objects.create(
+        session_key=session_key,
+        expire_date=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+    )
+
+    def mock_file_link(_, url_name, mash):
+        return f'http://a-link-here/?url_name={url_name}&mash={mash}'
+
+    monkeypatch.setattr(dl, "_build_file_link", mock_file_link)
+
+    BACKEND_KEY = "azure_backend"
+
+    def mock_backends():
+        return {
+            BACKEND_KEY: {
+                "protocol": "az",
+                "nickname": "for testing azure",
+                "kwargs": {"account_name": "mystorageacct"},
+            },
+        }
+
+    monkeypatch.setattr(dl, "get_backends", mock_backends)
+
+    uri_pic = "az://mathesar-file-attachments/admin/20250919-192215167015/pic.jpeg"
+    uri_pdf = "az://mathesar-file-attachments/admin/20250919-192215167016/document.pdf"
+
+    results = [
+        {"files": dl.create_json_for_uri(uri_pic, BACKEND_KEY)},
+        {"files": dl.create_json_for_uri(uri_pdf, BACKEND_KEY)},
+    ]
+
+    expect_pic_mash = dl.create_mash_for_uri(uri_pic, BACKEND_KEY)
+    expect_pdf_mash = dl.create_mash_for_uri(uri_pdf, BACKEND_KEY)
+
+    mock_col_meta = MagicMock()
+    mock_col_meta.attnum = "files"
+    mock_col_meta.file_backend = BACKEND_KEY
+    actual_output = dl.get_download_links(request, results, [mock_col_meta])
+    assert actual_output == {
+        "files": {
+            expect_pdf_mash: {
+                "attachment": mock_file_link(None, "files_download", expect_pdf_mash),
+                "direct": mock_file_link(None, "files_direct", expect_pdf_mash),
+                "mimetype": "application/pdf",
+                "name": "document.pdf",
+                "thumbnail": None,
+                "uri": uri_pdf,
+            },
+            expect_pic_mash: {
+                "attachment": mock_file_link(None, "files_download", expect_pic_mash),
+                "direct": mock_file_link(None, "files_direct", expect_pic_mash),
+                "mimetype": "image/jpeg",
+                "name": "pic.jpeg",
+                "thumbnail": mock_file_link(None, "files_thumbnail", expect_pic_mash),
+                "uri": uri_pic,
+            },
+        },
+    }
+
+    for li in DownloadLink.objects.all():
+        assert li.fsspec_kwargs == {"account_name": "mystorageacct"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ s3fs==2025.7.0
 SQLAlchemy==1.4.54
 whitenoise==6.7.0
 azure-identity==1.25.3
+adlfs==2026.4.0


### PR DESCRIPTION
This PR:
- Adds the adlfs package required by fssec for enabling azure blob storage support
- Adds user facing documentation on how to use it

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
