### PR TITLE
Fix confusing internal database description and broken link

### DIFF
--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -35,11 +35,11 @@ This page contains all available environment variables supported by Mathesar. Se
 
 !!! note "Default values below are from our [docker-compose.yml](https://github.com/mathesar-foundation/mathesar/raw/{{mathesar_version}}/docker-compose.yml) file, used if installing via [Docker Compose](./install-via-docker-compose.md)."
 
-The database configured using these environment variables stores Mathesar's internal metadata. If the postgres role configured here has the permissions to create new databases in the same database server, then Mathesar admins can also create new databases via the Mathesar UI.
+The database configured using these environment variables is used to store Mathesar's internal metadata.
 
-Under the Docker Compose setup, a single PostgreSQL instance hosts both Mathesar's internal database and any databases created via the UI using **"Connect Database" → "Create a New Database"**. The **"Connect Database" → "Connect to an Existing Database"** option, on the other hand, allows connecting to any accessible database on any server.
+Additionally, If the postgres role configured here has the permissions to create new databases,  Mathesar admins are allowed to create new databases within the same database server via the Mathesar UI using **"Connect Database" → "Create a New Database"**.
 
-See also: [Connecting a database](../../user-guide/databases.md#connection).
+See also: [Connecting a database](../../user-guide/databases/#connection).
 
 
 ### `POSTGRES_DB`

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -35,7 +35,11 @@ This page contains all available environment variables supported by Mathesar. Se
 
 !!! note "Default values below are from our [docker-compose.yml](https://github.com/mathesar-foundation/mathesar/raw/{{mathesar_version}}/docker-compose.yml) file, used if installing via [Docker Compose](./install-via-docker-compose.md)."
 
-The database specified in this section is used to store Mathesar's internal data. If desired, it can also be [connected to Mathesar's UI](http://localhost:9000/user-guide/databases/#connection) to store user data.
+The database configured using these environment variables stores Mathesar's internal metadata. If the postgres role configured here has the permissions to create new databases in the same database server, then Mathesar admins can also create new databases via the Mathesar UI.
+
+Under the Docker Compose setup, a single PostgreSQL instance hosts both Mathesar's internal database and any databases created via the UI using **"Connect Database" → "Create a New Database"**. The **"Connect Database" → "Connect to an Existing Database"** option, on the other hand, allows connecting to any accessible database on any server.
+
+See also: [Connecting a database](../../user-guide/databases.md#connection).
 
 
 ### `POSTGRES_DB`

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -37,7 +37,7 @@ This page contains all available environment variables supported by Mathesar. Se
 
 The database configured using these environment variables is used to store Mathesar's internal metadata.
 
-Additionally, If the postgres role configured here has the permissions to create new databases,  Mathesar admins are allowed to create new databases within the same database server via the Mathesar UI using **"Connect Database" → "Create a New Database"**.
+Additionally, if the [`POSTGRES_USER`](#postgres_user) configured here has the permissions to create new databases,  Mathesar admins are allowed to create new databases within the same database server via the Mathesar UI using **"Connect Database" → "Create a New Database"**.
 
 See also: [Connecting a database](../user-guide/databases.md#connection).
 

--- a/docs/docs/administration/environment-variables.md
+++ b/docs/docs/administration/environment-variables.md
@@ -39,7 +39,7 @@ The database configured using these environment variables is used to store Mathe
 
 Additionally, If the postgres role configured here has the permissions to create new databases,  Mathesar admins are allowed to create new databases within the same database server via the Mathesar UI using **"Connect Database" → "Create a New Database"**.
 
-See also: [Connecting a database](../../user-guide/databases/#connection).
+See also: [Connecting a database](../user-guide/databases.md#connection).
 
 
 ### `POSTGRES_DB`


### PR DESCRIPTION
## Description

Fixes the confusing documentation in the Internal database configuration section of the environment variables page.

### Changes:
- Reworded the description to clarify that a single PostgreSQL instance hosts both Mathesar's internal database and user-created databases under Docker Compose
- Distinguished between "Create a New Database" (same server) and "Connect to an Existing Database" (any server) options
- Fixed the broken `http://localhost:9000/user-guide/databases/#connection` link to use a relative path

### Related Issue
Fixes #5273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the configured database stores Mathesar internal metadata.
  * Added guidance on how `POSTGRES_USER` permissions enable admins to create new databases via the UI (“Connect Database” → “Create a New Database”).
  * Added a “See also” link to the database connection documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->