### PR TITLE
Use root role connection to user DB to `GRANT CREATE` on `public`

### DIFF
--- a/mathesar/utils/permissions.py
+++ b/mathesar/utils/permissions.py
@@ -87,7 +87,17 @@ def set_up_home_role_and_db_for_user(user, sample_data=[]):
             root_conn,
             owner=user_database_role.configured_role.name,
         )
-        _grant_create_on_public(root_conn, owner=user_database_role.configured_role.name)
+    with mathesar_connection(
+        host=conn_info.host,
+        port=conn_info.port,
+        dbname=user_database_role.database.name,
+        user=conn_info.role,
+        password=conn_info.password,
+        sslmode=conn_info.sslmode,
+        application_name="mathesar.utils.permissions.set_up_home_role_and_db_for_user",
+    ) as root_conn_to_user_db:
+        _grant_create_on_public(root_conn_to_user_db, owner=user_database_role.configured_role.name)
+
     user_database_role.database.install_sql(
         username=user_database_role.configured_role.name,
         password=user_database_role.configured_role.password,


### PR DESCRIPTION
<!-- Concisely describe what the pull request does. -->

#5302 changed to using the root connection for granting `CREATE` on `public`. Unfortunately, the root connection is to the `mathesar_django` DB!!! This PR opens a connection to the _user's_ DB, as the root user, to accomplish the needed `GRANT` command.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
