### PR TITLE
Handle anonymous users in Common Data getter

### DIFF
--- a/mathesar/tests/views/test_page_not_found_view.py
+++ b/mathesar/tests/views/test_page_not_found_view.py
@@ -1,0 +1,69 @@
+"""
+Tests for the custom 404 handler (page_not_found_view).
+
+Verifies that:
+- Non-logged-in users get a 404 (not 500) when requesting a nonexistent path.
+- Authenticated users also get a 404.
+- Anonymous users receive only minimal context (no sensitive data).
+- Authenticated users receive full context.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+from django.test.utils import override_settings
+
+from mathesar.views import get_common_data, page_not_found_view
+
+NONEXISTENT_PATH = '/nonexistent-path-xyz/'
+TEST_STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+
+def _make_request(rf):
+    request = rf.get(NONEXISTENT_PATH)
+    request.LANGUAGE_CODE = settings.LANGUAGE_CODE
+    return request
+
+
+@override_settings(MATHESAR_MODE='DEVELOPMENT', STORAGES=TEST_STORAGES)
+def test_404_anonymous_user(rf):
+    request = _make_request(rf)
+    request.user = AnonymousUser()
+    response = page_not_found_view(request, None)
+    assert response.status_code == 404
+
+
+@override_settings(MATHESAR_MODE='DEVELOPMENT', STORAGES=TEST_STORAGES)
+@pytest.mark.django_db
+def test_404_authenticated_user(rf, admin_user):
+    request = _make_request(rf)
+    request.user = admin_user
+    response = page_not_found_view(request, None)
+    assert response.status_code == 404
+
+
+def test_get_common_data_dispatches_to_anonymous(rf):
+    request = rf.get(NONEXISTENT_PATH)
+    request.user = MagicMock(is_authenticated=False, is_anonymous=True)
+    data = get_common_data(request)
+    assert data['routing_context'] == 'anonymous'
+    assert 'user' not in data
+    assert 'internal_db' not in data
+    assert 'databases' not in data
+    assert 'servers' not in data
+
+
+@pytest.mark.django_db
+def test_get_common_data_dispatches_to_authorized(rf, admin_user):
+    request = rf.get(NONEXISTENT_PATH)
+    request.user = admin_user
+    data = get_common_data(request)
+    assert data['routing_context'] == 'normal'
+    assert data['user'] is not None
+    assert 'internal_db' in data
+    assert isinstance(data['databases'], list)

--- a/mathesar/views/__init__.py
+++ b/mathesar/views/__init__.py
@@ -93,18 +93,16 @@ def _get_internal_db_meta():
         }
 
 
-def get_base_common_data(request):
-    return {
-        'current_release_tag_name': __version__,
-        'is_authenticated': not request.user.is_anonymous,
-        'is_sso_login_required': settings.REQUIRE_SSO_LOGIN,
-        'per_user_databases_enabled': settings.PER_USER_DATABASES_ENABLED,
-        'supported_languages': dict(getattr(settings, 'LANGUAGES', [])),
-        'file_backends': get_file_backends(public_info=True),
-    }
-
-
 def get_common_data(request, database_id=None, schema_oid=None):
+    if request.user.is_authenticated:
+        print("RETURNING AUTHORIZED COMMON DATA")
+        return get_authorized_common_data(request, database_id, schema_oid)
+    else:
+        print("RETURNING ANON COMMON DATA")
+        return get_anonymous_common_data(request)
+
+
+def get_authorized_common_data(request, database_id, schema_oid):
     databases = get_database_list(request)
     database_id_int = int(database_id) if database_id else None
     current_database = next((database for database in databases if database['id'] == database_id_int), None)
@@ -135,6 +133,17 @@ def get_anonymous_common_data(request):
     return {
         **get_base_common_data(request),
         'routing_context': 'anonymous',
+    }
+
+
+def get_base_common_data(request):
+    return {
+        'current_release_tag_name': __version__,
+        'is_authenticated': not request.user.is_anonymous,
+        'is_sso_login_required': settings.REQUIRE_SSO_LOGIN,
+        'per_user_databases_enabled': settings.PER_USER_DATABASES_ENABLED,
+        'supported_languages': dict(getattr(settings, 'LANGUAGES', [])),
+        'file_backends': get_file_backends(public_info=True),
     }
 
 
@@ -185,7 +194,7 @@ def anonymous_route_home(request, **kwargs):
     if not request.session.session_key:
         request.session.save()
     return render(request, 'mathesar/index.html', {
-        'common_data': get_anonymous_common_data(request)
+        'common_data': get_common_data(request)
     })
 
 
@@ -193,7 +202,7 @@ def analytics_sample_report(request):
     return render(request, 'analytics/sample_report.html')
 
 
-def page_not_found_view(request, exception):
+def page_not_found_view(request, _):
     return render(request, 'mathesar/index.html', {
         'common_data': get_common_data(request),
     }, status=404)

--- a/mathesar/views/__init__.py
+++ b/mathesar/views/__init__.py
@@ -95,10 +95,8 @@ def _get_internal_db_meta():
 
 def get_common_data(request, database_id=None, schema_oid=None):
     if request.user.is_authenticated:
-        print("RETURNING AUTHORIZED COMMON DATA")
         return get_authorized_common_data(request, database_id, schema_oid)
     else:
-        print("RETURNING ANON COMMON DATA")
         return get_anonymous_common_data(request)
 
 
@@ -202,7 +200,10 @@ def analytics_sample_report(request):
     return render(request, 'analytics/sample_report.html')
 
 
-def page_not_found_view(request, _):
-    return render(request, 'mathesar/index.html', {
-        'common_data': get_common_data(request),
-    }, status=404)
+def page_not_found_view(request, exception):
+    return render(
+        request,
+        'mathesar/index.html',
+        {'common_data': get_common_data(request)},
+        status=404
+    )


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #5310 

<!-- Concisely describe what the pull request does. -->

Moves logic for determining which common data to return to its proper place within `get_common_data`, so it's consistently applied.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The underlying problem causing #5310 was that the 404 handler was calling `get_common_data` rather than `get_anonymous_common_data`. The design of the common data getters meant the caller had to know which to call. After this change, the getter dispatches based on whether the user is logged in or not. This solves the issue, and probably other random bugs that may have arisen from trying to get a common data blob for which some info was privileged.

NOTE TO REVIEWERS:

The issue #5310 only occurred in prod, or at least when `DEBUG=false`. So, verification that this fixes the problem needs to be done in those situations. However, when `DEBUG=false`, but you're running in the dev docker environment, the static files don't really work (unrelated to these changes), so the best way to test this is to build a prod image with

```
docker build -t mathesar/mathesar:latest .
```

and then run the app in prod mode with `docker compose up`.

Then, navigate to `http://localhost/aslkfjasflkj`

Note that after this fix, the back end returns 404, but the front end does not render anything because it _never_ renders `index.html`. I think this is a net improvement, and it does solve the linked issue, but we should consider figuring out what we want to actually render in cases where non-logged-in users navigate to a non-existent path and implement that (someday).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
