### PR TITLE
Fix broken links to removed files in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We highly recommend joining our [Matrix community](https://wiki.mathesar.org/com
 1. **Begin making your changes.**
 
     - Refer to our **[Developer Guide](./DEVELOPER_GUIDE.md)** for questions about the code.
-    - Make sure to follow our [front end code standards](./mathesar_ui/STANDARDS.md) and [API standards](./mathesar/api/STANDARDS.md) where applicable.
+    - Make sure to follow our [front end code standards](./mathesar_ui/STANDARDS.md) where applicable.
     - If you are not familiar with GitHub or pull requests, please follow [GitHub's "Hello World" guide](https://guides.github.com/activities/hello-world/) first. Make sure to commit your changes on a new git branch named after the ticket you claimed. Base that new branch on our `develop` branch.
     - Commit early, commit often. Write [good commit messages](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53). Try to keep pull requests small if possible, since it makes review easier.
     - If you expect your work to last longer than 1 week, open a draft pull request for your in-progress work.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -55,7 +55,7 @@ For more example datasets, see the [mathesar-data-playground](https://github.com
 
 ## API
 
-See our [API guide](./mathesar/api/README.md) for more information on API usage and development.
+See our [API documentation](https://docs.mathesar.org/latest/api/) for more information on API usage and development.
 
 ## Back end development
 

--- a/mathesar_ui/README.md
+++ b/mathesar_ui/README.md
@@ -107,10 +107,6 @@ ESLint can fix some errors automatically. In particular, we rely on ESLint to au
 
 ## Testing
 
-### Integration tests
-
-See [Integration tests](../mathesar/tests/integration/README.md).
-
 ### Unit tests
 
 We use [Vitest](https://vitest.dev/) to run our unit tests, and we use [Testing Library](https://testing-library.com/docs/svelte-testing-library/intro/) to test our Svelte components.


### PR DESCRIPTION
## Description

Three relative links in the contributor-facing docs point at files that no longer exist, so they 404 on GitHub. I found them while reading through the contributor docs, and each target was removed some time ago:

| File | Dead link | Removed in |
|---|---|---|
| `CONTRIBUTING.md` | `mathesar/api/STANDARDS.md` | c73b663 — "remove mathesar/api/" |
| `DEVELOPER_GUIDE.md` | `mathesar/api/README.md` | c73b663 — "remove mathesar/api/" |
| `mathesar_ui/README.md` | `mathesar/tests/integration/README.md` | 3e32316 — "remove disabled integration tests" |

### Changes

- **CONTRIBUTING.md** — the API standards doc has no successor now that `mathesar/api/` is gone, so I dropped just that link and left the front end standards link intact.
- **DEVELOPER_GUIDE.md** — repointed the "API guide" link to the published API docs at https://docs.mathesar.org/latest/api/, which now covers API usage.
- **mathesar_ui/README.md** — removed the "Integration tests" subsection, since the integration tests it pointed at were removed as disabled.

Docs only; no code or behavior changes. After this, every relative link in the repo's markdown (outside `docs/`, which mkdocs resolves separately) resolves to a file that exists.

### Question for reviewers

`db/sql/STANDARDS.md` does still exist. Would you like it linked from that CONTRIBUTING.md line in place of the removed API standards, e.g. "follow our front end code standards and SQL code standards where applicable"? Happy to add it if so — I left it out to keep the change strictly a fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to reference the applicable front-end coding standards.
  * Updated the developer guide to link to the official online API documentation.
  * Simplified the front-end testing documentation by removing the integration testing section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->