### PR TITLE
Add TOS and Privacy Policy links to login template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ PER_USER_DATABASES_ENABLED=false
 # DATA_FILES_STORAGE_BACKEND=azure
 # DATA_FILES_AZURE_ACCOUNT_NAME=
 # DATA_FILES_AZURE_CONTAINER=mathesar-datafiles
+# Optional: Links shown at the bottom of the login page. If unset, no links display.
+# MATHESAR_TERMS_OF_SERVICE_URL=https://example.com/terms
+# MATHESAR_PRIVACY_POLICY_URL=https://example.com/privacy

--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -264,6 +264,8 @@ MATHESAR_STATIC_NON_CODE_FILES_LOCATION = os.path.join(BASE_DIR, 'mathesar/stati
 MATHESAR_ANALYTICS_URL = os.environ.get('MATHESAR_ANALYTICS_URL', default='https://example.com/collector')
 MATHESAR_INIT_REPORT_URL = os.environ.get('MATHESAR_INIT_REPORT_URL', default='https://example.com/hello')
 MATHESAR_FEEDBACK_URL = os.environ.get('MATHESAR_FEEDBACK_URL', default='https://example.com/feedback')
+MATHESAR_TERMS_OF_SERVICE_URL = os.environ.get('MATHESAR_TERMS_OF_SERVICE_URL', default=None)
+MATHESAR_PRIVACY_POLICY_URL = os.environ.get('MATHESAR_PRIVACY_POLICY_URL', default=None)
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,6 +71,8 @@ services:
       - MATHESAR_ANALYTICS_URL=${MATHESAR_ANALYTICS_URL-https://example.com/collector}
       - MATHESAR_INIT_REPORT_URL=${MATHESAR_INIT_REPORT_URL-https://example.com/hello}
       - MATHESAR_FEEDBACK_URL=${MATHESAR_FEEDBACK_URL-https://example.com/feedback}
+      - MATHESAR_TERMS_OF_SERVICE_URL=${MATHESAR_TERMS_OF_SERVICE_URL-}
+      - MATHESAR_PRIVACY_POLICY_URL=${MATHESAR_PRIVACY_POLICY_URL-}
       - DJANGO_SUPERUSER_PASSWORD=password
       - POSTGRES_DB=mathesar_django
       - POSTGRES_USER=mathesar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,11 @@ x-config: &config
   # least one SSO provider is configured.
   REQUIRE_SSO_LOGIN: ${REQUIRE_SSO_LOGIN:-false}
 
+  # (Optional) Set one or both to show links to your terms of service and
+  # privacy policy pages at the bottom of the login page.
+  MATHESAR_TERMS_OF_SERVICE_URL: ${MATHESAR_TERMS_OF_SERVICE_URL:-}
+  MATHESAR_PRIVACY_POLICY_URL: ${MATHESAR_PRIVACY_POLICY_URL:-}
+
 #-------------------------------------------------------------------------------
 # ADDITIONAL INFO ABOUT CONFIG VARIABLES
 #

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -179,3 +179,21 @@ The database specified in this section is used to store Mathesar's internal data
 - **Description**: The Azure Blob Storage container in which datafiles are stored. Required when `DATA_FILES_STORAGE_BACKEND` is `azure`.
 - **Format**: An Azure Blob Storage container name
 - **Default value**: `mathesar-datafiles`
+
+## Login page links {: #login-links}
+
+!!! info "**OPTIONAL**"
+    Only needed if you want to show links to your own terms of service and/or privacy
+    policy pages at the bottom of the login page. If both are unset, nothing displays.
+
+### `MATHESAR_TERMS_OF_SERVICE_URL` (optional)
+
+- **Description**: URL for a "Terms of Service" link shown at the bottom of the login page.
+- **Format**: A URL
+- **Default value**: (none — no link is shown)
+
+### `MATHESAR_PRIVACY_POLICY_URL` (optional)
+
+- **Description**: URL for a "Privacy Policy" link shown at the bottom of the login page.
+- **Format**: A URL
+- **Default value**: (none — no link is shown)

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -95,6 +95,7 @@
     .login-card-footer-links {
       margin-top: var(--lg3);
       text-align: center;
+      color: var(--color-fg-subtle-2);
       font-size: var(--sm2);
     }
     .login-card-footer-links a {

--- a/mathesar/templates/mathesar/login_base.html
+++ b/mathesar/templates/mathesar/login_base.html
@@ -92,6 +92,15 @@
       font-size: var(--lg3);
       text-align: center;
     }
+    .login-card-footer-links {
+      margin-top: var(--lg3);
+      text-align: center;
+      font-size: var(--sm2);
+    }
+    .login-card-footer-links a {
+      color: var(--color-fg-subtle-2);
+      text-decoration: underline;
+    }
     .login-card .language-selector {
       display: block;
       background-color: var(--color-bg-input);

--- a/mathesar/templates/registration/login.html
+++ b/mathesar/templates/registration/login.html
@@ -108,4 +108,17 @@
 
     </div>
   </form>
+  {% if terms_of_service_url or privacy_policy_url %}
+    <div class="login-card-footer-links">
+      {% if terms_of_service_url %}
+        <a href="{{ terms_of_service_url }}" target="_blank">{% translate "Terms of Service" %}</a>
+      {% endif %}
+      {% if terms_of_service_url and privacy_policy_url %}
+        <span> | </span>
+      {% endif %}
+      {% if privacy_policy_url %}
+        <a href="{{ privacy_policy_url }}" target="_blank">{% translate "Privacy Policy" %}</a>
+      {% endif %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/mathesar/tests/views/test_login_view.py
+++ b/mathesar/tests/views/test_login_view.py
@@ -29,3 +29,29 @@ def test_login_view_context_flag_false_when_sso_not_required(rf, settings):
     view.setup(rf.get('/auth/login/'))
     ctx = view.get_context_data(form=view.get_form())
     assert ctx['is_sso_login_required'] is False
+
+
+def test_login_view_context_terms_of_service_url_defaults_to_none(rf, settings):
+    settings.MATHESAR_TERMS_OF_SERVICE_URL = None
+    view = MathesarLoginView()
+    view.setup(rf.get('/auth/login/'))
+    ctx = view.get_context_data(form=view.get_form())
+    assert ctx['terms_of_service_url'] is None
+
+
+def test_login_view_context_privacy_policy_url_defaults_to_none(rf, settings):
+    settings.MATHESAR_PRIVACY_POLICY_URL = None
+    view = MathesarLoginView()
+    view.setup(rf.get('/auth/login/'))
+    ctx = view.get_context_data(form=view.get_form())
+    assert ctx['privacy_policy_url'] is None
+
+
+def test_login_view_context_includes_custom_urls_when_set(rf, settings):
+    settings.MATHESAR_TERMS_OF_SERVICE_URL = 'https://example.com/terms'
+    settings.MATHESAR_PRIVACY_POLICY_URL = 'https://example.com/privacy'
+    view = MathesarLoginView()
+    view.setup(rf.get('/auth/login/'))
+    ctx = view.get_context_data(form=view.get_form())
+    assert ctx['terms_of_service_url'] == 'https://example.com/terms'
+    assert ctx['privacy_policy_url'] == 'https://example.com/privacy'

--- a/mathesar/views/users/login.py
+++ b/mathesar/views/users/login.py
@@ -14,4 +14,6 @@ class MathesarLoginView(LoginView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['is_sso_login_required'] = settings.REQUIRE_SSO_LOGIN
+        ctx['terms_of_service_url'] = settings.MATHESAR_TERMS_OF_SERVICE_URL
+        ctx['privacy_policy_url'] = settings.MATHESAR_PRIVACY_POLICY_URL
         return ctx


### PR DESCRIPTION
<!-- Concisely describe what the pull request does. -->

This adds configuration variables that allow an admin to configure URLs for TOS and privacy policy pages if desired.

The relevant config environment variables are:

- `MATHESAR_TERMS_OF_SERVICE_URL` and
- `MATHESAR_PRIVACY_POLICY_URL`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
